### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module gopkg.in/resty.v1
+module gopkg.in/resty
 
 require golang.org/x/net v0.0.0-20180911220305-26e67e76b6c3


### PR DESCRIPTION
It is mandatory to omit `v0` or `v1` according to `Why are v0, v1 omitted in the import paths? Why must the others appear? Why must v0, v1 never appear?` in https://github.com/golang/go/issues/24301