### PR TITLE
Allow to override default retry wait times for Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -68,19 +68,21 @@ var (
 // Client type is used for HTTP/RESTful global values
 // for all request raised from the client
 type Client struct {
-	HostURL         string
-	QueryParam      url.Values
-	FormData        url.Values
-	Header          http.Header
-	UserInfo        *User
-	Token           string
-	Cookies         []*http.Cookie
-	Error           reflect.Type
-	Debug           bool
-	DisableWarn     bool
-	Log             *log.Logger
-	RetryCount      int
-	RetryConditions []RetryConditionFunc
+	HostURL          string
+	QueryParam       url.Values
+	FormData         url.Values
+	Header           http.Header
+	UserInfo         *User
+	Token            string
+	Cookies          []*http.Cookie
+	Error            reflect.Type
+	Debug            bool
+	DisableWarn      bool
+	Log              *log.Logger
+	RetryCount       int
+	RetryWaitTime    time.Duration
+	RetryMaxWaitTime time.Duration
+	RetryConditions  []RetryConditionFunc
 
 	httpClient       *http.Client
 	transport        *http.Transport
@@ -411,6 +413,20 @@ func (c *Client) SetRedirectPolicy(policies ...interface{}) *Client {
 // to set no. of retry count. Resty uses a Backoff mechanism.
 func (c *Client) SetRetryCount(count int) *Client {
 	c.RetryCount = count
+	return c
+}
+
+// SetRetryWaitTime method sets default wait time to sleep before retrying
+// request
+func (c *Client) SetRetryWaitTime(waitTime time.Duration) *Client {
+	c.RetryWaitTime = waitTime
+	return c
+}
+
+// SetRetryMaxWaitTime method sets max wait time to sleep before retrying
+// request
+func (c *Client) SetRetryMaxWaitTime(maxWaitTime time.Duration) *Client {
+	c.RetryMaxWaitTime = maxWaitTime
 	return c
 }
 

--- a/client.go
+++ b/client.go
@@ -417,14 +417,16 @@ func (c *Client) SetRetryCount(count int) *Client {
 }
 
 // SetRetryWaitTime method sets default wait time to sleep before retrying
-// request
+// request.
+// Default is 100 milliseconds.
 func (c *Client) SetRetryWaitTime(waitTime time.Duration) *Client {
 	c.RetryWaitTime = waitTime
 	return c
 }
 
 // SetRetryMaxWaitTime method sets max wait time to sleep before retrying
-// request
+// request.
+// Default is 2 seconds.
 func (c *Client) SetRetryMaxWaitTime(maxWaitTime time.Duration) *Client {
 	c.RetryMaxWaitTime = maxWaitTime
 	return c

--- a/default.go
+++ b/default.go
@@ -24,18 +24,20 @@ func New() *Client {
 	cookieJar, _ := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
 
 	c := &Client{
-		HostURL:    "",
-		QueryParam: url.Values{},
-		FormData:   url.Values{},
-		Header:     http.Header{},
-		UserInfo:   nil,
-		Token:      "",
-		Cookies:    make([]*http.Cookie, 0),
-		Debug:      false,
-		Log:        getLogger(os.Stderr),
-		RetryCount: 0,
-		httpClient: &http.Client{Jar: cookieJar},
-		transport:  &http.Transport{},
+		HostURL:          "",
+		QueryParam:       url.Values{},
+		FormData:         url.Values{},
+		Header:           http.Header{},
+		UserInfo:         nil,
+		Token:            "",
+		Cookies:          make([]*http.Cookie, 0),
+		Debug:            false,
+		Log:              getLogger(os.Stderr),
+		RetryCount:       0,
+		RetryWaitTime:    defaultWaitTime,
+		RetryMaxWaitTime: defaultMaxWaitTime,
+		httpClient:       &http.Client{Jar: cookieJar},
+		transport:        &http.Transport{},
 	}
 
 	c.httpClient.Transport = c.transport

--- a/retry.go
+++ b/retry.go
@@ -12,8 +12,8 @@ import (
 
 const (
 	defaultMaxRetries  = 3
-	defaultWaitTime    = 100  // base Milliseconds
-	defaultMaxWaitTime = 2000 // cap level Milliseconds
+	defaultWaitTime    = time.Duration(100) * time.Millisecond
+	defaultMaxWaitTime = time.Duration(2000) * time.Millisecond
 )
 
 // Option is to create convenient retry options like wait time, max retries, etc.
@@ -25,8 +25,8 @@ type RetryConditionFunc func(*Response) (bool, error)
 // Options to hold go-resty retry values
 type Options struct {
 	maxRetries      int
-	waitTime        int
-	maxWaitTime     int
+	waitTime        time.Duration
+	maxWaitTime     time.Duration
 	retryConditions []RetryConditionFunc
 }
 
@@ -38,14 +38,14 @@ func Retries(value int) Option {
 }
 
 // WaitTime sets the default wait time to sleep between requests
-func WaitTime(value int) Option {
+func WaitTime(value time.Duration) Option {
 	return func(o *Options) {
 		o.waitTime = value
 	}
 }
 
 // MaxWaitTime sets the max wait time to sleep between requests
-func MaxWaitTime(value int) Option {
+func MaxWaitTime(value time.Duration) Option {
 	return func(o *Options) {
 		o.maxWaitTime = value
 	}
@@ -100,9 +100,8 @@ func Backoff(operation func() (*Response, error), options ...Option) error {
 		// See the following article...
 		// http://www.awsarchitectureblog.com/2015/03/backoff.html
 		temp := math.Min(capLevel, base*math.Exp2(float64(attempt)))
-		sleepTime := int(temp/2) + rand.Intn(int(temp/2))
+		sleepDuration := time.Duration(int(temp/2) + rand.Intn(int(temp/2)))
 
-		sleepDuration := time.Duration(sleepTime) * time.Millisecond
 		time.Sleep(sleepDuration)
 	}
 

--- a/retry.go
+++ b/retry.go
@@ -102,6 +102,9 @@ func Backoff(operation func() (*Response, error), options ...Option) error {
 		temp := math.Min(capLevel, base*math.Exp2(float64(attempt)))
 		sleepDuration := time.Duration(int(temp/2) + rand.Intn(int(temp/2)))
 
+		if sleepDuration < opts.waitTime {
+			sleepDuration = opts.waitTime
+		}
 		time.Sleep(sleepDuration)
 	}
 


### PR DESCRIPTION
This resolves #64 

Changes made here:

- Changing retry wait time options to have `time.Duration` type instead of of `int` holding milliseconds.

- Adding `RetryWaitTime` and `RetryMaxWaitTime` fields to `Client` along with chaining setters.

- A condition to make sure `Backoff` always sleeps at least `WaitTime` duration. Before this change it could sleep less than this due to jitter we have there. Especially before the very first retry, the sleep duration was always somewhere between `WaitTime / 2` and `WaitTime`.

- Test to make sure overridden wait times are actually used.