### PR TITLE
Allow uncommon HTTP methods to support payloads

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -1246,3 +1246,17 @@ func TestGetPathParams(t *testing.T) {
 		"userId": "sample@sample.com",
 	})
 }
+
+func TestReportMethodSupportsPayload(t *testing.T) {
+	ts := createGenServer(t)
+	defer ts.Close()
+
+	c := dc()
+	resp, err := c.R().
+		SetBody("body").
+		Execute("REPORT", ts.URL + "/report")
+
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
+
+}

--- a/resty_test.go
+++ b/resty_test.go
@@ -421,6 +421,14 @@ func createGenServer(t *testing.T) *httptest.Server {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
+
+		if r.Method == "REPORT" && r.URL.Path == "/report" {
+			body, _ := ioutil.ReadAll(r.Body)
+			if len(body) == 0 {
+				w.WriteHeader(http.StatusOK)
+			}
+			return
+		}
 	})
 
 	return ts

--- a/util.go
+++ b/util.go
@@ -157,7 +157,7 @@ func getPointer(v interface{}) interface{} {
 }
 
 func isPayloadSupported(m string, allowMethodGet bool) bool {
-	return (m == MethodPost || m == MethodPut || m == MethodDelete || m == MethodPatch || (allowMethodGet && m == MethodGet))
+	return !(m == MethodHead || m == MethodOptions || (m == MethodGet && !allowMethodGet))
 }
 
 func typeOf(i interface{}) reflect.Type {


### PR DESCRIPTION
We use `REPORT` and [other HTTP methods](https://www.iana.org/assignments/http-methods/http-methods.xhtml) as part of our REST API for their defined semantics. The `REPORT` method is defined to support a request body. I've refactored `isPayloadSupported` to explicitly look for the standard HTTP methods that are defined as not supporting request bodies so that uncommon HTTP methods may support request bodies, too.