### PR TITLE
point to the same context after http.Request created

### DIFF
--- a/context18_test.go
+++ b/context18_test.go
@@ -10,6 +10,7 @@ package resty
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 	"testing"
 )
@@ -20,6 +21,28 @@ func TestRequestContext(t *testing.T) {
 
 	r.SetContext(context.Background())
 	assertNotNil(t, r.Context())
+}
+
+func TestContextWithPreRequestHook(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	c := dc()
+	c.SetPreRequestHook(func(cl *Client, r *Request) error {
+		type ctxKey int
+		var key ctxKey
+		val := "test-value"
+		ctx := context.WithValue(r.Context(), key, val)
+		r.SetContext(ctx)
+		ctxValue := r.RawRequest.Context().Value(key).(string)
+		assertEqual(t, val, ctxValue)
+		return nil
+	})
+
+	resp, err := c.R().Get(ts.URL)
+
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
 }
 
 func errIsContextCanceled(err error) bool {

--- a/request17.go
+++ b/request17.go
@@ -55,6 +55,9 @@ type Request struct {
 // Context method returns the Context if its already set in request
 // otherwise it creates new one using `context.Background()`.
 func (r *Request) Context() context.Context {
+	if r.RawRequest != nil {
+		return r.RawRequest.Context()
+	}
 	if r.ctx == nil {
 		return context.Background()
 	}
@@ -67,6 +70,9 @@ func (r *Request) Context() context.Context {
 // documentation.
 func (r *Request) SetContext(ctx context.Context) *Request {
 	r.ctx = ctx
+	if r.RawRequest != nil {
+		r.addContextIfAvailable()
+	}
 	return r
 }
 


### PR DESCRIPTION
This pull request adds checks related to context methods. When http.Request is created, context between resty.Request and http.Request stays the same. This can avoid mess when working with preReqHook.

See #206 