### PR TITLE
force option to attempt http2

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/net/http2"
 )
 
 const (
@@ -973,16 +971,14 @@ func createTransport(localAddr net.Addr) *http.Transport {
 	if localAddr != nil {
 		dialer.LocalAddr = localAddr
 	}
-	transp := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
-		DialContext:           dialer.DialContext,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
-	}
-	_ = http2.ConfigureTransport(transp)
+	transp := http.DefaultTransport.(*http.Transport).Clone()
+	transp.Proxy = http.ProxyFromEnvironment
+	transp.DialContext = dialer.DialContext
+	transp.MaxIdleConns = 100
+	transp.IdleConnTimeout = 90 * time.Second
+	transp.TLSHandshakeTimeout = 10 * time.Second
+	transp.ExpectContinueTimeout = 1 * time.Second
+	transp.MaxIdleConnsPerHost = runtime.GOMAXPROCS(0) + 1
 
 	return transp
 }

--- a/client.go
+++ b/client.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/net/http2"
 )
 
 const (
@@ -971,7 +973,7 @@ func createTransport(localAddr net.Addr) *http.Transport {
 	if localAddr != nil {
 		dialer.LocalAddr = localAddr
 	}
-	return &http.Transport{
+	transp := &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
 		DialContext:           dialer.DialContext,
 		MaxIdleConns:          100,
@@ -980,4 +982,7 @@ func createTransport(localAddr net.Addr) *http.Transport {
 		ExpectContinueTimeout: 1 * time.Second,
 		MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
 	}
+	_ = http2.ConfigureTransport(transp)
+
+	return transp
 }

--- a/client_test.go
+++ b/client_test.go
@@ -196,7 +196,7 @@ func TestClientSetRootCertificateNotExists(t *testing.T) {
 	transport, err := client.transport()
 
 	assertNil(t, err)
-	assertNil(t, transport.TLSClientConfig.RootCAs)
+	assertNotNil(t, transport.TLSClientConfig)
 }
 
 func TestClientSetRootCertificateFromString(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -196,7 +196,7 @@ func TestClientSetRootCertificateNotExists(t *testing.T) {
 	transport, err := client.transport()
 
 	assertNil(t, err)
-	assertNil(t, transport.TLSClientConfig)
+	assertNil(t, transport.TLSClientConfig.RootCAs)
 }
 
 func TestClientSetRootCertificateFromString(t *testing.T) {


### PR DESCRIPTION
Resty does not use http2 golang conn. Forcing attempt option in transport allow resty to use http2