### PR TITLE
Added Content-Type support for SetFileReader

### DIFF
--- a/client.go
+++ b/client.go
@@ -85,19 +85,18 @@ type Client struct {
 	JSONMarshal           func(v interface{}) ([]byte, error)
 	JSONUnmarshal         func(data []byte, v interface{}) error
 
-	httpClient         *http.Client
-	setContentLength   bool
-	isHTTPMode         bool
-	outputDirectory    string
-	scheme             string
-	proxyURL           *url.URL
-	closeConnection    bool
-	notParseResponse   bool
-	debugBodySizeLimit int64
-	beforeRequest      []func(*Client, *Request) error
-	udBeforeRequest    []func(*Client, *Request) error
-	preReqHook         func(*Client, *Request) error
-	afterResponse      []func(*Client, *Response) error
+	httpClient       *http.Client
+	setContentLength bool
+	isHTTPMode       bool
+	outputDirectory  string
+	scheme           string
+	proxyURL         *url.URL
+	closeConnection  bool
+	notParseResponse bool
+	beforeRequest    []func(*Client, *Request) error
+	udBeforeRequest  []func(*Client, *Request) error
+	preReqHook       func(*Client, *Request) error
+	afterResponse    []func(*Client, *Response) error
 }
 
 // User type is to hold an username and password information
@@ -370,14 +369,6 @@ func (c *Client) SetPreRequestHook(h func(*Client, *Request) error) *Client {
 //
 func (c *Client) SetDebug(d bool) *Client {
 	c.Debug = d
-	return c
-}
-
-// SetDebugBodyLimit sets the maximum size for which the response body will be logged in debug mode.
-//		resty.SetDebugBodyLimit(1000000)
-//
-func (c *Client) SetDebugBodyLimit(sl int64) *Client {
-	c.debugBodySizeLimit = sl
 	return c
 }
 
@@ -716,11 +707,6 @@ func (c *Client) IsProxySet() bool {
 	return c.proxyURL != nil
 }
 
-// GetClient method returns the current http.Client used by the resty client.
-func (c *Client) GetClient() *http.Client {
-	return c.httpClient
-}
-
 //‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 // Client Unexported methods
 //___________________________________
@@ -827,12 +813,13 @@ func (c *Client) getTransport() (*http.Transport, error) {
 
 // File represent file information for multipart request
 type File struct {
-	Name      string
-	ParamName string
+	Name        string
+	ParamName   string
+	ContentType string
 	io.Reader
 }
 
 // String returns string value of current file details
 func (f *File) String() string {
-	return fmt.Sprintf("ParamName: %v; FileName: %v", f.ParamName, f.Name)
+	return fmt.Sprintf("ParamName: %v; FileName: %v; ContentType: %v", f.ParamName, f.Name, f.ContentType)
 }

--- a/client.go
+++ b/client.go
@@ -85,18 +85,19 @@ type Client struct {
 	JSONMarshal           func(v interface{}) ([]byte, error)
 	JSONUnmarshal         func(data []byte, v interface{}) error
 
-	httpClient       *http.Client
-	setContentLength bool
-	isHTTPMode       bool
-	outputDirectory  string
-	scheme           string
-	proxyURL         *url.URL
-	closeConnection  bool
-	notParseResponse bool
-	beforeRequest    []func(*Client, *Request) error
-	udBeforeRequest  []func(*Client, *Request) error
-	preReqHook       func(*Client, *Request) error
-	afterResponse    []func(*Client, *Response) error
+	httpClient         *http.Client
+	setContentLength   bool
+	isHTTPMode         bool
+	outputDirectory    string
+	scheme             string
+	proxyURL           *url.URL
+	closeConnection    bool
+	notParseResponse   bool
+	debugBodySizeLimit int64
+	beforeRequest      []func(*Client, *Request) error
+	udBeforeRequest    []func(*Client, *Request) error
+	preReqHook         func(*Client, *Request) error
+	afterResponse      []func(*Client, *Response) error
 }
 
 // User type is to hold an username and password information
@@ -369,6 +370,14 @@ func (c *Client) SetPreRequestHook(h func(*Client, *Request) error) *Client {
 //
 func (c *Client) SetDebug(d bool) *Client {
 	c.Debug = d
+	return c
+}
+
+// SetDebugBodyLimit sets the maximum size for which the response body will be logged in debug mode.
+//		resty.SetDebugBodyLimit(1000000)
+//
+func (c *Client) SetDebugBodyLimit(sl int64) *Client {
+	c.debugBodySizeLimit = sl
 	return c
 }
 
@@ -707,6 +716,11 @@ func (c *Client) IsProxySet() bool {
 	return c.proxyURL != nil
 }
 
+// GetClient method returns the current http.Client used by the resty client.
+func (c *Client) GetClient() *http.Client {
+	return c.httpClient
+}
+
 //‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 // Client Unexported methods
 //___________________________________
@@ -813,13 +827,13 @@ func (c *Client) getTransport() (*http.Transport, error) {
 
 // File represent file information for multipart request
 type File struct {
-	Name        string
-	ParamName   string
+	Name      string
+	ParamName string
 	ContentType string
 	io.Reader
 }
 
 // String returns string value of current file details
 func (f *File) String() string {
-	return fmt.Sprintf("ParamName: %v; FileName: %v; ContentType: %v", f.ParamName, f.Name, f.ContentType)
+	return fmt.Sprintf("ParamName: %v; FileName: %v; Content-Type: %v", f.ParamName, f.Name, f.ContentType)
 }

--- a/request.go
+++ b/request.go
@@ -262,6 +262,24 @@ func (r *Request) SetFiles(files map[string]string) *Request {
 	return r
 }
 
+// SetFileReaderWithContenttype method is to set single file using io.Reader for multipart upload.
+//	resty.R().
+//		SetFileReader("profile_img", "my-profile-img.png", bytes.NewReader(profileImgBytes), "image/png").
+//		SetFileReader("notes", "user-notes.txt", bytes.NewReader(notesBytes), "plain/text")
+//
+func (r *Request) SetFileReaderWithContenttype(param, fileName string, reader io.Reader, contenttype string) *Request {
+	r.isMultiPart = true
+
+	r.multipartFiles = append(r.multipartFiles, &File{
+		Name:        fileName,
+		ParamName:   param,
+		ContentType: contenttype,
+		Reader:      reader,
+	})
+
+	return r
+}
+
 // SetFileReader method is to set single file using io.Reader for multipart upload.
 //	resty.R().
 //		SetFileReader("profile_img", "my-profile-img.png", bytes.NewReader(profileImgBytes)).
@@ -271,9 +289,10 @@ func (r *Request) SetFileReader(param, fileName string, reader io.Reader) *Reque
 	r.isMultiPart = true
 
 	r.multipartFiles = append(r.multipartFiles, &File{
-		Name:      fileName,
-		ParamName: param,
-		Reader:    reader,
+		Name:        fileName,
+		ParamName:   param,
+		ContentType: "application/octet-stream",
+		Reader:      reader,
 	})
 
 	return r


### PR DESCRIPTION
Simple solution to set content type for multipart filereader parts. Default resty behaviour of "application/octet-stream" still present if no content-type is given.