### PR TITLE
 Add batch SetMultipartFields in order to set multiple fields

### DIFF
--- a/client.go
+++ b/client.go
@@ -311,7 +311,7 @@ func (c *Client) R() *Request {
 
 		client:          c,
 		multipartFiles:  []*File{},
-		multipartFields: []*multipartField{},
+		multipartFields: []*MultipartField{},
 		pathParams:      map[string]string{},
 		jsonEscapeHTML:  true,
 	}
@@ -918,7 +918,7 @@ func (f *File) String() string {
 }
 
 // multipartField represent custom data part for multipart request
-type multipartField struct {
+type MultipartField struct {
 	Param       string
 	FileName    string
 	ContentType string

--- a/client.go
+++ b/client.go
@@ -917,7 +917,7 @@ func (f *File) String() string {
 	return fmt.Sprintf("ParamName: %v; FileName: %v", f.ParamName, f.Name)
 }
 
-// multipartField represent custom data part for multipart request
+// MultipartField represent custom data part for multipart request
 type MultipartField struct {
 	Param       string
 	FileName    string

--- a/request.go
+++ b/request.go
@@ -299,14 +299,14 @@ func (r *Request) SetMultipartField(param, fileName, contentType string, reader 
 
 // SetMultipartFields method is to set multiple data fields using io.Reader for multipart upload.
 // Example: set multiple json strings.
-//  fields := []*MultipartField{
-//		&MultipartField{
+//  fields := []*resty.MultipartField{
+//		&resty.MultipartField{
 //			Param:       "uploadManifest1",
 //			FileName:    "upload-file-1.json",
 //			ContentType: "application/json",
 //			Reader:      strings.NewReader(`{"input": {"name": "Uploaded document 1", "_filename" : ["file1.txt"]}}`),
 //		},
-//		&MultipartField{
+//		&resty.MultipartField{
 //			Param:       "uploadManifest2",
 //			FileName:    "upload-file-2.json",
 //			ContentType: "application/json",

--- a/request.go
+++ b/request.go
@@ -298,6 +298,22 @@ func (r *Request) SetMultipartField(param, fileName, contentType string, reader 
 }
 
 // SetMultipartFields method is to set multiple data fields using io.Reader for multipart upload.
+// Example: set multiple json strings.
+//  fields := []*MultipartField{
+//		&MultipartField{
+//			Param:       "uploadManifest1",
+//			FileName:    "upload-file-1.json",
+//			ContentType: "application/json",
+//			Reader:      strings.NewReader(`{"input": {"name": "Uploaded document 1", "_filename" : ["file1.txt"]}}`),
+//		},
+//		&MultipartField{
+//			Param:       "uploadManifest2",
+//			FileName:    "upload-file-2.json",
+//			ContentType: "application/json",
+//			Reader:      strings.NewReader(`{"input": {"name": "Uploaded document 2", "_filename" : ["file2.txt"]}}`),
+//		},
+//	}
+//  resty.R().SetMultipartFields(fields)
 func (r *Request) SetMultipartFields(fields []*MultipartField) *Request {
 	r.isMultiPart = true
 

--- a/request.go
+++ b/request.go
@@ -298,9 +298,9 @@ func (r *Request) SetMultipartField(param, fileName, contentType string, reader 
 }
 
 // SetMultipartFields method is to set multiple data fields using io.Reader for multipart upload.
-// Example: set multiple json strings.
-//  fields := []*resty.MultipartField{
-//		&resty.MultipartField{
+// Example:
+// 	resty.R().SetMultipartFields(
+// 		&resty.MultipartField{
 //			Param:       "uploadManifest1",
 //			FileName:    "upload-file-1.json",
 //			ContentType: "application/json",
@@ -311,9 +311,10 @@ func (r *Request) SetMultipartField(param, fileName, contentType string, reader 
 //			FileName:    "upload-file-2.json",
 //			ContentType: "application/json",
 //			Reader:      strings.NewReader(`{"input": {"name": "Uploaded document 2", "_filename" : ["file2.txt"]}}`),
-//		},
-//	}
-//  resty.R().SetMultipartFields(fields...)
+//		})
+//
+// If you have slice already, then simply call-
+// 	resty.R().SetMultipartFields(fields...)
 func (r *Request) SetMultipartFields(fields ...*MultipartField) *Request {
 	r.isMultiPart = true
 	r.multipartFields = append(r.multipartFields, fields...)

--- a/request.go
+++ b/request.go
@@ -244,7 +244,6 @@ func (r *Request) SetError(err interface{}) *Request {
 func (r *Request) SetFile(param, filePath string) *Request {
 	r.isMultiPart = true
 	r.FormData.Set("@"+param, filePath)
-
 	return r
 }
 
@@ -273,27 +272,23 @@ func (r *Request) SetFiles(files map[string]string) *Request {
 //
 func (r *Request) SetFileReader(param, fileName string, reader io.Reader) *Request {
 	r.isMultiPart = true
-
 	r.multipartFiles = append(r.multipartFiles, &File{
 		Name:      fileName,
 		ParamName: param,
 		Reader:    reader,
 	})
-
 	return r
 }
 
 // SetMultipartField method is to set custom data using io.Reader for multipart upload.
 func (r *Request) SetMultipartField(param, fileName, contentType string, reader io.Reader) *Request {
 	r.isMultiPart = true
-
 	r.multipartFields = append(r.multipartFields, &MultipartField{
 		Param:       param,
 		FileName:    fileName,
 		ContentType: contentType,
 		Reader:      reader,
 	})
-
 	return r
 }
 
@@ -328,7 +323,6 @@ func (r *Request) SetMultipartFields(fields ...*MultipartField) *Request {
 //
 func (r *Request) SetContentLength(l bool) *Request {
 	r.setContentLength = true
-
 	return r
 }
 

--- a/request.go
+++ b/request.go
@@ -287,12 +287,21 @@ func (r *Request) SetFileReader(param, fileName string, reader io.Reader) *Reque
 func (r *Request) SetMultipartField(param, fileName, contentType string, reader io.Reader) *Request {
 	r.isMultiPart = true
 
-	r.multipartFields = append(r.multipartFields, &multipartField{
+	r.multipartFields = append(r.multipartFields, &MultipartField{
 		Param:       param,
 		FileName:    fileName,
 		ContentType: contentType,
 		Reader:      reader,
 	})
+
+	return r
+}
+
+// SetMultipartFields method is to set multiple data fields using io.Reader for multipart upload.
+func (r *Request) SetMultipartFields(fields []*MultipartField) *Request {
+	r.isMultiPart = true
+
+	r.multipartFields = append(r.multipartFields, fields...)
 
 	return r
 }

--- a/request.go
+++ b/request.go
@@ -313,12 +313,10 @@ func (r *Request) SetMultipartField(param, fileName, contentType string, reader 
 //			Reader:      strings.NewReader(`{"input": {"name": "Uploaded document 2", "_filename" : ["file2.txt"]}}`),
 //		},
 //	}
-//  resty.R().SetMultipartFields(fields)
-func (r *Request) SetMultipartFields(fields []*MultipartField) *Request {
+//  resty.R().SetMultipartFields(fields...)
+func (r *Request) SetMultipartFields(fields ...*MultipartField) *Request {
 	r.isMultiPart = true
-
 	r.multipartFields = append(r.multipartFields, fields...)
-
 	return r
 }
 

--- a/request16.go
+++ b/request16.go
@@ -47,7 +47,7 @@ type Request struct {
 	client              *Client
 	bodyBuf             *bytes.Buffer
 	multipartFiles      []*File
-	multipartFields     []*multipartField
+	multipartFields     []*MultipartField
 }
 
 func (r *Request) addContextIfAvailable() {

--- a/request17.go
+++ b/request17.go
@@ -49,7 +49,7 @@ type Request struct {
 	client              *Client
 	bodyBuf             *bytes.Buffer
 	multipartFiles      []*File
-	multipartFields     []*multipartField
+	multipartFields     []*MultipartField
 }
 
 // Context method returns the Context if its already set in request

--- a/request_test.go
+++ b/request_test.go
@@ -710,7 +710,7 @@ func TestMultiPartMultipartFields(t *testing.T) {
 
 	resp, err := dclr().
 		SetFormData(map[string]string{"first_name": "Jeevanandam", "last_name": "M"}).
-		SetMultipartFields(fields).
+		SetMultipartFields(fields...).
 		Post(ts.URL + "/upload")
 
 	responseStr := resp.String()

--- a/request_test.go
+++ b/request_test.go
@@ -690,21 +690,21 @@ func TestMultiPartMultipartFields(t *testing.T) {
 	defer ts.Close()
 	defer cleanupFiles(".testdata/upload")
 
-	jsonBytes1 := []byte(`{"input": {"name": "Uploaded document 1", "_filename" : ["file1.txt"]}}`)
-	jsonBytes2 := []byte(`{"input": {"name": "Uploaded document 2", "_filename" : ["file2.txt"]}}`)
+	jsonStr1 := `{"input": {"name": "Uploaded document 1", "_filename" : ["file1.txt"]}}`
+	jsonStr2 := `{"input": {"name": "Uploaded document 2", "_filename" : ["file2.txt"]}}`
 
 	fields := []*MultipartField{
 		&MultipartField{
 			Param:       "uploadManifest1",
 			FileName:    "upload-file-1.json",
 			ContentType: "application/json",
-			Reader:      bytes.NewReader(jsonBytes1),
+			Reader:      strings.NewReader(jsonStr1),
 		},
 		&MultipartField{
 			Param:       "uploadManifest2",
 			FileName:    "upload-file-2.json",
 			ContentType: "application/json",
-			Reader:      bytes.NewReader(jsonBytes2),
+			Reader:      strings.NewReader(jsonStr2),
 		},
 	}
 

--- a/request_test.go
+++ b/request_test.go
@@ -685,6 +685,42 @@ func TestMultiPartMultipartField(t *testing.T) {
 	assertEqual(t, true, strings.Contains(responseStr, "upload-file.json"))
 }
 
+func TestMultiPartMultipartFields(t *testing.T) {
+	ts := createFormPostServer(t)
+	defer ts.Close()
+	defer cleanupFiles(".testdata/upload")
+
+	jsonBytes1 := []byte(`{"input": {"name": "Uploaded document 1", "_filename" : ["file1.txt"]}}`)
+	jsonBytes2 := []byte(`{"input": {"name": "Uploaded document 2", "_filename" : ["file2.txt"]}}`)
+
+	fields := []*MultipartField{
+		&MultipartField{
+			Param:       "uploadManifest1",
+			FileName:    "upload-file-1.json",
+			ContentType: "application/json",
+			Reader:      bytes.NewReader(jsonBytes1),
+		},
+		&MultipartField{
+			Param:       "uploadManifest2",
+			FileName:    "upload-file-2.json",
+			ContentType: "application/json",
+			Reader:      bytes.NewReader(jsonBytes2),
+		},
+	}
+
+	resp, err := dclr().
+		SetFormData(map[string]string{"first_name": "Jeevanandam", "last_name": "M"}).
+		SetMultipartFields(fields).
+		Post(ts.URL + "/upload")
+
+	responseStr := resp.String()
+
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
+	assertEqual(t, true, strings.Contains(responseStr, "upload-file-1.json"))
+	assertEqual(t, true, strings.Contains(responseStr, "upload-file-2.json"))
+}
+
 func TestGetWithCookie(t *testing.T) {
 	ts := createGetServer(t)
 	defer ts.Close()

--- a/util.go
+++ b/util.go
@@ -145,7 +145,7 @@ func createMultipartHeader(param, fileName, contentType string) textproto.MIMEHe
 	return hdr
 }
 
-func addMultipartFormField(w *multipart.Writer, mf *multipartField) error {
+func addMultipartFormField(w *multipart.Writer, mf *MultipartField) error {
 	partWriter, err := w.CreatePart(createMultipartHeader(mf.Param, mf.FileName, mf.ContentType))
 	if err != nil {
 		return err


### PR DESCRIPTION
Dear Jeevanandam,

Thank you for your great library. I would like to propose you this small improvement.
The idea is to add SetMultipartFields method to set multiple fields. Sometimes it is convenient to prepare list with some hardcoded fields at top of request processing function in declarative way and then pass it to request. Resty API already has similar functions: SetHeaders and SetFiles.
Example of usage SetMultipartFields method (extracted from comment):
```
fields := []*MultipartField{
		&MultipartField{
			Param:       "uploadManifest1",
			FileName:    "upload-file-1.json",
			ContentType: "application/json",
			Reader:      strings.NewReader(`{"input": {"name": "Uploaded document 1", "_filename" : ["file1.txt"]}}`),
		},
		&MultipartField{
			Param:       "uploadManifest2",
			FileName:    "upload-file-2.json",
			ContentType: "application/json",
			Reader:      strings.NewReader(`{"input": {"name": "Uploaded document 2", "_filename" : ["file2.txt"]}}`),
		},
	}
resty.R().SetMultipartFields(fields)
```