### PR TITLE
Only skip decompression if the Content-Length is 0.

### DIFF
--- a/client.go
+++ b/client.go
@@ -810,8 +810,8 @@ func (c *Client) execute(req *Request) (*Response, error) {
 		defer closeq(resp.Body)
 		body := resp.Body
 
-		// GitHub #142
-		if strings.EqualFold(resp.Header.Get(hdrContentEncodingKey), "gzip") && resp.ContentLength > 0 {
+		// GitHub #142 & #187
+		if strings.EqualFold(resp.Header.Get(hdrContentEncodingKey), "gzip") && resp.ContentLength != 0 {
 			if _, ok := body.(*gzip.Reader); !ok {
 				body, err = gzip.NewReader(body)
 				if err != nil {


### PR DESCRIPTION
Resolves #187
    
Skip decompression if the Content-Length is 0 specifically. Chunked gzipped responses can return a Content-Length of -1 to specify an unknown size.