### PR TITLE
make default retry not on middlewares errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -784,14 +784,14 @@ func (c *Client) execute(req *Request) (*Response, error) {
 	// to modify the *resty.Request object
 	for _, f := range c.udBeforeRequest {
 		if err = f(c, req); err != nil {
-			return nil, err
+			return nil, wrapNoRetryErr(err)
 		}
 	}
 
 	// resty middlewares
 	for _, f := range c.beforeRequest {
 		if err = f(c, req); err != nil {
-			return nil, err
+			return nil, wrapNoRetryErr(err)
 		}
 	}
 
@@ -802,12 +802,12 @@ func (c *Client) execute(req *Request) (*Response, error) {
 	// call pre-request if defined
 	if c.preReqHook != nil {
 		if err = c.preReqHook(c, req.RawRequest); err != nil {
-			return nil, err
+			return nil, wrapNoRetryErr(err)
 		}
 	}
 
 	if err = requestLogger(c, req); err != nil {
-		return nil, err
+		return nil, wrapNoRetryErr(err)
 	}
 
 	req.Time = time.Now()
@@ -855,7 +855,7 @@ func (c *Client) execute(req *Request) (*Response, error) {
 		}
 	}
 
-	return response, err
+	return response, wrapNoRetryErr(err)
 }
 
 // getting TLS client config if not exists then create one

--- a/retry.go
+++ b/retry.go
@@ -99,10 +99,11 @@ func Backoff(operation func() (*Response, error), options ...Option) error {
 			return err
 		}
 
-		needsRetry := err != nil // retry on operation errors by default
+		err1 := unwrapNoRetryErr(err)           // raw error, it used for return users callback.
+		needsRetry := err != nil && err == err1 // retry on a few operation errors by default
 
 		for _, condition := range opts.retryConditions {
-			needsRetry = condition(resp, err)
+			needsRetry = condition(resp, err1)
 			if needsRetry {
 				break
 			}

--- a/util.go
+++ b/util.go
@@ -331,3 +331,25 @@ func copyHeaders(hdrs http.Header) http.Header {
 	}
 	return nh
 }
+
+type noRetryErr struct {
+	err error
+}
+
+func (e *noRetryErr) Error() string {
+	return e.err.Error()
+}
+
+func wrapNoRetryErr(err error) error {
+	if err != nil {
+		err = &noRetryErr{err: err}
+	}
+	return err
+}
+
+func unwrapNoRetryErr(err error) error {
+	if e, ok := err.(*noRetryErr); ok {
+		err = e.err
+	}
+	return err
+}


### PR DESCRIPTION
This patch make default retry not on middlewares errors, which will make the retry action more sense and return error faster.