### PR TITLE
Debug log with concatenated string

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -201,18 +201,18 @@ func addCredentials(c *Client, r *Request) error {
 func requestLogger(c *Client, r *Request) error {
 	if c.Debug {
 		rr := r.RawRequest
-		c.Log.Println()
-		c.disableLogPrefix()
-		c.Log.Println("---------------------- REQUEST LOG -----------------------")
-		c.Log.Printf("%s  %s  %s\n", r.Method, rr.URL.RequestURI(), rr.Proto)
-		c.Log.Printf("HOST   : %s", rr.URL.Host)
-		c.Log.Println("HEADERS:")
+		reqLog := "\n---------------------- REQUEST LOG -----------------------\n" +
+			fmt.Sprintf("%s  %s  %s\n", r.Method, rr.URL.RequestURI(), rr.Proto) +
+			fmt.Sprintf("HOST   : %s\n", rr.URL.Host) +
+			fmt.Sprintf("HEADERS:\n")
+
 		for h, v := range rr.Header {
-			c.Log.Printf("%25s: %v", h, strings.Join(v, ", "))
+			reqLog += fmt.Sprintf("%25s: %v\n", h, strings.Join(v, ", "))
 		}
-		c.Log.Printf("BODY   :\n%v", r.fmtBodyString())
-		c.Log.Println("----------------------------------------------------------")
-		c.enableLogPrefix()
+		reqLog += fmt.Sprintf("BODY   :\n%v\n", r.fmtBodyString()) +
+			"----------------------------------------------------------\n"
+
+		c.Log.Print(reqLog)
 	}
 
 	return nil
@@ -224,23 +224,23 @@ func requestLogger(c *Client, r *Request) error {
 
 func responseLogger(c *Client, res *Response) error {
 	if c.Debug {
-		c.Log.Println()
-		c.disableLogPrefix()
-		c.Log.Println("---------------------- RESPONSE LOG -----------------------")
-		c.Log.Printf("STATUS 		: %s", res.Status())
-		c.Log.Printf("RECEIVED AT	: %v", res.ReceivedAt().Format(time.RFC3339Nano))
-		c.Log.Printf("RESPONSE TIME	: %v", res.Time())
-		c.Log.Println("HEADERS:")
+		resLog := "\n---------------------- RESPONSE LOG -----------------------\n" +
+			fmt.Sprintf("STATUS 		: %s\n", res.Status()) +
+			fmt.Sprintf("RECEIVED AT	: %v\n", res.ReceivedAt().Format(time.RFC3339Nano)) +
+			fmt.Sprintf("RESPONSE TIME	: %v\n", res.Time()) +
+			"HEADERS:\n"
+
 		for h, v := range res.Header() {
-			c.Log.Printf("%30s: %v", h, strings.Join(v, ", "))
+			resLog += fmt.Sprintf("%30s: %v\n", h, strings.Join(v, ", "))
 		}
 		if res.Request.isSaveResponse {
-			c.Log.Printf("BODY   :\n***** RESPONSE WRITTEN INTO FILE *****")
+			resLog += fmt.Sprintf("BODY   :\n***** RESPONSE WRITTEN INTO FILE *****\n")
 		} else {
-			c.Log.Printf("BODY   :\n%v", res.fmtBodyString(c.debugBodySizeLimit))
+			resLog += fmt.Sprintf("BODY   :\n%v\n", res.fmtBodyString(c.debugBodySizeLimit))
 		}
-		c.Log.Println("----------------------------------------------------------")
-		c.enableLogPrefix()
+		resLog += "----------------------------------------------------------\n"
+
+		c.Log.Print(resLog)
 	}
 
 	return nil


### PR DESCRIPTION
The debug logs become unreadable for concurrent requests made with resty. Here's some code which demonstrates the issue:

```go
package main

import (
    "sync"
    "time"

    resty "gopkg.in/resty.v1"
)

func main() {
    client := resty.New().
        SetHostURL("https://jsonplaceholder.typicode.com").
        SetDebug(true).
        SetDebugBodyLimit(10000).
        SetTimeout(time.Minute).
        SetContentLength(true).
        SetHeaders(map[string]string{
            "Content-Type": "application/json; charset=utf-8",
            "Accept":       "application/json; charset=utf-8",
        })

    var wg sync.WaitGroup
    wg.Add(3)

    go func() {
        defer wg.Done()
        client.R().Get("/posts/1")
    }()

    go func() {
        defer wg.Done()
        client.R().Get("/posts/2")
    }()

    go func() {
        defer wg.Done()
        client.R().Get("/posts/3")
    }()

    wg.Wait()
}

```

<details>

<summary>debug logs (before)</summary>

```
λ go run concurrent_resty.go
RESTY 2018/02/19 17:00:43
---------------------- REQUEST LOG -----------------------
GET  /posts/3  HTTP/1.1


HOST   : jsonplaceholder.typicode.com
HEADERS:
                   Accept: application/json; charset=utf-8
             Content-Type: application/json; charset=utf-8
---------------------- REQUEST LOG -----------------------
GET  /posts/1  HTTP/1.1
HOST   : jsonplaceholder.typicode.com
HEADERS:
               User-Agent: go-resty v1.2 - https://github.com/go-resty/resty
             Content-Type: application/json; charset=utf-8
               User-Agent: go-resty v1.2 - https://github.com/go-resty/resty
                   Accept: application/json; charset=utf-8
BODY   :
***** NO CONTENT *****
---------------------- REQUEST LOG -----------------------
BODY   :
***** NO CONTENT *****
----------------------------------------------------------
----------------------------------------------------------
GET  /posts/2  HTTP/1.1
RESTY 2018/02/19 17:00:43 HOST   : jsonplaceholder.typicode.com
RESTY 2018/02/19 17:00:43 HEADERS:
RESTY 2018/02/19 17:00:43              Content-Type: application/json; charset=utf-8
RESTY 2018/02/19 17:00:43                    Accept: application/json; charset=utf-8
RESTY 2018/02/19 17:00:43                User-Agent: go-resty v1.2 - https://github.com/go-resty/resty
RESTY 2018/02/19 17:00:43 BODY   :
***** NO CONTENT *****
RESTY 2018/02/19 17:00:43 ----------------------------------------------------------
RESTY 2018/02/19 17:00:43
---------------------- RESPONSE LOG -----------------------
STATUS          : 200 OK
RECEIVED AT     : 2018-02-19T17:00:43.9766988+05:30
RESPONSE TIME   : 674.4783ms
HEADERS:
                           Via: 1.1 vegur
               Cf-Cache-Status: HIT
                        Cf-Ray: 3ef8e5506cc634dc-LHR
                    Set-Cookie: __cfduid=d0006d215aa47d5dac22b13dd966610751519039843; expires=Tue, 19-Feb-19 11:30:43 GMT; path=/; domain=.typicode.com; HttpOnly
                  X-Powered-By: Express
Access-Control-Allow-Credentials: true
                       Expires: Mon, 19 Feb 2018 15:30:43 GMT
        X-Content-Type-Options: nosniff
                  Content-Type: application/json; charset=utf-8
                          Vary: Origin, Accept-Encoding
                          Etag: W/"11b-USacuIw5a/iXAGdNKBvqr/TbMTc"
                     Expect-Ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
                          Date: Mon, 19 Feb 2018 11:30:43 GMT
                 Cache-Control: public, max-age=14400
                        Pragma: no-cache
                        Server: cloudflare
BODY   :
{
   "userId": 1,
   "id": 3,
   "title": "ea molestias quasi exercitationem repellat qui ipsa sit aut",
   "body": "et iusto sed quo iure\nvoluptatem occaecati omnis eligendi aut ad\nvoluptatem doloribus vel accusantium quis pariatur\nmolestiae porro eius odio et labore et velit aut"
}
----------------------------------------------------------
RESTY 2018/02/19 17:00:43
---------------------- RESPONSE LOG -----------------------
STATUS          : 200 OK
RECEIVED AT     : 2018-02-19T17:00:43.9807021+05:30
RESPONSE TIME   : 676.4792ms
HEADERS:
                          Date: Mon, 19 Feb 2018 11:30:43 GMT
                    Set-Cookie: __cfduid=d0006d215aa47d5dac22b13dd966610751519039843; expires=Tue, 19-Feb-19 11:30:43 GMT; path=/; domain=.typicode.com; HttpOnly
                          Vary: Origin, Accept-Encoding
                        Pragma: no-cache
                       Expires: Mon, 19 Feb 2018 15:30:43 GMT
        X-Content-Type-Options: nosniff
                           Via: 1.1 vegur
               Cf-Cache-Status: HIT
                 Cache-Control: public, max-age=14400
                          Etag: W/"116-jnDuMpjju89+9j7e0BqkdFsVRjs"
                     Expect-Ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
                        Cf-Ray: 3ef8e5506cc434dc-LHR
                  Content-Type: application/json; charset=utf-8
                  X-Powered-By: Express
Access-Control-Allow-Credentials: true
                        Server: cloudflare
BODY   :
{
   "userId": 1,
   "id": 2,
   "title": "qui est esse",
   "body": "est rerum tempore vitae\nsequi sint nihil reprehenderit dolor beatae ea dolores neque\nfugiat blanditiis voluptate porro vel nihil molestiae ut reiciendis\nqui aperiam non debitis possimus qui neque nisi nulla"
}
----------------------------------------------------------
RESTY 2018/02/19 17:00:43
---------------------- RESPONSE LOG -----------------------
STATUS          : 200 OK
RECEIVED AT     : 2018-02-19T17:00:43.989708+05:30
RESPONSE TIME   : 687.4875ms
HEADERS:
                    Set-Cookie: __cfduid=d0006d215aa47d5dac22b13dd966610751519039843; expires=Tue, 19-Feb-19 11:30:43 GMT; path=/; domain=.typicode.com; HttpOnly
                 Cache-Control: public, max-age=14400
                       Expires: Mon, 19 Feb 2018 15:30:43 GMT
        X-Content-Type-Options: nosniff
                           Via: 1.1 vegur
                        Cf-Ray: 3ef8e5507ce134dc-LHR
                          Date: Mon, 19 Feb 2018 11:30:43 GMT
                          Etag: W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"
                        Server: cloudflare
                  Content-Type: application/json; charset=utf-8
                          Vary: Origin, Accept-Encoding
Access-Control-Allow-Credentials: true
                     Expect-Ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
                  X-Powered-By: Express
                        Pragma: no-cache
               Cf-Cache-Status: HIT
BODY   :
{
   "userId": 1,
   "id": 1,
   "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
   "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
}
----------------------------------------------------------
```

</details>

<br>

This change builds up the log string by concatenation and prints it in a single function call.

<details>

<summary>debug logs (after)</summary>

```
RESTY 2018/02/19 17:13:49
---------------------- REQUEST LOG -----------------------
GET  /posts/3  HTTP/1.1
HOST   : jsonplaceholder.typicode.com
HEADERS:
             Content-Type: application/json; charset=utf-8
                   Accept: application/json; charset=utf-8
               User-Agent: go-resty v1.2 - https://github.com/go-resty/resty
BODY   :
***** NO CONTENT *****
----------------------------------------------------------
RESTY 2018/02/19 17:13:49
---------------------- REQUEST LOG -----------------------
GET  /posts/1  HTTP/1.1
HOST   : jsonplaceholder.typicode.com
HEADERS:
             Content-Type: application/json; charset=utf-8
                   Accept: application/json; charset=utf-8
               User-Agent: go-resty v1.2 - https://github.com/go-resty/resty
BODY   :
***** NO CONTENT *****
----------------------------------------------------------
RESTY 2018/02/19 17:13:49
---------------------- REQUEST LOG -----------------------
GET  /posts/2  HTTP/1.1
HOST   : jsonplaceholder.typicode.com
HEADERS:
                   Accept: application/json; charset=utf-8
               User-Agent: go-resty v1.2 - https://github.com/go-resty/resty
             Content-Type: application/json; charset=utf-8
BODY   :
***** NO CONTENT *****
----------------------------------------------------------
RESTY 2018/02/19 17:13:50
---------------------- RESPONSE LOG -----------------------
STATUS          : 200 OK
RECEIVED AT     : 2018-02-19T17:13:50.6824563+05:30
RESPONSE TIME   : 696.5046ms
HEADERS:
                  Content-Type: application/json; charset=utf-8
                          Vary: Origin, Accept-Encoding
                 Cache-Control: public, max-age=14400
                        Pragma: no-cache
                     Expect-Ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
                        Server: cloudflare
                          Etag: W/"124-yiKdLzqO5gfBrJFrcdJ8Yq0LGnU"
                           Via: 1.1 vegur
                       Expires: Mon, 19 Feb 2018 15:43:50 GMT
        X-Content-Type-Options: nosniff
               Cf-Cache-Status: HIT
                        Cf-Ray: 3ef8f88548893488-LHR
                          Date: Mon, 19 Feb 2018 11:43:50 GMT
                    Set-Cookie: __cfduid=de8e7fb2dec26397f7a7a9b315e5b48ec1519040630; expires=Tue, 19-Feb-19 11:43:50 GMT; path=/; domain=.typicode.com; HttpOnly
                  X-Powered-By: Express
Access-Control-Allow-Credentials: true
BODY   :
{
   "userId": 1,
   "id": 1,
   "title": "sunt aut facere repellat provident occaecati excepturi optio reprehenderit",
   "body": "quia et suscipit\nsuscipit recusandae consequuntur expedita et cum\nreprehenderit molestiae ut ut quas totam\nnostrum rerum est autem sunt rem eveniet architecto"
}
----------------------------------------------------------
RESTY 2018/02/19 17:13:50
---------------------- RESPONSE LOG -----------------------
STATUS          : 200 OK
RECEIVED AT     : 2018-02-19T17:13:50.6834397+05:30
RESPONSE TIME   : 696.4949ms
HEADERS:
                        Pragma: no-cache
                       Expires: Mon, 19 Feb 2018 15:43:50 GMT
                          Etag: W/"116-jnDuMpjju89+9j7e0BqkdFsVRjs"
                        Cf-Ray: 3ef8f885588b3488-LHR
Access-Control-Allow-Credentials: true
                 Cache-Control: public, max-age=14400
                           Via: 1.1 vegur
                     Expect-Ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
                  Content-Type: application/json; charset=utf-8
                    Set-Cookie: __cfduid=de8e7fb2dec26397f7a7a9b315e5b48ec1519040630; expires=Tue, 19-Feb-19 11:43:50 GMT; path=/; domain=.typicode.com; HttpOnly
                          Vary: Origin, Accept-Encoding
                        Server: cloudflare
                          Date: Mon, 19 Feb 2018 11:43:50 GMT
                  X-Powered-By: Express
        X-Content-Type-Options: nosniff
               Cf-Cache-Status: HIT
BODY   :
{
   "userId": 1,
   "id": 2,
   "title": "qui est esse",
   "body": "est rerum tempore vitae\nsequi sint nihil reprehenderit dolor beatae ea dolores neque\nfugiat blanditiis voluptate porro vel nihil molestiae ut reiciendis\nqui aperiam non debitis possimus qui neque nisi nulla"
}
----------------------------------------------------------
RESTY 2018/02/19 17:13:50
---------------------- RESPONSE LOG -----------------------
STATUS          : 200 OK
RECEIVED AT     : 2018-02-19T17:13:50.6854416+05:30
RESPONSE TIME   : 700.4945ms
HEADERS:
                           Via: 1.1 vegur
                        Server: cloudflare
        X-Content-Type-Options: nosniff
               Cf-Cache-Status: HIT
                     Expect-Ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
                    Set-Cookie: __cfduid=de8e7fb2dec26397f7a7a9b315e5b48ec1519040630; expires=Tue, 19-Feb-19 11:43:50 GMT; path=/; domain=.typicode.com; HttpOnly
                          Vary: Origin, Accept-Encoding
Access-Control-Allow-Credentials: true
                        Pragma: no-cache
                       Expires: Mon, 19 Feb 2018 15:43:50 GMT
                        Cf-Ray: 3ef8f885588c3488-LHR
                          Date: Mon, 19 Feb 2018 11:43:50 GMT
                  Content-Type: application/json; charset=utf-8
                  X-Powered-By: Express
                 Cache-Control: public, max-age=14400
                          Etag: W/"11b-USacuIw5a/iXAGdNKBvqr/TbMTc"
BODY   :
{
   "userId": 1,
   "id": 3,
   "title": "ea molestias quasi exercitationem repellat qui ipsa sit aut",
   "body": "et iusto sed quo iure\nvoluptatem occaecati omnis eligendi aut ad\nvoluptatem doloribus vel accusantium quis pariatur\nmolestiae porro eius odio et labore et velit aut"
}
----------------------------------------------------------
```

</details>

<br>
