### PR TITLE
Update bazel definitions to work with release 0.13.0, following up on #140

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -31,7 +31,6 @@ go_test(
     embed = [":go_default_library"],
     importpath = "gopkg.in/resty.v1",
     deps = [
-        "@com_github_go_resty_resty//:go_default_library",
         "@org_golang_x_net//proxy:go_default_library",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,30 +1,20 @@
 package(default_visibility = ["//visibility:private"])
 
 load("@bazel_gazelle//:def.bzl", "gazelle")
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_prefix", "go_test")
-
-go_prefix("gopkg.in/resty.v1")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 gazelle(
     name = "gazelle",
     command = "fix",
+    prefix = "gopkg.in/resty.v1",
 )
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "client.go",
-        "default.go",
-        "middleware.go",
-        "redirect.go",
-        "request.go",
-        "request16.go",
-        "request17.go",
-        "response.go",
-        "resty.go",
-        "retry.go",
-        "util.go",
-    ],
+    srcs = glob(
+        ["*.go"],
+        exclude = ["*_test.go"],
+    ),
     importpath = "gopkg.in/resty.v1",
     visibility = ["//visibility:public"],
     deps = ["@org_golang_x_net//publicsuffix:go_default_library"],
@@ -32,16 +22,16 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = [
-        "client_test.go",
-        "context17_test.go",
-        "context18_test.go",
-        "context_test.go",
-        "request_test.go",
-        "resty_test.go",
-        "retry_test.go",
-    ],
+    srcs =
+        glob(
+            ["*_test.go"],
+            exclude = ["example_test.go"],
+        ),
     data = glob(["test-data/*"]),
     embed = [":go_default_library"],
+    importpath = "gopkg.in/resty.v1",
+    deps = [
+        "@com_github_go_resty_resty//:go_default_library",
+        "@org_golang_x_net//proxy:go_default_library",
+    ],
 )
-

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,24 +1,27 @@
 workspace(name = "resty")
 
-http_archive(
+git_repository(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.10.1/rules_go-0.10.1.tar.gz",
-    sha256 = "4b14d8dd31c6dbaf3ff871adcd03f28c3274e42abc855cb8fb4d01233c0154dc",
+    remote = "https://github.com/bazelbuild/rules_go.git",
+    tag = "0.13.0",
 )
-http_archive(
+
+git_repository(
     name = "bazel_gazelle",
-    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.9/bazel-gazelle-0.9.tar.gz",
-    sha256 = "0103991d994db55b3b5d7b06336f8ae355739635e0c2379dea16b8213ea5a223",
+    remote = "https://github.com/bazelbuild/bazel-gazelle.git",
+    tag = "0.13.0",
 )
 
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_rules_dependencies",
-    "go_register_toolchains"
+    "go_register_toolchains",
 )
 
 go_rules_dependencies()
-go_register_toolchains()
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
-gazelle_dependencies()
 
+go_register_toolchains()
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+gazelle_dependencies()


### PR DESCRIPTION
Some cleanups on the workspace definition (e.g. depending on labels).
Updated the structure to work with 0.13.0, removing go_prefix.
Moved file targeting to globs to be more future proof.