### PR TITLE
Apply debugBodySizeLimit to Request debug logger

### DIFF
--- a/client.go
+++ b/client.go
@@ -366,7 +366,7 @@ func (c *Client) SetDebug(d bool) *Client {
 	return c
 }
 
-// SetDebugBodyLimit sets the maximum size for which the response body will be logged in debug mode.
+// SetDebugBodyLimit sets the maximum size for which the response and request body will be logged in debug mode.
 //		client.SetDebugBodyLimit(1000000)
 func (c *Client) SetDebugBodyLimit(sl int64) *Client {
 	c.debugBodySizeLimit = sl

--- a/middleware.go
+++ b/middleware.go
@@ -265,7 +265,7 @@ func addCredentials(c *Client, r *Request) error {
 func requestLogger(c *Client, r *Request) error {
 	if c.Debug {
 		rr := r.RawRequest
-		rl := &RequestLog{Header: copyHeaders(rr.Header), Body: r.fmtBodyString()}
+		rl := &RequestLog{Header: copyHeaders(rr.Header), Body: r.fmtBodyString(c.debugBodySizeLimit)}
 		if c.requestLog != nil {
 			if err := c.requestLog(rl); err != nil {
 				return err

--- a/request_test.go
+++ b/request_test.go
@@ -1576,3 +1576,82 @@ func TestTraceInfoWithoutEnableTrace(t *testing.T) {
 		assertEqual(t, true, tr.TotalTime == 0)
 	}
 }
+
+func TestDebugLoggerRequestBodyTooLarge(t *testing.T) {
+	ts := createFilePostServer(t)
+	defer ts.Close()
+
+	debugBodySizeLimit := int64(512)
+
+	// upload an image with more than 512 bytes
+	output := bytes.NewBufferString("")
+	resp, err := New().SetDebug(true).outputLogTo(output).SetDebugBodyLimit(debugBodySizeLimit).R().
+		SetFile("file", filepath.Join(getTestDataPath(), "test-img.png")).
+		SetHeader("Content-Type", "image/png").
+		Post(ts.URL + "/upload")
+	assertNil(t, err)
+	assertNotNil(t, resp)
+	assertEqual(t, true, strings.Contains(output.String(), "REQUEST TOO LARGE"))
+
+	// upload a text file with no more than 512 bytes
+	output = bytes.NewBufferString("")
+	resp, err = New().SetDebug(true).outputLogTo(output).SetDebugBodyLimit(debugBodySizeLimit).R().
+		SetFile("file", filepath.Join(getTestDataPath(), "text-file.txt")).
+		SetHeader("Content-Type", "text/plain").
+		Post(ts.URL + "/upload")
+	assertNil(t, err)
+	assertNotNil(t, resp)
+	assertEqual(t, true, strings.Contains(output.String(), " THIS IS TEXT FILE FOR MULTIPART UPLOAD TEST "))
+
+	formTs := createFormPostServer(t)
+	defer formTs.Close()
+
+	// post form with more than 512 bytes data
+	output = bytes.NewBufferString("")
+	resp, err = New().SetDebug(true).outputLogTo(output).SetDebugBodyLimit(debugBodySizeLimit).R().
+		SetFormData(map[string]string{
+			"first_name": "Alex",
+			"last_name": strings.Repeat("C", int(debugBodySizeLimit)),
+			"zip_code": "00001"}).
+		SetBasicAuth("myuser", "mypass").
+		Post(formTs.URL + "/profile")
+	assertNil(t, err)
+	assertNotNil(t, resp)
+	assertEqual(t, true, strings.Contains(output.String(), "REQUEST TOO LARGE"))
+
+	// post form with no more than 512 bytes data
+	output = bytes.NewBufferString("")
+	resp, err = New().SetDebug(true).outputLogTo(output).SetDebugBodyLimit(debugBodySizeLimit).R().
+		SetFormData(map[string]string{
+			"first_name": "Alex",
+			"last_name": "C",
+			"zip_code": "00001"}).
+		SetBasicAuth("myuser", "mypass").
+		Post(formTs.URL + "/profile")
+	assertNil(t, err)
+	assertNotNil(t, resp)
+	assertEqual(t, true, strings.Contains(output.String(), "Alex"))
+
+	// post string with more than 512 bytes data
+	output = bytes.NewBufferString("")
+	resp, err = New().SetDebug(true).outputLogTo(output).SetDebugBodyLimit(debugBodySizeLimit).R().
+		SetBody(`{
+			"first_name": "Alex",
+			"last_name": "` + strings.Repeat("C", int(debugBodySizeLimit)) + `C",
+			"zip_code": "00001"}`).
+		SetBasicAuth("myuser", "mypass").
+		Post(formTs.URL + "/profile")
+	assertNil(t, err)
+	assertNotNil(t, resp)
+	assertEqual(t, true, strings.Contains(output.String(), "REQUEST TOO LARGE"))
+
+	// post slice with more than 512 bytes data
+	output = bytes.NewBufferString("")
+	resp, err = New().SetDebug(true).outputLogTo(output).SetDebugBodyLimit(debugBodySizeLimit).R().
+		SetBody([]string{strings.Repeat("C", int(debugBodySizeLimit))}).
+		SetBasicAuth("myuser", "mypass").
+		Post(formTs.URL + "/profile")
+	assertNil(t, err)
+	assertNotNil(t, resp)
+	assertEqual(t, true, strings.Contains(output.String(), "REQUEST TOO LARGE"))
+}


### PR DESCRIPTION
To solve https://github.com/go-resty/resty/issues/281 

`(c *Client) SetDebugBodyLimit(sl int64)` of resty client works only on response logger,
but not request logger, resty will log the whole file content in strings when post files

This PR is trying to apply `SetDebugBodyLimit()` to request logger just like response logger. 
@jeevatkm 