### PR TITLE
added SetRootCertificateFromString method to read cert from string

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,29 @@ if err != nil {
 client.SetCertificates(cert1, cert2, cert3)
 ```
 
+#### Custom Root Certificates and Client Certificates from string
+
+```go
+// Custom Root certificates from string
+// You can pass you certificates throught env variables as strings
+// you can add one or more root certificates, its get appended
+client.SetRootCertificateFromString("-----BEGIN CERTIFICATE-----content-----END CERTIFICATE-----")
+client.SetRootCertificateFromString("-----BEGIN CERTIFICATE-----content-----END CERTIFICATE-----")
+// ... and so on!
+
+// Adding Client Certificates, you add one or more certificates
+// Sample for creating certificate object
+// Parsing public/private key pair from a pair of files. The files must contain PEM encoded data.
+cert1, err := tls.X509KeyPair([]byte("-----BEGIN CERTIFICATE-----content-----END CERTIFICATE-----"), []byte("-----BEGIN CERTIFICATE-----content-----END CERTIFICATE-----"))
+if err != nil {
+  log.Fatalf("ERROR client certificate: %s", err)
+}
+// ...
+
+// You add one or more certificates
+client.SetCertificates(cert1, cert2, cert3)
+```
+
 #### Proxy Settings - Client as well as at Request Level
 
 Default `Go` supports Proxy via environment variable `HTTP_PROXY`. Resty provides support via `SetProxy` & `RemoveProxy`.

--- a/client.go
+++ b/client.go
@@ -606,6 +606,22 @@ func (c *Client) SetRootCertificate(pemFilePath string) *Client {
 	return c
 }
 
+// SetRootCertificateFromString method helps to add one or more root certificates into Resty client
+// 		client.SetRootCertificateFromString("pem file content")
+func (c *Client) SetRootCertificateFromString(pemContent string) *Client {
+	config, err := c.tlsConfig()
+	if err != nil {
+		c.log.Errorf("%v", err)
+		return c
+	}
+	if config.RootCAs == nil {
+		config.RootCAs = x509.NewCertPool()
+	}
+
+	config.RootCAs.AppendCertsFromPEM([]byte(pemContent))
+	return c
+}
+
 // SetOutputDirectory method sets output directory for saving HTTP response into file.
 // If the output directory not exists then resty creates one. This setting is optional one,
 // if you're planning using absolute path in `Request.SetOutput` and can used together.

--- a/client_test.go
+++ b/client_test.go
@@ -175,6 +175,19 @@ func TestClientSetRootCertificateNotExists(t *testing.T) {
 	assertNil(t, transport.TLSClientConfig)
 }
 
+func TestClientSetRootCertificateFromString(t *testing.T) {
+	client := dc()
+	rootPemData, err := ioutil.ReadFile(filepath.Join(getTestDataPath(), "sample-root.pem"))
+	assertNil(t, err)
+
+	client.SetRootCertificateFromString(string(rootPemData))
+
+	transport, err := client.transport()
+
+	assertNil(t, err)
+	assertNotNil(t, transport.TLSClientConfig.RootCAs)
+}
+
 func TestClientOnBeforeRequestModification(t *testing.T) {
 	tc := dc()
 	tc.OnBeforeRequest(func(c *Client, r *Request) error {

--- a/client_test.go
+++ b/client_test.go
@@ -188,6 +188,23 @@ func TestClientSetRootCertificateFromString(t *testing.T) {
 	assertNotNil(t, transport.TLSClientConfig.RootCAs)
 }
 
+func TestClientSetRootCertificateFromStringErrorTls(t *testing.T) {
+	client := NewWithClient(&http.Client{})
+	client.outputLogTo(ioutil.Discard)
+
+	rootPemData, err := ioutil.ReadFile(filepath.Join(getTestDataPath(), "sample-root.pem"))
+	assertNil(t, err)
+	rt := &CustomRoundTripper{}
+	client.SetTransport(rt)
+	transport, err := client.transport()
+
+	client.SetRootCertificateFromString(string(rootPemData))
+
+	assertNotNil(t, rt)
+	assertNotNil(t, err)
+	assertNil(t, transport)
+}
+
 func TestClientOnBeforeRequestModification(t *testing.T) {
 	tc := dc()
 	tc.OnBeforeRequest(func(c *Client, r *Request) error {


### PR DESCRIPTION
Now it's impossible to set root certificate from string value, only from file path