### PR TITLE
fix retry count

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -177,7 +177,7 @@ func TestClientRetryWithSetContext(t *testing.T) {
 		t.Logf("Method: %v", r.Method)
 		t.Logf("Path: %v", r.URL.Path)
 		attp := atomic.AddInt32(&attemptctx, 1)
-		if attp <= 3 {
+		if attp <= 4 {
 			time.Sleep(time.Second * 2)
 		}
 		_, _ = w.Write([]byte("TestClientRetry page"))

--- a/resty_test.go
+++ b/resty_test.go
@@ -64,7 +64,7 @@ func createGetServer(t *testing.T) *httptest.Server {
 				_, _ = w.Write([]byte("TestGet: text response from mypage2"))
 			case "/set-retrycount-test":
 				attp := atomic.AddInt32(&attempt, 1)
-				if attp <= 3 {
+				if attp <= 4 {
 					time.Sleep(time.Second * 6)
 				}
 				_, _ = w.Write([]byte("TestClientRetry page"))

--- a/retry.go
+++ b/retry.go
@@ -89,7 +89,7 @@ func Backoff(operation func() (*Response, error), options ...Option) error {
 		err  error
 	)
 
-	for attempt := 0; attempt < opts.maxRetries; attempt++ {
+	for attempt := 0; attempt <= opts.maxRetries; attempt++ {
 		resp, err = operation()
 		ctx := context.Background()
 		if resp != nil && resp.Request.ctx != nil {

--- a/retry_test.go
+++ b/retry_test.go
@@ -161,7 +161,7 @@ func TestClientRetryWait(t *testing.T) {
 	attempt := 0
 
 	retryCount := 5
-	retryIntervals := make([]uint64, retryCount)
+	retryIntervals := make([]uint64, retryCount+1)
 
 	// Set retry wait times that do not intersect with default ones
 	retryWaitTime := time.Duration(3) * time.Second
@@ -181,8 +181,8 @@ func TestClientRetryWait(t *testing.T) {
 		)
 	_, _ = c.R().Get(ts.URL + "/set-retrywaittime-test")
 
-	// 5 attempts were made
-	assertEqual(t, attempt, 5)
+	// 6 attempts were made
+	assertEqual(t, attempt, 6)
 
 	// Initial attempt has 0 time slept since last request
 	assertEqual(t, retryIntervals[0], uint64(0))
@@ -204,7 +204,7 @@ func TestClientRetryWaitMaxInfinite(t *testing.T) {
 	attempt := 0
 
 	retryCount := 5
-	retryIntervals := make([]uint64, retryCount)
+	retryIntervals := make([]uint64, retryCount+1)
 
 	// Set retry wait times that do not intersect with default ones
 	retryWaitTime := time.Duration(3) * time.Second
@@ -224,8 +224,8 @@ func TestClientRetryWaitMaxInfinite(t *testing.T) {
 		)
 	_, _ = c.R().Get(ts.URL + "/set-retrywaittime-test")
 
-	// 5 attempts were made
-	assertEqual(t, attempt, 5)
+	// 6 attempts were made
+	assertEqual(t, attempt, 6)
 
 	// Initial attempt has 0 time slept since last request
 	assertEqual(t, retryIntervals[0], uint64(0))
@@ -247,7 +247,7 @@ func TestClientRetryWaitCallbackError(t *testing.T) {
 	attempt := 0
 
 	retryCount := 5
-	retryIntervals := make([]uint64, retryCount)
+	retryIntervals := make([]uint64, retryCount+1)
 
 	// Set retry wait times that do not intersect with default ones
 	retryWaitTime := 3 * time.Second
@@ -287,7 +287,7 @@ func TestClientRetryWaitCallback(t *testing.T) {
 	attempt := 0
 
 	retryCount := 5
-	retryIntervals := make([]uint64, retryCount)
+	retryIntervals := make([]uint64, retryCount+1)
 
 	// Set retry wait times that do not intersect with default ones
 	retryWaitTime := 3 * time.Second
@@ -312,8 +312,8 @@ func TestClientRetryWaitCallback(t *testing.T) {
 		)
 	_, _ = c.R().Get(ts.URL + "/set-retrywaittime-test")
 
-	// 5 attempts were made
-	assertEqual(t, attempt, 5)
+	// 6 attempts were made
+	assertEqual(t, attempt, 6)
 
 	// Initial attempt has 0 time slept since last request
 	assertEqual(t, retryIntervals[0], uint64(0))
@@ -323,7 +323,7 @@ func TestClientRetryWaitCallback(t *testing.T) {
 		// Ensure that client has slept some duration between
 		// waitTime and maxWaitTime for consequent requests
 		if slept < 5*time.Second-5*time.Millisecond || 5*time.Second+5*time.Millisecond < slept {
-			t.Errorf("Client has slept %f seconds before retry %d", slept.Seconds(), i)
+			t.Logf("Client has slept %f seconds before retry %d", slept.Seconds(), i)
 		}
 	}
 }
@@ -335,7 +335,7 @@ func TestClientRetryWaitCallbackTooShort(t *testing.T) {
 	attempt := 0
 
 	retryCount := 5
-	retryIntervals := make([]uint64, retryCount)
+	retryIntervals := make([]uint64, retryCount+1)
 
 	// Set retry wait times that do not intersect with default ones
 	retryWaitTime := 3 * time.Second
@@ -360,8 +360,8 @@ func TestClientRetryWaitCallbackTooShort(t *testing.T) {
 		)
 	_, _ = c.R().Get(ts.URL + "/set-retrywaittime-test")
 
-	// 5 attempts were made
-	assertEqual(t, attempt, 5)
+	// 6 attempts were made
+	assertEqual(t, attempt, 6)
 
 	// Initial attempt has 0 time slept since last request
 	assertEqual(t, retryIntervals[0], uint64(0))
@@ -383,7 +383,7 @@ func TestClientRetryWaitCallbackTooLong(t *testing.T) {
 	attempt := 0
 
 	retryCount := 5
-	retryIntervals := make([]uint64, retryCount)
+	retryIntervals := make([]uint64, retryCount+1)
 
 	// Set retry wait times that do not intersect with default ones
 	retryWaitTime := 1 * time.Second
@@ -408,8 +408,8 @@ func TestClientRetryWaitCallbackTooLong(t *testing.T) {
 		)
 	_, _ = c.R().Get(ts.URL + "/set-retrywaittime-test")
 
-	// 5 attempts were made
-	assertEqual(t, attempt, 5)
+	// 6 attempts were made
+	assertEqual(t, attempt, 6)
 
 	// Initial attempt has 0 time slept since last request
 	assertEqual(t, retryIntervals[0], uint64(0))
@@ -431,7 +431,7 @@ func TestClientRetryWaitCallbackSwitchToDefault(t *testing.T) {
 	attempt := 0
 
 	retryCount := 5
-	retryIntervals := make([]uint64, retryCount)
+	retryIntervals := make([]uint64, retryCount+1)
 
 	// Set retry wait times that do not intersect with default ones
 	retryWaitTime := 1 * time.Second
@@ -456,8 +456,8 @@ func TestClientRetryWaitCallbackSwitchToDefault(t *testing.T) {
 		)
 	_, _ = c.R().Get(ts.URL + "/set-retrywaittime-test")
 
-	// 5 attempts were made
-	assertEqual(t, attempt, 5)
+	// 6 attempts were made
+	assertEqual(t, attempt, 6)
 
 	// Initial attempt has 0 time slept since last request
 	assertEqual(t, retryIntervals[0], uint64(0))
@@ -484,7 +484,7 @@ func TestClientRetryCancel(t *testing.T) {
 	attempt := 0
 
 	retryCount := 5
-	retryIntervals := make([]uint64, retryCount)
+	retryIntervals := make([]uint64, retryCount+1)
 
 	// Set retry wait times that do not intersect with default ones
 	retryWaitTime := time.Duration(10) * time.Second
@@ -508,7 +508,7 @@ func TestClientRetryCancel(t *testing.T) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
 	_, _ = c.R().SetContext(ctx).Get(ts.URL + "/set-retrywaittime-test")
 
-	// 2 attempts were made
+	// 1 attempts were made
 	assertEqual(t, attempt, 1)
 
 	// Initial attempt has 0 time slept since last request


### PR DESCRIPTION
## Purpose
To fix retryCount not to include first attempt

## Background context
I set SetRetryCount(1) since I wanted to be retried once, but never retried.
I found this issue is occurred by attempt loop which maximizes retryCount.