### PR TITLE
Add support for bazel build rules

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,47 @@
+package(default_visibility = ["//visibility:private"])
+
+load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_prefix", "go_test")
+
+go_prefix("gopkg.in/resty.v1")
+
+gazelle(
+    name = "gazelle",
+    command = "fix",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "client.go",
+        "default.go",
+        "middleware.go",
+        "redirect.go",
+        "request.go",
+        "request16.go",
+        "request17.go",
+        "response.go",
+        "resty.go",
+        "retry.go",
+        "util.go",
+    ],
+    importpath = "gopkg.in/resty.v1",
+    visibility = ["//visibility:public"],
+    deps = ["@org_golang_x_net//publicsuffix:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "client_test.go",
+        "context17_test.go",
+        "context18_test.go",
+        "context_test.go",
+        "request_test.go",
+        "resty_test.go",
+        "retry_test.go",
+    ],
+    data = glob(["test-data/*"]),
+    embed = [":go_default_library"],
+)
+

--- a/README.md
+++ b/README.md
@@ -635,7 +635,15 @@ r := resty.New().SetTransport(&transport).SetScheme("http").SetHostURL(unixSocke
 
 // No need to write the host's URL on the request, just the path.
 r.R().Get("/index.html")
+```
 
+#### Bazel support
+
+Resty can be built, tested and depended upon via [Bazel](https://bazel.build).
+For example, to run all tests:
+
+```shell
+bazel test :go_default_test
 ```
 
 ## Versioning

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,24 @@
+workspace(name = "resty")
+
+http_archive(
+    name = "io_bazel_rules_go",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.10.1/rules_go-0.10.1.tar.gz",
+    sha256 = "4b14d8dd31c6dbaf3ff871adcd03f28c3274e42abc855cb8fb4d01233c0154dc",
+)
+http_archive(
+    name = "bazel_gazelle",
+    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.9/bazel-gazelle-0.9.tar.gz",
+    sha256 = "0103991d994db55b3b5d7b06336f8ae355739635e0c2379dea16b8213ea5a223",
+)
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_rules_dependencies",
+    "go_register_toolchains"
+)
+
+go_rules_dependencies()
+go_register_toolchains()
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+gazelle_dependencies()
+


### PR DESCRIPTION
Adding a basic workspace and bazel rules.
The rules were generated via gazelle (blaze run :gazelle) and tuned a bit (e.g. changing visibility and adding the data dependency).
This should allow bazel users to just depend on the project without a local BUILD file.