### PR TITLE
Use HTTP Client SetTimeout instead of custom timeout

### DIFF
--- a/client.go
+++ b/client.go
@@ -491,14 +491,6 @@ func (c *Client) SetTLSClientConfig(config *tls.Config) *Client {
 	return c
 }
 
-// SetTimeout method sets timeout for request raised from client
-//		resty.SetTimeout(time.Duration(1 * time.Minute))
-//
-func (c *Client) SetTimeout(timeout time.Duration) *Client {
-	c.httpClient.Timeout = timeout
-	return c
-}
-
 // SetProxy method sets the Proxy URL and Port for resty client.
 //		resty.SetProxy("http://proxyserver:8888")
 //

--- a/client.go
+++ b/client.go
@@ -14,7 +14,6 @@ import (
 	"io/ioutil"
 	"log"
 	"mime/multipart"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -496,17 +495,7 @@ func (c *Client) SetTLSClientConfig(config *tls.Config) *Client {
 //		resty.SetTimeout(time.Duration(1 * time.Minute))
 //
 func (c *Client) SetTimeout(timeout time.Duration) *Client {
-	c.transport.Dial = func(network, addr string) (net.Conn, error) {
-		conn, err := net.DialTimeout(network, addr, timeout)
-		if err != nil {
-			c.Log.Printf("ERROR [%v]", err)
-			return nil, err
-		}
-		err = conn.SetDeadline(time.Now().Add(timeout))
-		return conn, err
-	}
-	c.httpClient.Transport = c.transport
-
+	c.httpClient.Timeout = timeout
 	return c
 }
 

--- a/client12.go
+++ b/client12.go
@@ -1,0 +1,24 @@
+// +build !go1.3
+
+// Copyright (c) 2015-2017 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
+// resty source code and usage is governed by a MIT style
+// license that can be found in the LICENSE file.
+
+package resty
+
+import (
+	"net"
+	"time"
+)
+
+// SetTimeout method sets timeout for request raised from client
+//		resty.SetTimeout(time.Duration(1 * time.Minute))
+//
+func (c *Client) SetTimeout(timeout time.Duration) *Client {
+	c.transport.Dial = func(network, addr string) (net.Conn, error) {
+		return net.DialTimeout(network, addr, timeout)
+	}
+	c.transport.ResponseHeaderTimeout = timeout
+	c.httpClient.Transport = c.transport
+	return c
+}

--- a/client13.go
+++ b/client13.go
@@ -1,0 +1,17 @@
+// +build go1.3
+
+// Copyright (c) 2015-2017 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
+// resty source code and usage is governed by a MIT style
+// license that can be found in the LICENSE file.
+
+package resty
+
+import "time"
+
+// SetTimeout method sets timeout for request raised from client
+//		resty.SetTimeout(time.Duration(1 * time.Minute))
+//
+func (c *Client) SetTimeout(timeout time.Duration) *Client {
+	c.httpClient.Timeout = timeout
+	return c
+}

--- a/client_test.go
+++ b/client_test.go
@@ -95,8 +95,28 @@ func TestClientTimeout(t *testing.T) {
 		SetTimeout(time.Duration(time.Second * 3))
 
 	_, err := c.R().Get(ts.URL + "/set-timeout-test")
+	assertEqual(t, true, strings.Contains(strings.ToLower(err.Error()), "timeout"))
+}
 
-	assertEqual(t, true, strings.Contains(err.Error(), "i/o timeout"))
+func TestClientTimeoutWithinThreshold(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	c := dc()
+	c.SetHTTPMode().
+		SetTimeout(time.Duration(time.Second * 3))
+
+	resp, err := c.R().Get(ts.URL + "/set-timeout-test-with-sequence")
+	assertError(t, err)
+
+	seq1, _ := strconv.ParseInt(resp.String(), 10, 64)
+
+	resp, err = c.R().Get(ts.URL + "/set-timeout-test-with-sequence")
+	assertError(t, err)
+
+	seq2, _ := strconv.ParseInt(resp.String(), 10, 64)
+
+	assertEqual(t, seq1+1, seq2)
 }
 
 func TestClientTimeoutInternalError(t *testing.T) {

--- a/resty_test.go
+++ b/resty_test.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -1165,6 +1166,7 @@ func getTestDataPath() string {
 // Used for retry testing...
 var mc = &sync.Mutex{}
 var attempt int
+var sequence int64
 
 func createGetServer(t *testing.T) *httptest.Server {
 	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
@@ -1186,6 +1188,10 @@ func createGetServer(t *testing.T) *httptest.Server {
 					time.Sleep(time.Second * 6)
 				}
 				_, _ = w.Write([]byte("TestClientRetry page"))
+			} else if r.URL.Path == "/set-timeout-test-with-sequence" {
+				seq := atomic.AddInt64(&sequence, 1)
+				time.Sleep(time.Second * 2)
+				_, _ = fmt.Fprintf(w, "%d", seq)
 			} else if r.URL.Path == "/set-timeout-test" {
 				time.Sleep(time.Second * 6)
 				_, _ = w.Write([]byte("TestClientTimeout page"))


### PR DESCRIPTION
fix(#59) by using `http.Client.Timeout` instead of a special `http.Transport`.