### PR TITLE
Introduce ITransport interface to provide better way to extend and mock http transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,28 @@ r.R().Get("/index.html")
 
 ```
 
+#### Mock Transport 
+
+```go
+type MockedTransport struct {
+}
+// Implement RoundTripper interface 
+func (t *MockedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+  // Your mocking code here, HTTP mocking pacakge like httpmock can be used as well
+  return httpmock.DefaultTransport.RoundTrip(req)
+}
+
+// Create a Go's ITransport so we can set it in resty.
+transport := &MockedTransport{}
+
+// Set the mocked transport that we created.
+r := resty.SetTransport(transport)
+
+// No need to write the host's URL on the request, just the path.
+r.New().R().Get("/index.html")
+
+```
+
 ## Versioning
 resty releases versions according to [Semantic Versioning](http://semver.org)
 

--- a/client_test.go
+++ b/client_test.go
@@ -152,21 +152,21 @@ func TestSetCertificates(t *testing.T) {
 	DefaultClient = dc()
 	SetCertificates(tls.Certificate{})
 
-	assertEqual(t, 1, len(DefaultClient.transport.TLSClientConfig.Certificates))
+	assertEqual(t, 1, len(DefaultClient.transport.GetTLSClientConfig().Certificates))
 }
 
 func TestSetRootCertificate(t *testing.T) {
 	DefaultClient = dc()
 	SetRootCertificate(getTestDataPath() + "/sample-root.pem")
 
-	assertEqual(t, true, DefaultClient.transport.TLSClientConfig.RootCAs != nil)
+	assertEqual(t, true, DefaultClient.transport.GetTLSClientConfig().RootCAs != nil)
 }
 
 func TestSetRootCertificateNotExists(t *testing.T) {
 	DefaultClient = dc()
 	SetRootCertificate(getTestDataPath() + "/not-exists-sample-root.pem")
 
-	assertEqual(t, true, DefaultClient.transport.TLSClientConfig == nil)
+	assertEqual(t, true, DefaultClient.transport.GetTLSClientConfig() == nil)
 }
 
 func TestOnBeforeRequestModification(t *testing.T) {
@@ -195,11 +195,12 @@ func TestSetTransport(t *testing.T) {
 	defer ts.Close()
 	DefaultClient = dc()
 
-	transport := &http.Transport{
+	transport := &Transport{transport: &http.Transport{
 		// somthing like Proxying to httptest.Server, etc...
 		Proxy: func(req *http.Request) (*url.URL, error) {
 			return url.Parse(ts.URL)
 		},
+	},
 	}
 	SetTransport(transport)
 
@@ -296,7 +297,7 @@ func TestClientOptions(t *testing.T) {
 	}
 
 	SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
-	assertEqual(t, true, DefaultClient.transport.TLSClientConfig.InsecureSkipVerify)
+	assertEqual(t, true, DefaultClient.transport.GetTLSClientConfig().InsecureSkipVerify)
 
 	OnBeforeRequest(func(c *Client, r *Request) error {
 		c.Log.Println("I'm in Request middleware")

--- a/default.go
+++ b/default.go
@@ -19,6 +19,9 @@ import (
 // DefaultClient of resty
 var DefaultClient *Client
 
+// DefaultTransport ...
+var DefaultTransport ITransport
+
 // New method creates a new go-resty client
 func New() *Client {
 	cookieJar, _ := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
@@ -37,7 +40,7 @@ func New() *Client {
 		RetryWaitTime:    defaultWaitTime,
 		RetryMaxWaitTime: defaultMaxWaitTime,
 		httpClient:       &http.Client{Jar: cookieJar},
-		transport:        &http.Transport{},
+		transport:        DefaultTransport,
 	}
 
 	c.httpClient.Transport = c.transport
@@ -236,9 +239,10 @@ func SetOutputDirectory(dirPath string) *Client {
 	return DefaultClient.SetOutputDirectory(dirPath)
 }
 
-// SetTransport method sets custom *http.Transport in the resty client.
+// SetTransport method sets custom ITransport in the resty client.
 // See `Client.SetTransport` for more information.
-func SetTransport(transport *http.Transport) *Client {
+func SetTransport(transport ITransport) *Client {
+	DefaultTransport = transport
 	return DefaultClient.SetTransport(transport)
 }
 
@@ -261,5 +265,6 @@ func IsProxySet() bool {
 }
 
 func init() {
+	DefaultTransport = &Transport{transport: &http.Transport{}}
 	DefaultClient = New()
 }

--- a/resty_test.go
+++ b/resty_test.go
@@ -849,23 +849,24 @@ func TestRawFileUploadByBody(t *testing.T) {
 
 func TestProxySetting(t *testing.T) {
 	c := dc()
+	transport := c.transport.(*Transport)
 
-	assertEqual(t, false, c.IsProxySet())
-	assertEqual(t, true, (c.transport.Proxy == nil))
+	assertEqual(t, false, c.transport.IsProxySet())
+	assertEqual(t, true, (c.transport.GetProxy() == nil))
 
 	c.SetProxy("http://sampleproxy:8888")
 	assertEqual(t, true, c.IsProxySet())
-	assertEqual(t, false, (c.transport.Proxy == nil))
+	assertEqual(t, false, (c.transport.GetProxy() == nil))
 
 	c.SetProxy("//not.a.user@%66%6f%6f.com:8888")
-	assertEqual(t, false, c.IsProxySet())
-	assertEqual(t, true, (c.transport.Proxy == nil))
+	assertEqual(t, false, c.transport.IsProxySet())
+	assertEqual(t, true, (c.transport.GetProxy() == nil))
 
 	SetProxy("http://sampleproxy:8888")
 	assertEqual(t, true, IsProxySet())
 	RemoveProxy()
-	assertEqual(t, true, (DefaultClient.proxyURL == nil))
-	assertEqual(t, true, (DefaultClient.transport.Proxy == nil))
+	assertEqual(t, true, (DefaultClient.transport.GetProxy() == nil))
+	assertEqual(t, true, (transport.proxyURL == nil))
 }
 
 func TestIncorrectURL(t *testing.T) {
@@ -1536,6 +1537,11 @@ func createTestServer(fn func(w http.ResponseWriter, r *http.Request)) *httptest
 func dc() *Client {
 	DefaultClient = New()
 	return DefaultClient
+}
+
+func dt() ITransport {
+	DefaultTransport = &Transport{transport: &http.Transport{}}
+	return DefaultTransport
 }
 
 func dcr() *Request {

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,66 @@
+package resty
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/url"
+)
+
+// ITransport ...
+type ITransport interface {
+	http.RoundTripper
+	SetTLSClientConfig(config *tls.Config)
+	GetTLSClientConfig() *tls.Config
+	SetProxy(proxyURL string) error
+	GetProxy() func(*http.Request) (*url.URL, error)
+	RemoveProxy()
+	IsProxySet() bool
+}
+
+// Transport ...
+type Transport struct {
+	transport *http.Transport
+	proxyURL  *url.URL
+}
+
+// SetTLSClientConfig ...
+func (t *Transport) SetTLSClientConfig(config *tls.Config) {
+	t.transport.TLSClientConfig = config
+}
+
+// GetTLSClientConfig ...
+func (t *Transport) GetTLSClientConfig() *tls.Config {
+	return t.transport.TLSClientConfig
+}
+
+// SetProxy ...
+func (t *Transport) SetProxy(proxyURL string) (err error) {
+	if pURL, err := url.Parse(proxyURL); err == nil {
+		t.proxyURL = pURL
+		t.transport.Proxy = http.ProxyURL(t.proxyURL)
+	} else {
+		t.RemoveProxy()
+	}
+	return
+}
+
+// GetProxy ...
+func (t *Transport) GetProxy() func(*http.Request) (*url.URL, error) {
+	return t.transport.Proxy
+}
+
+// RemoveProxy ...
+func (t *Transport) RemoveProxy() {
+	t.proxyURL = nil
+	t.transport.Proxy = nil
+}
+
+// IsProxySet ...
+func (t *Transport) IsProxySet() bool {
+	return t.proxyURL != nil
+}
+
+// RoundTrip ...
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.transport.RoundTrip(req)
+}


### PR DESCRIPTION
When writing integration tests in some cases you need to mock some 3rd Party services (if the service usage is payed). In this case http mocking package (like httpmock, gock, etc) will be handy, which will replace http.DefaultTransport (of type RoundTripper interface).
This change introduces ITransport interface which inherits RoundTripper and easily can be changed with mocked implementation
