### PR TITLE
Fixed Panic When Calling TraceInfo But Tracing Has Not Been Enabled

### DIFF
--- a/request.go
+++ b/request.go
@@ -525,10 +525,17 @@ func (r *Request) EnableTrace() *Request {
 }
 
 // TraceInfo method returns the trace info for the request.
+// If either the Client or Request EnableTrace function has not been called
+// prior to the request being made, an empty TraceInfo object will be returned.
 //
 // Since v2.0.0
 func (r *Request) TraceInfo() TraceInfo {
 	ct := r.clientTrace
+
+	if ct == nil {
+		return TraceInfo{}
+	}
+
 	return TraceInfo{
 		DNSLookup:     ct.dnsDone.Sub(ct.dnsStart),
 		ConnTime:      ct.gotConn.Sub(ct.getConn),

--- a/request_test.go
+++ b/request_test.go
@@ -1555,3 +1555,24 @@ func TestTraceInfo(t *testing.T) {
 	// for sake of hook funcs
 	_, _ = client.R().EnableTrace().Get("https://httpbin.org/get")
 }
+
+func TestTraceInfoWithoutEnableTrace(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	client := dc()
+	client.SetHostURL(ts.URL)
+	for _, u := range []string{"/", "/json", "/long-text", "/long-json"} {
+		resp, err := client.R().Get(u)
+		assertNil(t, err)
+		assertNotNil(t, resp)
+
+		tr := resp.Request.TraceInfo()
+		assertEqual(t, true, tr.DNSLookup == 0)
+		assertEqual(t, true, tr.ConnTime == 0)
+		assertEqual(t, true, tr.TLSHandshake == 0)
+		assertEqual(t, true, tr.ServerTime == 0)
+		assertEqual(t, true, tr.ResponseTime == 0)
+		assertEqual(t, true, tr.TotalTime == 0)
+	}
+}


### PR DESCRIPTION
Fixes #293

If EnableTrace has not been called prior to a request being made, an empty TraceInfo is returned rather than panicing