### PR TITLE
Add Request.Send() method to execute Request as-is

### DIFF
--- a/request.go
+++ b/request.go
@@ -581,6 +581,16 @@ func (r *Request) Patch(url string) (*Response, error) {
 	return r.Execute(MethodPatch, url)
 }
 
+// Send method performs the HTTP request using the method and URL already defined
+// for current `Request`.
+//      req := client.R()
+//      req.Method = resty.GET
+//      req.URL = "http://httpbin.org/get"
+// 		resp, err := client.R().Send()
+func (r *Request) Send() (*Response, error) {
+	return r.Execute(r.Method, r.URL)
+}
+
 // Execute method performs the HTTP request with given HTTP method and URL
 // for current `Request`.
 // 		resp, err := client.R().Execute(resty.GET, "http://httpbin.org/get")

--- a/request_test.go
+++ b/request_test.go
@@ -943,6 +943,64 @@ func TestPatchMethod(t *testing.T) {
 	assertEqual(t, "", resp.String())
 }
 
+func TestSendMethod(t *testing.T) {
+	ts := createGenServer(t)
+	defer ts.Close()
+
+	t.Run("send-get", func(t *testing.T) {
+		req := dclr()
+		req.Method = http.MethodGet
+		req.URL = ts.URL + "/gzip-test"
+
+		resp, err := req.Send()
+
+		assertError(t, err)
+		assertEqual(t, http.StatusOK, resp.StatusCode())
+
+		assertEqual(t, "This is Gzip response testing", resp.String())
+	})
+
+	t.Run("send-options", func(t *testing.T) {
+		req := dclr()
+		req.Method = http.MethodOptions
+		req.URL = ts.URL + "/options"
+
+		resp, err := req.Send()
+
+		assertError(t, err)
+		assertEqual(t, http.StatusOK, resp.StatusCode())
+
+		assertEqual(t, "", resp.String())
+		assertEqual(t, "x-go-resty-id", resp.Header().Get("Access-Control-Expose-Headers"))
+	})
+
+	t.Run("send-patch", func(t *testing.T) {
+		req := dclr()
+		req.Method = http.MethodPatch
+		req.URL = ts.URL + "/patch"
+
+		resp, err := req.Send()
+
+		assertError(t, err)
+		assertEqual(t, http.StatusOK, resp.StatusCode())
+
+		assertEqual(t, "", resp.String())
+	})
+
+	t.Run("send-put", func(t *testing.T) {
+		req := dclr()
+		req.Method = http.MethodPut
+		req.URL = ts.URL + "/plaintext"
+
+		resp, err := req.Send()
+
+		assertError(t, err)
+		assertEqual(t, http.StatusOK, resp.StatusCode())
+
+		assertEqual(t, "TestPut: plain text response", resp.String())
+	})
+}
+
 func TestRawFileUploadByBody(t *testing.T) {
 	ts := createFormPostServer(t)
 	defer ts.Close()


### PR DESCRIPTION
Was working on a project recently that could have benefitted from something like this since the requests were constructed in a different place than they were actually sent.

You can already do this in Resty with something like this:
```
req := client.R()
req.URL = "http://httpbin.org/get"
req.Method = "GET"

resp, err := req.Execute(req.Method, req.URL)
```
It just feels a bit clunky to me.