### PR TITLE
Fixed Debugf call in Request/Response logguer

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -325,7 +325,7 @@ func responseLogger(c *Client, res *Response) error {
 		}
 		debugLog += "==============================================================================\n"
 
-		c.log.Debugf(debugLog)
+		c.log.Debugf("%s", debugLog)
 	}
 
 	return nil


### PR DESCRIPTION
It was calling `Debugf(debugLog)` which tries to handle `%` parameters, resulting in strange logs. Must be called this way instead `Debugf("%s", debugLog)`