### PR TITLE
Make IsJSONType and IsXMLType more robust

### DIFF
--- a/client.go
+++ b/client.go
@@ -58,8 +58,8 @@ var (
 	jsonContentType = "application/json; charset=utf-8"
 	formContentType = "application/x-www-form-urlencoded"
 
-	jsonCheck = regexp.MustCompile(`(?i:(application|text)/(json$|.*\+json$))`)
-	xmlCheck  = regexp.MustCompile(`(?i:(application|text)/(xml$|.*\+xml$))`)
+	jsonCheck = regexp.MustCompile(`(?i:(application|text)/(json|.*\+json)(;|$))`)
+	xmlCheck  = regexp.MustCompile(`(?i:(application|text)/(xml|.*\+xml)(;|$))`)
 
 	hdrUserAgentValue = "go-resty v%s - https://github.com/go-resty/resty"
 	bufPool           = &sync.Pool{New: func() interface{} { return &bytes.Buffer{} }}

--- a/client.go
+++ b/client.go
@@ -58,8 +58,8 @@ var (
 	jsonContentType = "application/json; charset=utf-8"
 	formContentType = "application/x-www-form-urlencoded"
 
-	jsonCheck = regexp.MustCompile(`(?i:(application|text)/(problem\+json|hal\+json|json))`)
-	xmlCheck  = regexp.MustCompile(`(?i:(application|text)/(problem\+xml|xml))`)
+	jsonCheck = regexp.MustCompile(`(?i:(application|text)/(json$|.*\+json$))`)
+	xmlCheck  = regexp.MustCompile(`(?i:(application|text)/(xml$|.*\+xml$))`)
 
 	hdrUserAgentValue = "go-resty v%s - https://github.com/go-resty/resty"
 	bufPool           = &sync.Pool{New: func() interface{} { return &bytes.Buffer{} }}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2015-2018 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
+// resty source code and usage is governed by a MIT style
+// license that can be found in the LICENSE file.
+
+package resty
+
+import (
+	"testing"
+)
+
+func TestIsJSONType(t *testing.T) {
+	for _, test := range []struct {
+		input  string
+		expect bool
+	}{
+		{"application/json", true},
+		{"application/xml+json", true},
+		{"application/vnd.foo+json", true},
+
+		{"text/json", true},
+		{"text/xml+json", true},
+		{"text/vnd.foo+json", true},
+
+		{"application/foo-json", false},
+		{"application/foo.json", false},
+		{"application/vnd.foo-json", false},
+		{"application/vnd.foo.json", false},
+		{"application/json+xml", false},
+
+		{"text/foo-json", false},
+		{"text/foo.json", false},
+		{"text/vnd.foo-json", false},
+		{"text/vnd.foo.json", false},
+		{"text/json+xml", false},
+	} {
+		result := IsJSONType(test.input)
+
+		if result != test.expect {
+			t.Errorf("failed on %q: want %v, got %v", test.input, test.expect, result)
+		}
+	}
+}
+
+func TestIsXMLType(t *testing.T) {
+	for _, test := range []struct {
+		input  string
+		expect bool
+	}{
+		{"application/xml", true},
+		{"application/json+xml", true},
+		{"application/vnd.foo+xml", true},
+
+		{"text/xml", true},
+		{"text/json+xml", true},
+		{"text/vnd.foo+xml", true},
+
+		{"application/foo-xml", false},
+		{"application/foo.xml", false},
+		{"application/vnd.foo-xml", false},
+		{"application/vnd.foo.xml", false},
+		{"application/xml+json", false},
+
+		{"text/foo-xml", false},
+		{"text/foo.xml", false},
+		{"text/vnd.foo-xml", false},
+		{"text/vnd.foo.xml", false},
+		{"text/xml+json", false},
+	} {
+		result := IsXMLType(test.input)
+
+		if result != test.expect {
+			t.Errorf("failed on %q: want %v, got %v", test.input, test.expect, result)
+		}
+	}
+}

--- a/util_test.go
+++ b/util_test.go
@@ -17,6 +17,9 @@ func TestIsJSONType(t *testing.T) {
 		{"application/xml+json", true},
 		{"application/vnd.foo+json", true},
 
+		{"application/json; charset=utf-8", true},
+		{"application/vnd.foo+json; charset=utf-8", true},
+
 		{"text/json", true},
 		{"text/xml+json", true},
 		{"text/vnd.foo+json", true},
@@ -49,6 +52,9 @@ func TestIsXMLType(t *testing.T) {
 		{"application/xml", true},
 		{"application/json+xml", true},
 		{"application/vnd.foo+xml", true},
+
+		{"application/xml; charset=utf-8", true},
+		{"application/vnd.foo+xml; charset=utf-8", true},
 
 		{"text/xml", true},
 		{"text/json+xml", true},


### PR DESCRIPTION
The existing IsJSONType and IsXMLType regular expressions are here
generalized to work with any properly formatted media type.