### PR TITLE
Fixes test failures in Windows

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -161,7 +162,7 @@ func TestClientSetCertificates(t *testing.T) {
 
 func TestClientSetRootCertificate(t *testing.T) {
 	DefaultClient = dc()
-	SetRootCertificate(getTestDataPath() + "/sample-root.pem")
+	SetRootCertificate(filepath.Join(getTestDataPath(), "sample-root.pem"))
 
 	transport, err := DefaultClient.getTransport()
 
@@ -171,7 +172,7 @@ func TestClientSetRootCertificate(t *testing.T) {
 
 func TestClientSetRootCertificateNotExists(t *testing.T) {
 	DefaultClient = dc()
-	SetRootCertificate(getTestDataPath() + "/not-exists-sample-root.pem")
+	SetRootCertificate(filepath.Join(getTestDataPath(), "not-exists-sample-root.pem"))
 
 	transport, err := DefaultClient.getTransport()
 
@@ -400,7 +401,7 @@ func TestClientRoundTripper(t *testing.T) {
 	c.SetProxy("http://localhost:9090")
 	c.RemoveProxy()
 	c.SetCertificates(tls.Certificate{})
-	c.SetRootCertificate(getTestDataPath() + "/sample-root.pem")
+	c.SetRootCertificate(filepath.Join(getTestDataPath(), "sample-root.pem"))
 }
 
 func TestClientNewRequest(t *testing.T) {

--- a/request_test.go
+++ b/request_test.go
@@ -1198,7 +1198,6 @@ func TestSRVInvalidService(t *testing.T) {
 
 	assertNotNil(t, err)
 	assertType(t, net.DNSError{}, err)
-	fmt.Printf("%#v\n", err)
 }
 
 func TestDeprecatedCodeCoverage(t *testing.T) {

--- a/request_test.go
+++ b/request_test.go
@@ -7,7 +7,6 @@ package resty
 import (
 	"bytes"
 	"crypto/tls"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net"

--- a/request_test.go
+++ b/request_test.go
@@ -7,11 +7,14 @@ package resty
 import (
 	"bytes"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -540,7 +543,7 @@ func TestMultiPartUploadFile(t *testing.T) {
 	c.SetFormData(map[string]string{"zip_code": "00001", "city": "Los Angeles"})
 
 	resp, err := c.R().
-		SetFile("profile_img", basePath+"/test-img.png").
+		SetFile("profile_img", filepath.Join(basePath, "test-img.png")).
 		SetContentLength(true).
 		Post(ts.URL + "/upload")
 
@@ -559,7 +562,7 @@ func TestMultiPartUploadFileError(t *testing.T) {
 	c.SetFormData(map[string]string{"zip_code": "00001", "city": "Los Angeles"})
 
 	resp, err := c.R().
-		SetFile("profile_img", basePath+"/test-img-not-exists.png").
+		SetFile("profile_img", filepath.Join(basePath, "test-img-not-exists.png")).
 		Post(ts.URL + "/upload")
 
 	if err == nil {
@@ -579,7 +582,7 @@ func TestMultiPartUploadFiles(t *testing.T) {
 
 	resp, err := dclr().
 		SetFormData(map[string]string{"first_name": "Jeevanandam", "last_name": "M"}).
-		SetFiles(map[string]string{"profile_img": basePath + "/test-img.png", "notes": basePath + "/text-file.txt"}).
+		SetFiles(map[string]string{"profile_img": filepath.Join(basePath, "test-img.png"), "notes": filepath.Join(basePath, "text-file.txt")}).
 		Post(ts.URL + "/upload")
 
 	responseStr := resp.String()
@@ -596,8 +599,8 @@ func TestMultiPartIoReaderFiles(t *testing.T) {
 	defer cleanupFiles("test-data/upload")
 
 	basePath := getTestDataPath()
-	profileImgBytes, _ := ioutil.ReadFile(basePath + "/test-img.png")
-	notesBytes, _ := ioutil.ReadFile(basePath + "/text-file.txt")
+	profileImgBytes, _ := ioutil.ReadFile(filepath.Join(basePath, "test-img.png"))
+	notesBytes, _ := ioutil.ReadFile(filepath.Join(basePath, "text-file.txt"))
 
 	// Just info values
 	file := File{
@@ -629,13 +632,13 @@ func TestMultiPartUploadFileNotOnGetOrDelete(t *testing.T) {
 	basePath := getTestDataPath()
 
 	_, err := dclr().
-		SetFile("profile_img", basePath+"/test-img.png").
+		SetFile("profile_img", filepath.Join(basePath, "test-img.png")).
 		Get(ts.URL + "/upload")
 
 	assertEqual(t, "multipart content is not allowed in HTTP verb [GET]", err.Error())
 
 	_, err = dclr().
-		SetFile("profile_img", basePath+"/test-img.png").
+		SetFile("profile_img", filepath.Join(basePath, "test-img.png")).
 		Delete(ts.URL + "/upload")
 
 	assertEqual(t, "multipart content is not allowed in HTTP verb [DELETE]", err.Error())
@@ -872,8 +875,10 @@ func TestRawFileUploadByBody(t *testing.T) {
 	ts := createFormPostServer(t)
 	defer ts.Close()
 
-	file, _ := os.Open(getTestDataPath() + "/test-img.png")
-	fileBytes, _ := ioutil.ReadAll(file)
+	file, err := os.Open(filepath.Join(getTestDataPath(), "test-img.png"))
+	assertNil(t, err)
+	fileBytes, err := ioutil.ReadAll(file)
+	assertNil(t, err)
 
 	resp, err := dclr().
 		SetBody(fileBytes).
@@ -1102,7 +1107,7 @@ func TestOutputFileWithBaseDirAndRelativePath(t *testing.T) {
 
 	DefaultClient = dc()
 	SetRedirectPolicy(FlexibleRedirectPolicy(10))
-	SetOutputDirectory(getTestDataPath() + "/dir-sample")
+	SetOutputDirectory(filepath.Join(getTestDataPath(), "dir-sample"))
 	SetDebug(true)
 
 	resp, err := R().
@@ -1115,7 +1120,7 @@ func TestOutputFileWithBaseDirAndRelativePath(t *testing.T) {
 
 func TestOutputFileWithBaseDirError(t *testing.T) {
 	c := dc().SetRedirectPolicy(FlexibleRedirectPolicy(10)).
-		SetOutputDirectory(getTestDataPath() + `/go-resty\0`)
+		SetOutputDirectory(filepath.Join(getTestDataPath(), `go-resty\0`))
 
 	_ = c
 }
@@ -1123,11 +1128,11 @@ func TestOutputFileWithBaseDirError(t *testing.T) {
 func TestOutputPathDirNotExists(t *testing.T) {
 	ts := createGetServer(t)
 	defer ts.Close()
-	defer cleanupFiles("test-data/not-exists-dir")
+	defer cleanupFiles(filepath.Join("test-data", "not-exists-dir"))
 
 	DefaultClient = dc()
 	SetRedirectPolicy(FlexibleRedirectPolicy(10))
-	SetOutputDirectory(getTestDataPath() + "/not-exists-dir")
+	SetOutputDirectory(filepath.Join(getTestDataPath(), "not-exists-dir"))
 
 	resp, err := R().
 		SetOutput("test-img-success.png").
@@ -1140,10 +1145,10 @@ func TestOutputPathDirNotExists(t *testing.T) {
 func TestOutputFileAbsPath(t *testing.T) {
 	ts := createGetServer(t)
 	defer ts.Close()
-	defer cleanupFiles("test-data/go-resty")
+	defer cleanupFiles(filepath.Join("test-data", "go-resty"))
 
 	_, err := dcr().
-		SetOutput(getTestDataPath() + "/go-resty/test-img-success-2.png").
+		SetOutput(filepath.Join(getTestDataPath(), "go-resty", "test-img-success-2.png")).
 		Get(ts.URL + "/my-image.png")
 
 	assertError(t, err)
@@ -1192,7 +1197,8 @@ func TestSRVInvalidService(t *testing.T) {
 		Get("/")
 
 	assertNotNil(t, err)
-	assertEqual(t, true, strings.Contains(err.Error(), "no such host"))
+	assertType(t, net.DNSError{}, err)
+	fmt.Printf("%#v\n", err)
 }
 
 func TestDeprecatedCodeCoverage(t *testing.T) {
@@ -1346,7 +1352,7 @@ func TestRequestFileUploadAsReader(t *testing.T) {
 	ts := createFilePostServer(t)
 	defer ts.Close()
 
-	file, _ := os.Open(getTestDataPath() + "/test-img.png")
+	file, _ := os.Open(filepath.Join(getTestDataPath(), "test-img.png"))
 	defer file.Close()
 
 	resp, err := dclr().
@@ -1358,7 +1364,7 @@ func TestRequestFileUploadAsReader(t *testing.T) {
 	assertEqual(t, http.StatusOK, resp.StatusCode())
 	assertEqual(t, true, strings.Contains(resp.String(), "File Uploaded successfully"))
 
-	file, _ = os.Open(getTestDataPath() + "/test-img.png")
+	file, _ = os.Open(filepath.Join(getTestDataPath(), "test-img.png"))
 	defer file.Close()
 
 	resp, err = dclr().

--- a/resty_test.go
+++ b/resty_test.go
@@ -29,7 +29,7 @@ import (
 
 func getTestDataPath() string {
 	pwd, _ := os.Getwd()
-	return pwd + "/test-data"
+	return filepath.Join(pwd, "test-data")
 }
 
 func createGetServer(t *testing.T) *httptest.Server {
@@ -88,7 +88,7 @@ func createGetServer(t *testing.T) *httptest.Server {
 				time.Sleep(time.Second * 6)
 				_, _ = w.Write([]byte("TestClientTimeout page"))
 			case "/my-image.png":
-				fileBytes, _ := ioutil.ReadFile(getTestDataPath() + "/test-img.png")
+				fileBytes, _ := ioutil.ReadFile(filepath.Join(getTestDataPath(), "test-img.png"))
 				w.Header().Set("Content-Type", "image/png")
 				w.Header().Set("Content-Length", strconv.Itoa(len(fileBytes)))
 				_, _ = w.Write(fileBytes)
@@ -294,7 +294,7 @@ func createFormPostServer(t *testing.T) *httptest.Server {
 				t.Logf("FirstName: %v", r.FormValue("first_name"))
 				t.Logf("LastName: %v", r.FormValue("last_name"))
 
-				targetPath := getTestDataPath() + "/upload"
+				targetPath := filepath.Join(getTestDataPath(), "upload")
 				_ = os.MkdirAll(targetPath, 0700)
 
 				for _, fhdrs := range r.MultipartForm.File {
@@ -307,7 +307,7 @@ func createFormPostServer(t *testing.T) *httptest.Server {
 						t.Logf("Write name: %v", fname)
 
 						infile, _ := hdr.Open()
-						f, err := os.OpenFile(targetPath+"/"+fname, os.O_WRONLY|os.O_CREATE, 0666)
+						f, err := os.OpenFile(filepath.Join(targetPath, fname), os.O_WRONLY|os.O_CREATE, 0666)
 						if err != nil {
 							t.Logf("Error: %v", err)
 							return
@@ -534,6 +534,12 @@ func assertNil(t *testing.T, v interface{}) {
 func assertNotNil(t *testing.T, v interface{}) {
 	if isNil(v) {
 		t.Errorf("[%v] was expected to be non-nil", v)
+	}
+}
+
+func assertType(t *testing.T, typ, v interface{}) {
+	if reflect.DeepEqual(reflect.TypeOf(typ), reflect.TypeOf(v)) {
+		t.Errorf("Expected type %t, got %t", typ, v)
 	}
 }
 


### PR DESCRIPTION
Use filepath when constructing local file paths.  Don't test Error()
text since it's platform specific for DNS errors; rather, test for type
net.DNSError.