### PR TITLE
Add ability to set Authorization header Scheme

### DIFF
--- a/client.go
+++ b/client.go
@@ -79,7 +79,8 @@ type Client struct {
 	FormData              url.Values
 	Header                http.Header
 	UserInfo              *User
-	Token                 string
+    Token                 string
+	AuthScheme	          string
 	Cookies               []*http.Cookie
 	Error                 reflect.Type
 	Debug                 bool
@@ -116,6 +117,10 @@ type Client struct {
 // User type is to hold an username and password information
 type User struct {
 	Username, Password string
+}
+
+type AuthHeader struct {
+    Scheme, Token string
 }
 
 //‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
@@ -278,19 +283,35 @@ func (c *Client) SetBasicAuth(username, password string) *Client {
 	return c
 }
 
-// SetAuthToken method sets bearer auth token header in the HTTP request. For Example:
-// 		Authorization: Bearer <auth-token-value-comes-here>
+// SetAuthToken method sets the auth token header (default scheme: Bearer) in the HTTP request. For Example:
+// 		Authorization: <auth-scheme> <auth-token-value-comes-here>
 //
 // For Example: To set auth token BC594900518B4F7EAC75BD37F019E08FBC594900518B4F7EAC75BD37F019E08F
 //
 // 		client.SetAuthToken("BC594900518B4F7EAC75BD37F019E08FBC594900518B4F7EAC75BD37F019E08F")
 //
-// This bearer auth token gets added to all the request rasied from this client instance.
+// This auth token gets added to all the request rasied from this client instance.
 // Also it can be overridden or set one at the request level is supported.
 //
 // See `Request.SetAuthToken`.
 func (c *Client) SetAuthToken(token string) *Client {
 	c.Token = token
+	return c
+}
+
+// SetAuthScheme method sets the auth token scheme type in the HTTP request. For Example:
+//      Authorization: <auth-scheme-value-set-here> <auth-token-value>
+//
+// For Example: To set the scheme to use OAuth 
+//
+// 		client.SetAuthScheme("OAuth")
+//
+// This auth token gets added to all the request rasied from this client instance.
+// Also it can be overridden or set one at the request level is supported.
+//
+// See `Request.SetAuthToken`.
+func (c *Client) SetAuthScheme(scheme string) *Client {
+	c.AuthScheme = scheme
 	return c
 }
 

--- a/client.go
+++ b/client.go
@@ -305,6 +305,11 @@ func (c *Client) SetAuthToken(token string) *Client {
 // This auth token gets added to all the request rasied from this client instance.
 // Also it can be overridden or set one at the request level is supported.
 //
+// Information about Auth schemes can be found in RFC7235 which is linked to below along with the page containing
+// the currently defined official authentication schemes:
+//     https://tools.ietf.org/html/rfc7235
+//     https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml#authschemes
+//
 // See `Request.SetAuthToken`.
 func (c *Client) SetAuthScheme(scheme string) *Client {
 	c.AuthScheme = scheme

--- a/client.go
+++ b/client.go
@@ -279,14 +279,15 @@ func (c *Client) SetBasicAuth(username, password string) *Client {
 	return c
 }
 
-// SetAuthToken method sets the auth token header (default scheme: Bearer) in the HTTP request. For Example:
-// 		Authorization: <auth-scheme> <auth-token-value-comes-here>
+// SetAuthToken method sets the auth token of the `Authorization` header for all HTTP requests.
+// The default auth scheme is `Bearer`, it can be customized with the method `SetAuthScheme`. For Example:
+// 		Authorization: <auth-scheme> <auth-token-value>
 //
 // For Example: To set auth token BC594900518B4F7EAC75BD37F019E08FBC594900518B4F7EAC75BD37F019E08F
 //
 // 		client.SetAuthToken("BC594900518B4F7EAC75BD37F019E08FBC594900518B4F7EAC75BD37F019E08F")
 //
-// This auth token gets added to all the request rasied from this client instance.
+// This auth token gets added to all the requests rasied from this client instance.
 // Also it can be overridden or set one at the request level is supported.
 //
 // See `Request.SetAuthToken`.
@@ -295,18 +296,18 @@ func (c *Client) SetAuthToken(token string) *Client {
 	return c
 }
 
-// SetAuthScheme method sets the auth token scheme type in the HTTP request. For Example:
-//      Authorization: <auth-scheme-value-set-here> <auth-token-value>
+// SetAuthScheme method sets the auth scheme type in the HTTP request. For Example:
+//      Authorization: <auth-scheme-value> <auth-token-value>
 //
 // For Example: To set the scheme to use OAuth
 //
 // 		client.SetAuthScheme("OAuth")
 //
-// This auth token gets added to all the request rasied from this client instance.
+// This auth scheme gets added to all the requests rasied from this client instance.
 // Also it can be overridden or set one at the request level is supported.
 //
-// Information about Auth schemes can be found in RFC7235 which is linked to below along with the page containing
-// the currently defined official authentication schemes:
+// Information about auth schemes can be found in RFC7235 which is linked to below
+// along with the page containing the currently defined official authentication schemes:
 //     https://tools.ietf.org/html/rfc7235
 //     https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml#authschemes
 //

--- a/client.go
+++ b/client.go
@@ -79,8 +79,8 @@ type Client struct {
 	FormData              url.Values
 	Header                http.Header
 	UserInfo              *User
-    Token                 string
-	AuthScheme	          string
+	Token                 string
+	AuthScheme            string
 	Cookies               []*http.Cookie
 	Error                 reflect.Type
 	Debug                 bool
@@ -117,10 +117,6 @@ type Client struct {
 // User type is to hold an username and password information
 type User struct {
 	Username, Password string
-}
-
-type AuthHeader struct {
-    Scheme, Token string
 }
 
 //‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
@@ -302,7 +298,7 @@ func (c *Client) SetAuthToken(token string) *Client {
 // SetAuthScheme method sets the auth token scheme type in the HTTP request. For Example:
 //      Authorization: <auth-scheme-value-set-here> <auth-token-value>
 //
-// For Example: To set the scheme to use OAuth 
+// For Example: To set the scheme to use OAuth
 //
 // 		client.SetAuthScheme("OAuth")
 //

--- a/client_test.go
+++ b/client_test.go
@@ -55,6 +55,21 @@ func TestClientAuthToken(t *testing.T) {
 	assertEqual(t, http.StatusOK, resp.StatusCode())
 }
 
+func TestClientAuthScheme(t *testing.T) {
+	ts := createAuthServer(t)
+	defer ts.Close()
+
+	c := dc()
+	c.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}).
+		SetAuthScheme("Bearer").
+		SetHostURL(ts.URL + "/")
+
+	resp, err := c.R().Get("/profile")
+
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
+}
+
 func TestOnAfterMiddleware(t *testing.T) {
 	ts := createGenServer(t)
 	defer ts.Close()

--- a/client_test.go
+++ b/client_test.go
@@ -60,6 +60,7 @@ func TestClientAuthScheme(t *testing.T) {
 	defer ts.Close()
 
 	c := dc()
+	// Ensure default Bearer
 	c.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}).
 		SetAuthToken("004DDB79-6801-4587-B976-F093E6AC44FF").
 		SetHostURL(ts.URL + "/")
@@ -68,6 +69,14 @@ func TestClientAuthScheme(t *testing.T) {
 
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
+
+	// Ensure setting the scheme works as well
+	c.SetAuthScheme("Bearer")
+
+	resp2, err2 := c.R().Get("/profile")
+	assertError(t, err2)
+	assertEqual(t, http.StatusOK, resp2.StatusCode())
+
 }
 
 func TestOnAfterMiddleware(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -61,7 +61,7 @@ func TestClientAuthScheme(t *testing.T) {
 
 	c := dc()
 	c.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}).
-		SetAuthScheme("Bearer").
+		SetAuthToken("004DDB79-6801-4587-B976-F093E6AC44FF").
 		SetHostURL(ts.URL + "/")
 
 	resp, err := c.R().Get("/profile")

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/go-resty/resty/v2
 
 require golang.org/x/net v0.0.0-20190628185345-da137c7871d7
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/go-resty/resty/v2
 
 require golang.org/x/net v0.0.0-20190628185345-da137c7871d7
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/rigrassm/resty/v2
+module github.com/go-resty/resty/v2
 
 require golang.org/x/net v0.0.0-20190628185345-da137c7871d7

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/go-resty/resty/v2
+module github.com/rigrassm/resty/v2
 
 require golang.org/x/net v0.0.0-20190628185345-da137c7871d7

--- a/middleware.go
+++ b/middleware.go
@@ -264,9 +264,9 @@ func addCredentials(c *Client, r *Request) error {
 
 	// Build the Token Auth header
 	if !IsStringEmpty(r.Token) { // takes precedence
-		r.RawRequest.Header.Set(hdrAuthorizationKey, fmt.Sprintf("%s %s", authScheme, r.Token))
+		r.RawRequest.Header.Set(hdrAuthorizationKey, authScheme+" "+r.Token)
 	} else if !IsStringEmpty(c.Token) {
-		r.RawRequest.Header.Set(hdrAuthorizationKey, fmt.Sprintf("%s %s", authScheme, c.Token))
+		r.RawRequest.Header.Set(hdrAuthorizationKey, authScheme+" "+c.Token)
 	}
 
 	return nil

--- a/middleware.go
+++ b/middleware.go
@@ -252,11 +252,21 @@ func addCredentials(c *Client, r *Request) error {
 		}
 	}
 
-	// Token Auth
+	// Set the Authorization Header Scheme
+	var authScheme string
+	if !IsStringEmpty(r.AuthScheme) {
+		authScheme = r.AuthScheme
+	} else if !IsStringEmpty(c.AuthScheme) {
+		authScheme = c.AuthScheme
+	} else {
+		authScheme = "Bearer"
+	}
+
+	// Build the Token Auth header
 	if !IsStringEmpty(r.Token) { // takes precedence
-		r.RawRequest.Header.Set(hdrAuthorizationKey, "Bearer "+r.Token)
+		r.RawRequest.Header.Set(hdrAuthorizationKey, fmt.Sprintf("%s %s", authScheme, r.Token))
 	} else if !IsStringEmpty(c.Token) {
-		r.RawRequest.Header.Set(hdrAuthorizationKey, "Bearer "+c.Token)
+		r.RawRequest.Header.Set(hdrAuthorizationKey, fmt.Sprintf("%s %s", authScheme, c.Token))
 	}
 
 	return nil

--- a/request.go
+++ b/request.go
@@ -30,6 +30,7 @@ type Request struct {
 	URL        string
 	Method     string
 	Token      string
+	AuthScheme string
 	QueryParam url.Values
 	FormData   url.Values
 	Header     http.Header
@@ -382,7 +383,7 @@ func (r *Request) SetBasicAuth(username, password string) *Request {
 	return r
 }
 
-// SetAuthToken method sets bearer auth token header in the current HTTP request. Header example:
+// SetAuthToken method sets the auth token header(Default Scheme: Bearer) in the current HTTP request. Header example:
 // 		Authorization: Bearer <auth-token-value-comes-here>
 //
 // For Example: To set auth token BC594900518B4F7EAC75BD37F019E08FBC594900518B4F7EAC75BD37F019E08F
@@ -392,6 +393,22 @@ func (r *Request) SetBasicAuth(username, password string) *Request {
 // This method overrides the Auth token set by method `Client.SetAuthToken`.
 func (r *Request) SetAuthToken(token string) *Request {
 	r.Token = token
+	return r
+}
+
+// SetAuthScheme method sets the auth token scheme type in the HTTP request. For Example:
+//      Authorization: <auth-scheme-value-set-here> <auth-token-value>
+//
+// For Example: To set the scheme to use OAuth 
+//
+// 		client.R().SetAuthScheme("OAuth")
+//
+// This auth header scheme gets added to all the request rasied from this client instance.
+// Also it can be overridden or set one at the request level is supported.
+//
+// This method overrides the Authorization scheme set by method `Client.SetAuthScheme`.
+func (r *Request) SetAuthScheme(scheme string) *Request {
+	r.AuthScheme = scheme
 	return r
 }
 

--- a/request.go
+++ b/request.go
@@ -399,7 +399,7 @@ func (r *Request) SetAuthToken(token string) *Request {
 // SetAuthScheme method sets the auth token scheme type in the HTTP request. For Example:
 //      Authorization: <auth-scheme-value-set-here> <auth-token-value>
 //
-// For Example: To set the scheme to use OAuth 
+// For Example: To set the scheme to use OAuth
 //
 // 		client.R().SetAuthScheme("OAuth")
 //

--- a/request.go
+++ b/request.go
@@ -406,6 +406,11 @@ func (r *Request) SetAuthToken(token string) *Request {
 // This auth header scheme gets added to all the request rasied from this client instance.
 // Also it can be overridden or set one at the request level is supported.
 //
+// Information about Auth schemes can be found in RFC7235 which is linked to below along with the page containing
+// the currently defined official authentication schemes:
+//     https://tools.ietf.org/html/rfc7235
+//     https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml#authschemes
+//
 // This method overrides the Authorization scheme set by method `Client.SetAuthScheme`.
 func (r *Request) SetAuthScheme(scheme string) *Request {
 	r.AuthScheme = scheme

--- a/request_test.go
+++ b/request_test.go
@@ -1611,8 +1611,8 @@ func TestDebugLoggerRequestBodyTooLarge(t *testing.T) {
 	resp, err = New().SetDebug(true).outputLogTo(output).SetDebugBodyLimit(debugBodySizeLimit).R().
 		SetFormData(map[string]string{
 			"first_name": "Alex",
-			"last_name": strings.Repeat("C", int(debugBodySizeLimit)),
-			"zip_code": "00001"}).
+			"last_name":  strings.Repeat("C", int(debugBodySizeLimit)),
+			"zip_code":   "00001"}).
 		SetBasicAuth("myuser", "mypass").
 		Post(formTs.URL + "/profile")
 	assertNil(t, err)
@@ -1624,8 +1624,8 @@ func TestDebugLoggerRequestBodyTooLarge(t *testing.T) {
 	resp, err = New().SetDebug(true).outputLogTo(output).SetDebugBodyLimit(debugBodySizeLimit).R().
 		SetFormData(map[string]string{
 			"first_name": "Alex",
-			"last_name": "C",
-			"zip_code": "00001"}).
+			"last_name":  "C",
+			"zip_code":   "00001"}).
 		SetBasicAuth("myuser", "mypass").
 		Post(formTs.URL + "/profile")
 	assertNil(t, err)
@@ -1637,7 +1637,7 @@ func TestDebugLoggerRequestBodyTooLarge(t *testing.T) {
 	resp, err = New().SetDebug(true).outputLogTo(output).SetDebugBodyLimit(debugBodySizeLimit).R().
 		SetBody(`{
 			"first_name": "Alex",
-			"last_name": "` + strings.Repeat("C", int(debugBodySizeLimit)) + `C",
+			"last_name": "`+strings.Repeat("C", int(debugBodySizeLimit))+`C",
 			"zip_code": "00001"}`).
 		SetBasicAuth("myuser", "mypass").
 		Post(formTs.URL + "/profile")

--- a/request_test.go
+++ b/request_test.go
@@ -491,7 +491,7 @@ func TestRequestAuthToken(t *testing.T) {
 	assertEqual(t, http.StatusOK, resp.StatusCode())
 }
 
-func TestClientAuthScheme(t *testing.T) {
+func TestRequestAuthScheme(t *testing.T) {
 	ts := createAuthServer(t)
 	defer ts.Close()
 
@@ -503,7 +503,7 @@ func TestClientAuthScheme(t *testing.T) {
 	resp, err := c.R().
 		SetAuthScheme("Bearer").
 		SetAuthToken("004DDB79-6801-4587-B976-F093E6AC44FF-Request").
-	        Get("/profile")
+	        Get(ts.URL + "/profile")
 
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())

--- a/request_test.go
+++ b/request_test.go
@@ -491,6 +491,24 @@ func TestRequestAuthToken(t *testing.T) {
 	assertEqual(t, http.StatusOK, resp.StatusCode())
 }
 
+func TestClientAuthScheme(t *testing.T) {
+	ts := createAuthServer(t)
+	defer ts.Close()
+
+	c := dc()
+	c.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}).
+		SetAuthScheme("OAuth").
+		SetAuthToken("004DDB79-6801-4587-B976-F093E6AC44FF")
+
+	resp, err := c.R().
+		SetAuthScheme("Bearer").
+		SetAuthToken("004DDB79-6801-4587-B976-F093E6AC44FF-Request").
+	        Get("/profile")
+
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
+}
+
 func TestFormData(t *testing.T) {
 	ts := createFormPostServer(t)
 	defer ts.Close()


### PR DESCRIPTION
Took a quick pass at implementing this to address issue #306.

This PR adds a new Client/Request method named `SetAuthScheme` that allows the user to specify an Authorization header scheme. If one isn't set, the `addCredentials()` function will see this and default to using the "Bearer" scheme.

I'm a new Gopher so please be critical of the work!