### PR TITLE
Why set a UA if one is already supplied

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -79,8 +79,6 @@ func parseRequestHeader(c *Client, r *Request) error {
 
 	if IsStringEmpty(hdr.Get(hdrUserAgentKey)) {
 		hdr.Set(hdrUserAgentKey, fmt.Sprintf(hdrUserAgentValue, Version))
-	} else {
-		hdr.Set("X-"+hdrUserAgentKey, fmt.Sprintf(hdrUserAgentValue, Version))
 	}
 
 	if IsStringEmpty(hdr.Get(hdrAcceptKey)) && !IsStringEmpty(hdr.Get(hdrContentTypeKey)) {


### PR DESCRIPTION
some monitoring software has to prioritize User-Agent, X-User-Agent or possibly some query string parameter where youd typically rank qs and X-User-Agent a higher prio than the normal UA because in some environments (browsers) you cant set the UA.

In such a (not uncommon) setup "resty" would show up as the UA which is not helpful at all. The user of resty already supplies a UA, there is no need to add another header with the resty UA.