### PR TITLE
Add shortcuts to set DefaultClient's retry timeouts

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -294,6 +294,14 @@ func TestClientOptions(t *testing.T) {
 
 	SetRetryCount(3)
 	assertEqual(t, 3, DefaultClient.RetryCount)
+	
+	rwt := time.Duration(1000) * time.Millisecond
+	SetRetryWaitTime(rwt)
+	assertEqual(t, rwt, DefaultClient.RetryWaitTime)
+
+	mrwt := time.Duration(2) * time.Second
+	SetRetryMaxWaitTime(mrwt)
+	assertEqual(t, mrwt, DefaultClient.RetryMaxWaitTime)
 
 	err := &AuthError{}
 	SetError(err)

--- a/default.go
+++ b/default.go
@@ -144,9 +144,19 @@ func SetDebug(d bool) *Client {
 	return DefaultClient.SetDebug(d)
 }
 
-// SetRetryCount method set the retry count. See `Client.SetRetryCount` for more information.
+// SetRetryCount method sets the retry count. See `Client.SetRetryCount` for more information.
 func SetRetryCount(count int) *Client {
 	return DefaultClient.SetRetryCount(count)
+}
+
+// SetRetryWaitTime method sets the retry wait time. See `Client.SetRetryWaitTime` for more information.
+func SetRetryWaitTime(waitTime time.Duration) *Client {
+	return DefaultClient.SetRetryWaitTime(waitTime)
+}
+
+// SetRetryMaxWaitTime method sets the retry max wait time. See `Client.SetRetryMaxWaitTime` for more information.
+func SetRetryMaxWaitTime(maxWaitTime time.Duration) *Client {
+	return DefaultClient.SetRetryMaxWaitTime(maxWaitTime)
 }
 
 // AddRetryCondition method appends check function for retry. See `Client.AddRetryCondition` for more information.

--- a/resty_test.go
+++ b/resty_test.go
@@ -1541,14 +1541,14 @@ func createRedirectServer(t *testing.T) *httptest.Server {
 					if cnt >= 5 {
 						http.Redirect(w, r, "http://httpbin.org/get", http.StatusTemporaryRedirect)
 					} else {
-						http.Redirect(w, r, fmt.Sprintf("/redirect-host-check-%d", (cnt + 1)), http.StatusTemporaryRedirect)
+						http.Redirect(w, r, fmt.Sprintf("/redirect-host-check-%d", (cnt+1)), http.StatusTemporaryRedirect)
 					}
 				}
 			} else if strings.HasPrefix(r.URL.Path, "/redirect-") {
 				cntStr := strings.SplitAfter(r.URL.Path, "-")[1]
 				cnt, _ := strconv.Atoi(cntStr)
 
-				http.Redirect(w, r, fmt.Sprintf("/redirect-%d", (cnt + 1)), http.StatusTemporaryRedirect)
+				http.Redirect(w, r, fmt.Sprintf("/redirect-%d", (cnt+1)), http.StatusTemporaryRedirect)
 			}
 		}
 	})


### PR DESCRIPTION
Just noticed we have these package level shortcuts for configuring DefaultClient and added them for retry timeouts.