### PR TITLE
Custom data for multipart request

### DIFF
--- a/client.go
+++ b/client.go
@@ -300,20 +300,20 @@ func (c *Client) SetAuthToken(token string) *Client {
 // R method creates a request instance, its used for Get, Post, Put, Delete, Patch, Head and Options.
 func (c *Client) R() *Request {
 	r := &Request{
-		URL:                 "",
-		Method:              "",
-		QueryParam:          url.Values{},
-		FormData:            url.Values{},
-		Header:              http.Header{},
-		Body:                nil,
-		Result:              nil,
-		Error:               nil,
-		RawRequest:          nil,
-		client:              c,
-		bodyBuf:             nil,
-		multipartFiles:      []*File{},
-		multipartCustomData: []*MultipartCustomData{},
-		pathParams:          make(map[string]string),
+		URL:             "",
+		Method:          "",
+		QueryParam:      url.Values{},
+		FormData:        url.Values{},
+		Header:          http.Header{},
+		Body:            nil,
+		Result:          nil,
+		Error:           nil,
+		RawRequest:      nil,
+		client:          c,
+		bodyBuf:         nil,
+		multipartFiles:  []*File{},
+		multipartFields: []*multipartField{},
+		pathParams:      make(map[string]string),
 	}
 
 	return r
@@ -867,9 +867,10 @@ func (f *File) String() string {
 	return fmt.Sprintf("ParamName: %v; FileName: %v", f.ParamName, f.Name)
 }
 
-// MultipartCustomData represent custom data part for multipart request
-type MultipartCustomData struct {
-	Params      map[string]string
+// multipartField represent custom data part for multipart request
+type multipartField struct {
+	Param string
+	FileName string
 	ContentType string
 	io.Reader
 }

--- a/client.go
+++ b/client.go
@@ -300,19 +300,20 @@ func (c *Client) SetAuthToken(token string) *Client {
 // R method creates a request instance, its used for Get, Post, Put, Delete, Patch, Head and Options.
 func (c *Client) R() *Request {
 	r := &Request{
-		URL:            "",
-		Method:         "",
-		QueryParam:     url.Values{},
-		FormData:       url.Values{},
-		Header:         http.Header{},
-		Body:           nil,
-		Result:         nil,
-		Error:          nil,
-		RawRequest:     nil,
-		client:         c,
-		bodyBuf:        nil,
-		multipartFiles: []*File{},
-		pathParams:     make(map[string]string),
+		URL:                 "",
+		Method:              "",
+		QueryParam:          url.Values{},
+		FormData:            url.Values{},
+		Header:              http.Header{},
+		Body:                nil,
+		Result:              nil,
+		Error:               nil,
+		RawRequest:          nil,
+		client:              c,
+		bodyBuf:             nil,
+		multipartFiles:      []*File{},
+		multipartCustomData: []*MultipartCustomData{},
+		pathParams:          make(map[string]string),
 	}
 
 	return r
@@ -864,4 +865,11 @@ type File struct {
 // String returns string value of current file details
 func (f *File) String() string {
 	return fmt.Sprintf("ParamName: %v; FileName: %v", f.ParamName, f.Name)
+}
+
+// MultipartCustomData represent custom data part for multipart request
+type MultipartCustomData struct {
+	Params      map[string]string
+	ContentType string
+	io.Reader
 }

--- a/middleware.go
+++ b/middleware.go
@@ -300,6 +300,16 @@ func handleMultipart(c *Client, r *Request) (err error) {
 		}
 	}
 
+	// adding custom data support
+	if len(r.multipartCustomData) > 0 {
+		for _, cd := range r.multipartCustomData {
+			err = addCustomDataReader(w, cd)
+			if err != nil {
+				return
+			}
+		}
+	}
+
 	r.Header.Set(hdrContentTypeKey, w.FormDataContentType())
 	err = w.Close()
 

--- a/middleware.go
+++ b/middleware.go
@@ -300,11 +300,10 @@ func handleMultipart(c *Client, r *Request) (err error) {
 		}
 	}
 
-	// adding custom data support
-	if len(r.multipartCustomData) > 0 {
-		for _, cd := range r.multipartCustomData {
-			err = addCustomDataReader(w, cd)
-			if err != nil {
+	// GitHub #130 adding multipart field support with content type
+	if len(r.multipartFields) > 0 {
+		for _, mf := range r.multipartFields {
+			if err = addMultipartFormField(w, mf); err != nil {
 				return
 			}
 		}

--- a/request.go
+++ b/request.go
@@ -279,12 +279,13 @@ func (r *Request) SetFileReader(param, fileName string, reader io.Reader) *Reque
 	return r
 }
 
-// SetMultipartData method is to set custom data using io.Reader for multipart upload.
-func (r *Request) SetMultipartData(params map[string]string, contentType string, reader io.Reader) *Request {
+// SetMultipartField method is to set custom data using io.Reader for multipart upload.
+func (r *Request) SetMultipartField(param, fileName, contentType string, reader io.Reader) *Request {
 	r.isMultiPart = true
 
-	r.multipartCustomData = append(r.multipartCustomData, &MultipartCustomData{
-		Params:      params,
+	r.multipartFields = append(r.multipartFields, &multipartField{
+		Param:       param,
+		FileName:    fileName,
 		ContentType: contentType,
 		Reader:      reader,
 	})

--- a/request.go
+++ b/request.go
@@ -279,8 +279,8 @@ func (r *Request) SetFileReader(param, fileName string, reader io.Reader) *Reque
 	return r
 }
 
-// SetCustomData method is to set custom data using io.Reader for multipart upload.
-func (r *Request) SetCustomData(params map[string]string, contentType string, reader io.Reader) *Request {
+// SetMultipartData method is to set custom data using io.Reader for multipart upload.
+func (r *Request) SetMultipartData(params map[string]string, contentType string, reader io.Reader) *Request {
 	r.isMultiPart = true
 
 	r.multipartCustomData = append(r.multipartCustomData, &MultipartCustomData{

--- a/request.go
+++ b/request.go
@@ -279,6 +279,19 @@ func (r *Request) SetFileReader(param, fileName string, reader io.Reader) *Reque
 	return r
 }
 
+// SetCustomData method is to set custom data using io.Reader for multipart upload.
+func (r *Request) SetCustomData(params map[string]string, contentType string, reader io.Reader) *Request {
+	r.isMultiPart = true
+
+	r.multipartCustomData = append(r.multipartCustomData, &MultipartCustomData{
+		Params:      params,
+		ContentType: contentType,
+		Reader:      reader,
+	})
+
+	return r
+}
+
 // SetContentLength method sets the HTTP header `Content-Length` value for current request.
 // By default go-resty won't set `Content-Length`. Also you have an option to enable for every
 // request. See `resty.SetContentLength`

--- a/request16.go
+++ b/request16.go
@@ -43,7 +43,7 @@ type Request struct {
 	isSaveResponse      bool
 	outputFile          string
 	multipartFiles      []*File
-	multipartCustomData []*MultipartCustomData
+	multipartFields     []*multipartField
 	notParseResponse    bool
 	fallbackContentType string
 	pathParams          map[string]string

--- a/request16.go
+++ b/request16.go
@@ -43,6 +43,7 @@ type Request struct {
 	isSaveResponse      bool
 	outputFile          string
 	multipartFiles      []*File
+	multipartCustomData []*MultipartCustomData
 	notParseResponse    bool
 	fallbackContentType string
 	pathParams          map[string]string

--- a/request17.go
+++ b/request17.go
@@ -44,7 +44,7 @@ type Request struct {
 	isSaveResponse      bool
 	outputFile          string
 	multipartFiles      []*File
-	multipartCustomData []*MultipartCustomData
+	multipartFields     []*multipartField
 	notParseResponse    bool
 	ctx                 context.Context
 	fallbackContentType string

--- a/request17.go
+++ b/request17.go
@@ -44,6 +44,7 @@ type Request struct {
 	isSaveResponse      bool
 	outputFile          string
 	multipartFiles      []*File
+	multipartCustomData []*MultipartCustomData
 	notParseResponse    bool
 	ctx                 context.Context
 	fallbackContentType string

--- a/request_test.go
+++ b/request_test.go
@@ -613,6 +613,25 @@ func TestMultiPartUploadFileNotOnGetOrDelete(t *testing.T) {
 	assertEqual(t, "Multipart content is not allowed in HTTP verb [DELETE]", err.Error())
 }
 
+func TestMultiPartMultipartField(t *testing.T) {
+	ts := createFormPostServer(t)
+	defer ts.Close()
+	defer cleaupFiles("test-data/upload")
+
+	jsonBytes := []byte(`{"input": {"name": "Uploaded document", "_filename" : ["file.txt"]}}`)
+
+	resp, err := dclr().
+		SetFormData(map[string]string{"first_name": "Jeevanandam", "last_name": "M"}).
+		SetMultipartField("uploadManifest", "upload-file.json", "application/json", bytes.NewReader(jsonBytes)).
+		Post(ts.URL + "/upload")
+
+	responseStr := resp.String()
+
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
+	assertEqual(t, true, strings.Contains(responseStr, "upload-file.json"))
+}
+
 func TestGetWithCookie(t *testing.T) {
 	ts := createGetServer(t)
 	defer ts.Close()

--- a/request_test.go
+++ b/request_test.go
@@ -616,7 +616,7 @@ func TestMultiPartUploadFileNotOnGetOrDelete(t *testing.T) {
 func TestMultiPartMultipartField(t *testing.T) {
 	ts := createFormPostServer(t)
 	defer ts.Close()
-	defer cleaupFiles("test-data/upload")
+	defer cleanupFiles("test-data/upload")
 
 	jsonBytes := []byte(`{"input": {"name": "Uploaded document", "_filename" : ["file.txt"]}}`)
 


### PR DESCRIPTION
Proposal for `MultipartCustomData` type, in case there's a need to inject custom data into multipart request. Since `SetFile()` and `SetFileReader()` functions are specifically file-oriented, I created a separate type to hold `Content-Disposition` header fields, `Content-Type` and the actual data.