### PR TITLE
Allow the Request to override the Authorization header set by the Client

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -472,3 +472,20 @@ func TestSetLogPrefix(t *testing.T) {
 	assertEqual(t, "CUSTOM ", c.logPrefix)
 	assertEqual(t, "CUSTOM ", c.Log.Prefix())
 }
+
+func TestRequestOverridesClientAuthorizationHeader(t *testing.T) {
+	ts := createAuthServer(t)
+	defer ts.Close()
+
+	c := dc()
+	c.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}).
+		SetHeader("Authorization", "some token")
+		SetHostURL(ts.URL + "/")
+
+	resp, err := c.R().
+		SetHeader("Authorization", "Bearer 004DDB79-6801-4587-B976-F093E6AC44FF").
+		Get("/profile")
+
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
+}

--- a/middleware.go
+++ b/middleware.go
@@ -76,6 +76,11 @@ func parseRequestHeader(c *Client, r *Request) error {
 		hdr[k] = append(hdr[k], r.Header[k]...)
 	}
 
+	// Allow the Request to override the Authorization header set by the Client
+	if !IsStringEmpty(r.Header.Get(hdrAuthorizationKey)) {
+		hdr.Set(hdrAuthorizationKey, r.Header.Get(hdrAuthorizationKey))
+	}
+
 	if IsStringEmpty(hdr.Get(hdrUserAgentKey)) {
 		hdr.Set(hdrUserAgentKey, fmt.Sprintf(hdrUserAgentValue, Version))
 	}


### PR DESCRIPTION
We have code that sets the `Authorization` header on the `Client` object and then overrides the header on the `Request` object.  That previously worked with Resty v0.13 but no longer worked after upgrading to Resty v1.2. The root cause of this issue is in `parseRequestHeader` where client and request headers are concatenated.

This PR fixes the issue for `Authorization`, but I suspect there are other singleton headers that could be affected.