### PR TITLE
Conditional retry

### DIFF
--- a/client.go
+++ b/client.go
@@ -71,18 +71,19 @@ var (
 // Client type is used for HTTP/RESTful global values
 // for all request raised from the client
 type Client struct {
-	HostURL     string
-	QueryParam  url.Values
-	FormData    url.Values
-	Header      http.Header
-	UserInfo    *User
-	Token       string
-	Cookies     []*http.Cookie
-	Error       reflect.Type
-	Debug       bool
-	DisableWarn bool
-	Log         *log.Logger
-	RetryCount  int
+	HostURL         string
+	QueryParam      url.Values
+	FormData        url.Values
+	Header          http.Header
+	UserInfo        *User
+	Token           string
+	Cookies         []*http.Cookie
+	Error           reflect.Type
+	Debug           bool
+	DisableWarn     bool
+	Log             *log.Logger
+	RetryCount      int
+	RetryConditions []func(*Response) (bool, error)
 
 	httpClient       *http.Client
 	transport        *http.Transport
@@ -95,7 +96,6 @@ type Client struct {
 	closeConnection  bool
 	beforeRequest    []func(*Client, *Request) error
 	afterResponse    []func(*Client, *Response) error
-	retryCondition   []func(*Response) (bool, error)
 }
 
 // User type is to hold an username and password information
@@ -351,7 +351,7 @@ func (c *Client) SetRetryCount(count int) *Client {
 // to determine if the request is retried. The request will retry if any of the
 // functions return true.
 func (c *Client) AddRetryCondition(m func(*Response) (bool, error)) *Client {
-	c.retryCondition = append(c.retryCondition, m)
+	c.RetryConditions = append(c.RetryConditions, m)
 	return c
 }
 

--- a/client.go
+++ b/client.go
@@ -82,6 +82,7 @@ type Client struct {
 	Debug       bool
 	DisableWarn bool
 	Log         *log.Logger
+	RetryCount  int
 
 	httpClient       *http.Client
 	transport        *http.Transport
@@ -336,6 +337,12 @@ func (c *Client) OnAfterResponse(m func(*Client, *Response) error) *Client {
 //
 func (c *Client) SetDebug(d bool) *Client {
 	c.Debug = d
+	return c
+}
+
+// SetRetryCount method enables retry on `go-resty` client. Uses a Backoff mechanism.
+func (c *Client) SetRetryCount(count int) *Client {
+	c.RetryCount = count
 	return c
 }
 

--- a/client.go
+++ b/client.go
@@ -95,6 +95,7 @@ type Client struct {
 	closeConnection  bool
 	beforeRequest    []func(*Client, *Request) error
 	afterResponse    []func(*Client, *Response) error
+	retryCondition   []func(*Response) (bool, error)
 }
 
 // User type is to hold an username and password information
@@ -343,6 +344,14 @@ func (c *Client) SetDebug(d bool) *Client {
 // SetRetryCount method enables retry on `go-resty` client. Uses a Backoff mechanism.
 func (c *Client) SetRetryCount(count int) *Client {
 	c.RetryCount = count
+	return c
+}
+
+// AddRetryCondition adds a function to the array of functions that are checked
+// to determine if the request is retried. The request will retry if any of the
+// functions return true.
+func (c *Client) AddRetryCondition(m func(*Response) (bool, error)) *Client {
+	c.retryCondition = append(c.retryCondition, m)
 	return c
 }
 

--- a/default.go
+++ b/default.go
@@ -37,6 +37,7 @@ func New() *Client {
 		httpClient: &http.Client{Jar: cookieJar},
 		transport:  &http.Transport{},
 		mutex:      &sync.Mutex{},
+		RetryCount: 0,
 	}
 
 	// Default redirect policy
@@ -131,6 +132,11 @@ func OnAfterResponse(m func(*Client, *Response) error) *Client {
 // SetDebug method enables the debug mode. See `Client.SetDebug` for more information.
 func SetDebug(d bool) *Client {
 	return DefaultClient.SetDebug(d)
+}
+
+// SetRetryCount method set the retry count. See `Client.SetRetryCount` for more information.
+func SetRetryCount(count int) *Client {
+	return DefaultClient.SetRetryCount(count)
 }
 
 // SetDisableWarn method disables warning comes from `go-resty` client. See `Client.SetDisableWarn` for more information.

--- a/default.go
+++ b/default.go
@@ -139,6 +139,11 @@ func SetRetryCount(count int) *Client {
 	return DefaultClient.SetRetryCount(count)
 }
 
+// AddRetryCondition method appends check function for retry. See `Client.AddRetryCondition` for more information.
+func AddRetryCondition(m func(*Response) (bool, error)) *Client {
+	return DefaultClient.AddRetryCondition(m)
+}
+
 // SetDisableWarn method disables warning comes from `go-resty` client. See `Client.SetDisableWarn` for more information.
 func SetDisableWarn(d bool) *Client {
 	return DefaultClient.SetDisableWarn(d)

--- a/request.go
+++ b/request.go
@@ -410,7 +410,24 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 	r.Method = method
 	r.URL = url
 
-	return r.client.execute(r)
+	if r.client.RetryCount == 0 {
+		return r.client.execute(r)
+	}
+
+	var resp *Response
+	var err error
+	attempt := 0
+	_ = Backoff(func() error {
+		attempt++
+		resp, err = r.client.execute(r)
+		if err != nil {
+			r.client.Log.Printf("ERROR [%v] Attempt [%v]", err, attempt)
+		}
+
+		return err
+	}, Retries(r.client.RetryCount))
+
+	return resp, err
 }
 
 func (r *Request) fmtBodyString() (body string) {

--- a/request.go
+++ b/request.go
@@ -417,14 +417,14 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 	var resp *Response
 	var err error
 	attempt := 0
-	_ = Backoff(func() error {
+	_ = Backoff(func() (*Response, error) {
 		attempt++
 		resp, err = r.client.execute(r)
 		if err != nil {
 			r.client.Log.Printf("ERROR [%v] Attempt [%v]", err, attempt)
 		}
 
-		return err
+		return resp, err
 	}, Retries(r.client.RetryCount))
 
 	return resp, err

--- a/request.go
+++ b/request.go
@@ -425,7 +425,7 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 		}
 
 		return resp, err
-	}, Retries(r.client.RetryCount))
+	}, Retries(r.client.RetryCount), RetryConditions(r.client.RetryConditions))
 
 	return resp, err
 }

--- a/resty_test.go
+++ b/resty_test.go
@@ -857,6 +857,20 @@ func TestClientTimeout(t *testing.T) {
 	assertEqual(t, true, strings.Contains(err.Error(), "i/o timeout"))
 }
 
+func TestClientRetry(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	c := dc()
+	c.SetHTTPMode().
+		SetTimeout(time.Duration(time.Second * 3)).
+		SetRetryCount(3)
+
+	_, err := c.R().Get(ts.URL + "/set-retrycount-test")
+
+	assertError(t, err)
+}
+
 func TestClientTimeoutInternalError(t *testing.T) {
 	c := dc()
 	c.SetHTTPMode()
@@ -1320,6 +1334,9 @@ func TestClientOptions(t *testing.T) {
 	SetDisableWarn(true)
 	assertEqual(t, DefaultClient.DisableWarn, true)
 
+	SetRetryCount(3)
+	assertEqual(t, 3, DefaultClient.RetryCount)
+
 	err := &AuthError{}
 	SetError(err)
 	if reflect.TypeOf(err) == DefaultClient.Error {
@@ -1361,10 +1378,14 @@ func getTestDataPath() string {
 	return pwd + "/test-data"
 }
 
+// Used for retry testing...
+var attempt int
+
 func createGetServer(t *testing.T) *httptest.Server {
 	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
 		t.Logf("Method: %v", r.Method)
 		t.Logf("Path: %v", r.URL.Path)
+
 		if r.Method == GET {
 			if r.URL.Path == "/" {
 				w.Write([]byte("TestGet: text response"))
@@ -1372,9 +1393,16 @@ func createGetServer(t *testing.T) *httptest.Server {
 				w.WriteHeader(http.StatusBadRequest)
 			} else if r.URL.Path == "/mypage2" {
 				w.Write([]byte("TestGet: text response from mypage2"))
+			} else if r.URL.Path == "/set-retrycount-test" {
+				attempt++
+				if attempt != 3 {
+					time.Sleep(time.Second * 6)
+				}
+				w.Write([]byte("TestClientRetry page"))
 			} else if r.URL.Path == "/set-timeout-test" {
 				time.Sleep(time.Second * 6)
 				w.Write([]byte("TestClientTimeout page"))
+
 			} else if r.URL.Path == "/my-image.png" {
 				fileBytes, _ := ioutil.ReadFile(getTestDataPath() + "/test-img.png")
 				w.Header().Set("Content-Type", "image/png")

--- a/retry.go
+++ b/retry.go
@@ -1,0 +1,69 @@
+package resty
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+type function func() error
+
+// Option ...
+type Option func(*Options)
+
+// Options ...
+type Options struct {
+	maxRetries  int
+	waitTime    int
+	maxWaitTime int
+}
+
+// Retries sets the max number of retries
+func Retries(value int) Option {
+	return func(o *Options) {
+		o.maxRetries = value
+	}
+}
+
+// WaitTime sets the default wait time to sleep between requests
+func WaitTime(value int) Option {
+	return func(o *Options) {
+		o.waitTime = value
+	}
+}
+
+// MaxWaitTime sets the max wait time to sleep between requests
+func MaxWaitTime(value int) Option {
+	return func(o *Options) {
+		o.maxWaitTime = value
+	}
+}
+
+//Backoff retries with increasing timeout duration up until X amount of retries (Default is 3 attempts, Override with option Retries(n))
+func Backoff(operation function, options ...Option) error {
+	// Defaults
+	opts := Options{maxRetries: 3, waitTime: 100, maxWaitTime: 2000}
+	for _, o := range options {
+		o(&opts)
+	}
+
+	var err error
+	base := float64(opts.waitTime)        // Time to wait between each attempt
+	capLevel := float64(opts.maxWaitTime) // Maximum amount of wait time for the retry
+	for attempt := 0; attempt < opts.maxRetries; attempt++ {
+		err = operation()
+		if err == nil {
+			return nil
+		}
+		// Adding capped exponential backup with jitter
+		// See the following article...
+		// http://www.awsarchitectureblog.com/2015/03/backoff.html
+		temp := math.Min(capLevel, base*math.Exp2(float64(attempt)))
+		sleepTime := int(temp/2) + rand.Intn(int(temp/2))
+
+		sleepDuration := time.Duration(sleepTime) * time.Millisecond
+		time.Sleep(sleepDuration)
+	}
+
+	return err
+}

--- a/retry_test.go
+++ b/retry_test.go
@@ -8,12 +8,12 @@ import (
 func TestBackoffSuccess(t *testing.T) {
 	attempts := 3
 	externalCounter := 0
-	retryErr := Backoff(func() error {
+	retryErr := Backoff(func() (*Response, error) {
 		externalCounter++
 		if externalCounter < attempts {
-			return errors.New("Not yet got the number we're after...")
+			return nil, errors.New("Not yet got the number we're after...")
 		}
-		return nil
+		return nil, nil
 	})
 
 	assertError(t, retryErr)
@@ -23,14 +23,68 @@ func TestBackoffSuccess(t *testing.T) {
 func TestBackoffTenAttemptsSuccess(t *testing.T) {
 	attempts := 10
 	externalCounter := 0
-	retryErr := Backoff(func() error {
+	retryErr := Backoff(func() (*Response, error) {
 		externalCounter++
 		if externalCounter < attempts {
-			return errors.New("Not yet got the number we're after...")
+			return nil, errors.New("Not yet got the number we're after...")
 		}
-		return nil
+		return nil, nil
 	}, Retries(attempts), WaitTime(5), MaxWaitTime(500))
 
 	assertError(t, retryErr)
 	assertEqual(t, externalCounter, attempts)
+}
+
+// Check to make sure the conditional of the retry condition is being used
+func TestConditionalBackoffCondition(t *testing.T) {
+	attempts := 3
+	counter := 0
+	check := func(*Response) (bool, error) {
+		return attempts != counter, nil
+	}
+	retryErr := Backoff(func() (*Response, error) {
+		counter++
+		return nil, nil
+	}, RetryConditions([]func(*Response) (bool, error){check}))
+
+	assertError(t, retryErr)
+	assertEqual(t, counter, attempts)
+}
+
+// Check to make sure that errors in the conditional cause a retry
+func TestConditionalBackoffConditionError(t *testing.T) {
+	attempts := 3
+	counter := 0
+	check := func(*Response) (bool, error) {
+		if attempts != counter {
+			return false, errors.New("Attempts not equal Counter")
+		}
+		return false, nil
+	}
+
+	retryErr := Backoff(func() (*Response, error) {
+		counter++
+		return nil, nil
+	}, RetryConditions([]func(*Response) (bool, error){check}))
+
+	assertError(t, retryErr)
+	assertEqual(t, counter, attempts)
+}
+
+// Check to make sure that if the conditional is false we don't retry
+func TestConditionalBackoffConditionNonExecution(t *testing.T) {
+	attempts := 3
+	counter := 0
+
+	filler := func(*Response) (bool, error) {
+		return false, nil
+	}
+
+	retryErr := Backoff(func() (*Response, error) {
+		counter++
+		return nil, nil
+	}, RetryConditions([]func(*Response) (bool, error){filler}))
+
+	assertError(t, retryErr)
+	assertNotEqual(t, counter, attempts)
 }

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,0 +1,36 @@
+package resty
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestBackoffSuccess(t *testing.T) {
+	attempts := 3
+	externalCounter := 0
+	retryErr := Backoff(func() error {
+		externalCounter++
+		if externalCounter < attempts {
+			return errors.New("Not yet got the number we're after...")
+		}
+		return nil
+	})
+
+	assertError(t, retryErr)
+	assertEqual(t, externalCounter, attempts)
+}
+
+func TestBackoffTenAttemptsSuccess(t *testing.T) {
+	attempts := 10
+	externalCounter := 0
+	retryErr := Backoff(func() error {
+		externalCounter++
+		if externalCounter < attempts {
+			return errors.New("Not yet got the number we're after...")
+		}
+		return nil
+	}, Retries(attempts), WaitTime(5), MaxWaitTime(500))
+
+	assertError(t, retryErr)
+	assertEqual(t, externalCounter, attempts)
+}


### PR DESCRIPTION
Added the ability to add conditions in which to actually retry instead of only on returned errors from the response. This allows you to retry you request again in the case of bad responses in addition to retrying based upon response status codes.