### PR TITLE
Request based on the SRV record of the service

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -125,7 +125,7 @@ func parseRequestBody(c *Client, r *Request) (err error) {
 
 CL:
 	// by default resty won't set content length, you can if you want to :)
-	if c.setContentLength || r.setContentLength {
+	if (c.setContentLength || r.setContentLength) && r.bodyBuf != nil {
 		r.Header.Set(hdrContentLengthKey, fmt.Sprintf("%d", r.bodyBuf.Len()))
 	}
 

--- a/request16.go
+++ b/request16.go
@@ -33,6 +33,7 @@ type Request struct {
 	Error      interface{}
 	Time       time.Time
 	RawRequest *http.Request
+	SRV        *SRVRecord
 
 	client           *Client
 	bodyBuf          *bytes.Buffer

--- a/request17.go
+++ b/request17.go
@@ -34,6 +34,7 @@ type Request struct {
 	Error      interface{}
 	Time       time.Time
 	RawRequest *http.Request
+	SRV        *SRVRecord
 
 	client           *Client
 	bodyBuf          *bytes.Buffer

--- a/resty_test.go
+++ b/resty_test.go
@@ -1409,6 +1409,31 @@ func TestClientOptions(t *testing.T) {
 	SetLogger(ioutil.Discard)
 }
 
+func TestSRV(t *testing.T) {
+	c := dc().
+		SetRedirectPolicy(FlexibleRedirectPolicy(20)).
+		SetScheme("http")
+
+	r := c.R().
+		SetSRV(&SRVRecord{"xmpp-server", "google.com"})
+
+	assertEqual(t, "xmpp-server", r.SRV.Service)
+	assertEqual(t, "google.com", r.SRV.Domain)
+
+	resp, err := r.Get("/")
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
+}
+
+func TestSRVInvalidService(t *testing.T) {
+	_, err := R().
+		SetSRV(&SRVRecord{"nonexistantservice", "sampledomain"}).
+		Get("/")
+
+	assertEqual(t, true, (err != nil))
+	assertEqual(t, true, strings.Contains(err.Error(), "no such host"))
+}
+
 func getTestDataPath() string {
 	pwd, _ := os.Getwd()
 	return pwd + "/test-data"


### PR DESCRIPTION
I've made this changes to be possible to do a request based on the SRV record of the service. It is useful when you have a service discovery mechanism, like Consul, so you can pass the information and the system will query the SRV record and to the request based on it.

I do not expect this PR to be merged right away, but to start a discussion on the following topic.

Please, review it and suggest the needed changes.