### PR TITLE
Adds an option to support GET method with request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Go Resty first released on Sep 15, 2015 then go-resty grew gradually as a very h
 * Cookies for your request and CookieJar support
 * SRV Record based request instead of Host URL
 * Client settings like `Timeout`, `RedirectPolicy`, `Proxy`, `TLSClientConfig`, `Transport`, etc.
+* Optionally allows GET request with payload, see [SetAllowGetMethodPayload](https://godoc.org/github.com/go-resty/resty#Client.SetOutputDirectory#Client.SetAllowGetMethodPayload)
 * resty design
   * Have client level settings & options and also override at Request level if you want to
   * Request and Response middlewares
@@ -47,7 +48,6 @@ Go Resty first released on Sep 15, 2015 then go-resty grew gradually as a very h
   * Debug mode - clean and informative logging presentation
   * Gzip - I'm not doing anything here. Go does it automatically
 * Well tested client library
-* Support GET request includes payload
 
 resty tested with Go `v1.3` and above.
 
@@ -512,6 +512,12 @@ resty.SetRESTMode()
 resty.SetHTTPMode()
 ```
 
+#### Allow GET request with Payload
+```go
+// Allow GET request with Payload. This is disabled by default.
+resty.SetAllowGetMethodPayload(true)
+```
+
 #### Wanna Multiple Clients
 ```go
 // Here you go!
@@ -619,12 +625,6 @@ r := resty.New().SetTransport(&transport).SetScheme("http").SetHostURL(unixSocke
 // No need to write the host's URL on the request, just the path.
 r.R().Get("/index.html")
 
-```
-
-#### Allow payload in GET request
-```go
-// Allow the request with GET method includes payload. This is disabled by default.
-resty.SetAllowGetMethodPayload(true)
 ```
 
 ## Versioning

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Go Resty first released on Sep 15, 2015 then go-resty grew gradually as a very h
   * Debug mode - clean and informative logging presentation
   * Gzip - I'm not doing anything here. Go does it automatically
 * Well tested client library
+* Support GET request includes payload
 
 resty tested with Go `v1.3` and above.
 
@@ -618,6 +619,12 @@ r := resty.New().SetTransport(&transport).SetScheme("http").SetHostURL(unixSocke
 // No need to write the host's URL on the request, just the path.
 r.R().Get("/index.html")
 
+```
+
+#### Allow payload in GET request
+```go
+// Allow the request with GET method includes payload. This is disabled by default.
+resty.SetAllowGetMethodPayload(true)
 ```
 
 ## Versioning

--- a/client.go
+++ b/client.go
@@ -71,21 +71,22 @@ var (
 // Client type is used for HTTP/RESTful global values
 // for all request raised from the client
 type Client struct {
-	HostURL          string
-	QueryParam       url.Values
-	FormData         url.Values
-	Header           http.Header
-	UserInfo         *User
-	Token            string
-	Cookies          []*http.Cookie
-	Error            reflect.Type
-	Debug            bool
-	DisableWarn      bool
-	Log              *log.Logger
-	RetryCount       int
-	RetryWaitTime    time.Duration
-	RetryMaxWaitTime time.Duration
-	RetryConditions  []RetryConditionFunc
+	HostURL               string
+	QueryParam            url.Values
+	FormData              url.Values
+	Header                http.Header
+	UserInfo              *User
+	Token                 string
+	Cookies               []*http.Cookie
+	Error                 reflect.Type
+	Debug                 bool
+	DisableWarn           bool
+	AllowGetMethodPayload bool
+	Log                   *log.Logger
+	RetryCount            int
+	RetryWaitTime         time.Duration
+	RetryMaxWaitTime      time.Duration
+	RetryConditions       []RetryConditionFunc
 
 	httpClient       *http.Client
 	transport        *http.Transport
@@ -370,6 +371,15 @@ func (c *Client) SetDebug(d bool) *Client {
 //
 func (c *Client) SetDisableWarn(d bool) *Client {
 	c.DisableWarn = d
+	return c
+}
+
+// SetAllowGetMethodPayload method allows the GET method with payload on `go-resty` client.
+// For example: go-resty allows the user sends request with a payload on HTTP GET method.
+//		resty.SetAllowGetMethodPayload(true)
+//
+func (c *Client) SetAllowGetMethodPayload(a bool) *Client {
+	c.AllowGetMethodPayload = a
 	return c
 }
 
@@ -851,8 +861,19 @@ func getPointer(v interface{}) interface{} {
 	return reflect.New(vv.Type()).Interface()
 }
 
-func isPayloadSupported(m string) bool {
-	return (m == MethodPost || m == MethodPut || m == MethodDelete || m == MethodPatch)
+func isPayloadSupported(allowGetMethodPayload bool, m string) bool {
+	methods := []string{MethodPost, MethodPut, MethodDelete, MethodPatch}
+
+	if allowGetMethodPayload {
+		methods = append(methods, MethodGet)
+	}
+
+	for _, method := range methods {
+		if m == method {
+			return true
+		}
+	}
+	return false
 }
 
 func typeOf(i interface{}) reflect.Type {

--- a/client.go
+++ b/client.go
@@ -861,19 +861,8 @@ func getPointer(v interface{}) interface{} {
 	return reflect.New(vv.Type()).Interface()
 }
 
-func isPayloadSupported(allowGetMethodPayload bool, m string) bool {
-	methods := []string{MethodPost, MethodPut, MethodDelete, MethodPatch}
-
-	if allowGetMethodPayload {
-		methods = append(methods, MethodGet)
-	}
-
-	for _, method := range methods {
-		if m == method {
-			return true
-		}
-	}
-	return false
+func isPayloadSupported(m string, allowMethodGet bool) bool {
+	return (m == MethodPost || m == MethodPut || m == MethodDelete || m == MethodPatch || (allowMethodGet && m == MethodGet))
 }
 
 func typeOf(i interface{}) reflect.Type {

--- a/client_test.go
+++ b/client_test.go
@@ -347,18 +347,3 @@ func TestClientPreRequestHook(t *testing.T) {
 		return nil
 	})
 }
-
-func TestClientAllowsGetMethodPayload(t *testing.T) {
-	ts := createGetServer(t)
-	defer ts.Close()
-
-	c := dc()
-	c.SetAllowGetMethodPayload(true)
-
-	payload := "test-payload"
-	resp, err := c.R().SetBody(payload).Get(ts.URL + "/get-method-payload-test")
-
-	assertError(t, err)
-	assertEqual(t, http.StatusOK, resp.StatusCode())
-	assertEqual(t, payload, resp.String())
-}

--- a/client_test.go
+++ b/client_test.go
@@ -288,7 +288,7 @@ func TestClientOptions(t *testing.T) {
 
 	SetRetryCount(3)
 	assertEqual(t, 3, DefaultClient.RetryCount)
-	
+
 	rwt := time.Duration(1000) * time.Millisecond
 	SetRetryWaitTime(rwt)
 	assertEqual(t, rwt, DefaultClient.RetryWaitTime)
@@ -324,6 +324,9 @@ func TestClientOptions(t *testing.T) {
 	SetDebug(true)
 	assertEqual(t, DefaultClient.Debug, true)
 
+	SetAllowGetMethodPayload(true)
+	assertEqual(t, DefaultClient.AllowGetMethodPayload, true)
+
 	SetScheme("http")
 	assertEqual(t, DefaultClient.scheme, "http")
 
@@ -343,4 +346,19 @@ func TestClientPreRequestHook(t *testing.T) {
 		c.Log.Println("I'm Overwriting existing Pre-Request Hook")
 		return nil
 	})
+}
+
+func TestClientAllowsGetMethodPayload(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	c := dc()
+	c.SetAllowGetMethodPayload(true)
+
+	payload := "test-payload"
+	resp, err := c.R().SetBody(payload).Get(ts.URL + "/get-method-payload-test")
+
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
+	assertEqual(t, payload, resp.String())
 }

--- a/client_test.go
+++ b/client_test.go
@@ -347,3 +347,19 @@ func TestClientPreRequestHook(t *testing.T) {
 		return nil
 	})
 }
+
+func TestClientAllowsGetMethodPayload(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	c := dc()
+	c.SetAllowGetMethodPayload(true)
+	c.SetPreRequestHook(func(*Client, *Request) error { return nil }) // for coverage
+
+	payload := "test-payload"
+	resp, err := c.R().SetBody(payload).Get(ts.URL + "/get-method-payload-test")
+
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
+	assertEqual(t, payload, resp.String())
+}

--- a/default.go
+++ b/default.go
@@ -149,6 +149,11 @@ func SetDebug(d bool) *Client {
 	return DefaultClient.SetDebug(d)
 }
 
+// SetAllowGetMethodPayload method allows the GET method with payload. See `Client.SetAllowGetMethodPayload` for more information.
+func SetAllowGetMethodPayload(a bool) *Client {
+	return DefaultClient.SetAllowGetMethodPayload(a)
+}
+
 // SetRetryCount method sets the retry count. See `Client.SetRetryCount` for more information.
 func SetRetryCount(count int) *Client {
 	return DefaultClient.SetRetryCount(count)

--- a/middleware.go
+++ b/middleware.go
@@ -91,8 +91,7 @@ func parseRequestHeader(c *Client, r *Request) error {
 }
 
 func parseRequestBody(c *Client, r *Request) (err error) {
-	if isPayloadSupported(r.Method) {
-
+	if isPayloadSupported(c.AllowGetMethodPayload, r.Method) {
 		// Handling Multipart
 		if r.isMultiPart && !(r.Method == MethodPatch) {
 			if err = handleMultipart(c, r); err != nil {

--- a/middleware.go
+++ b/middleware.go
@@ -91,7 +91,7 @@ func parseRequestHeader(c *Client, r *Request) error {
 }
 
 func parseRequestBody(c *Client, r *Request) (err error) {
-	if isPayloadSupported(c.AllowGetMethodPayload, r.Method) {
+	if isPayloadSupported(r.Method, c.AllowGetMethodPayload) {
 		// Handling Multipart
 		if r.isMultiPart && !(r.Method == MethodPatch) {
 			if err = handleMultipart(c, r); err != nil {

--- a/request.go
+++ b/request.go
@@ -439,7 +439,7 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 
 func (r *Request) fmtBodyString() (body string) {
 	body = "***** NO CONTENT *****"
-	if isPayloadSupported(r.Method) {
+	if isPayloadSupported(r.client.AllowGetMethodPayload, r.Method) {
 		// multipart or form-data
 		if r.isMultiPart || r.isFormData {
 			body = string(r.bodyBuf.Bytes())

--- a/request.go
+++ b/request.go
@@ -439,7 +439,7 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 
 func (r *Request) fmtBodyString() (body string) {
 	body = "***** NO CONTENT *****"
-	if isPayloadSupported(r.client.AllowGetMethodPayload, r.Method) {
+	if isPayloadSupported(r.Method, r.client.AllowGetMethodPayload) {
 		// multipart or form-data
 		if r.isMultiPart || r.isFormData {
 			body = string(r.bodyBuf.Bytes())

--- a/resty_test.go
+++ b/resty_test.go
@@ -1187,6 +1187,12 @@ func createGetServer(t *testing.T) *httptest.Server {
 				w.Header().Set("Content-Type", "image/png")
 				w.Header().Set("Content-Length", strconv.Itoa(len(fileBytes)))
 				_, _ = w.Write(fileBytes)
+			} else if r.URL.Path == "/get-method-payload-test" {
+				body, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("Error: could not read get body: %s", err.Error())
+				}
+				_, _ = w.Write(body)
 			}
 		}
 	})

--- a/resty_test.go
+++ b/resty_test.go
@@ -1135,6 +1135,21 @@ func TestSRVInvalidService(t *testing.T) {
 	assertEqual(t, true, strings.Contains(err.Error(), "no such host"))
 }
 
+func TestAllowsGetMethodPayload(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	c := dc()
+	c.SetAllowGetMethodPayload(true)
+
+	payload := "test-payload"
+	resp, err := c.R().SetBody(payload).Get(ts.URL + "/get-method-payload-test")
+
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
+	assertEqual(t, payload, resp.String())
+}
+
 func getTestDataPath() string {
 	pwd, _ := os.Getwd()
 	return pwd + "/test-data"

--- a/resty_test.go
+++ b/resty_test.go
@@ -1135,21 +1135,6 @@ func TestSRVInvalidService(t *testing.T) {
 	assertEqual(t, true, strings.Contains(err.Error(), "no such host"))
 }
 
-func TestAllowsGetMethodPayload(t *testing.T) {
-	ts := createGetServer(t)
-	defer ts.Close()
-
-	c := dc()
-	c.SetAllowGetMethodPayload(true)
-
-	payload := "test-payload"
-	resp, err := c.R().SetBody(payload).Get(ts.URL + "/get-method-payload-test")
-
-	assertError(t, err)
-	assertEqual(t, http.StatusOK, resp.StatusCode())
-	assertEqual(t, payload, resp.String())
-}
-
 func getTestDataPath() string {
 	pwd, _ := os.Getwd()
 	return pwd + "/test-data"


### PR DESCRIPTION
Implements `SetAllowGetMethodPayload()` on `go-resty` client to
allow developer decides if request includes payload with GET method.

fixes #81