### PR TITLE
Fix trace timing for reused connections

### DIFF
--- a/request.go
+++ b/request.go
@@ -578,10 +578,15 @@ func (r *Request) TraceInfo() TraceInfo {
 		DNSLookup:     ct.dnsDone.Sub(ct.dnsStart),
 		TLSHandshake:  ct.tlsHandshakeDone.Sub(ct.tlsHandshakeStart),
 		ServerTime:    ct.gotFirstResponseByte.Sub(ct.gotConn),
-		TotalTime:     ct.endTime.Sub(ct.dnsStart),
 		IsConnReused:  ct.gotConnInfo.Reused,
 		IsConnWasIdle: ct.gotConnInfo.WasIdle,
 		ConnIdleTime:  ct.gotConnInfo.IdleTime,
+	}
+
+	if ct.gotConnInfo.Reused {
+		ti.TotalTime = ct.endTime.Sub(ct.getConn)
+	} else {
+		ti.TotalTime = ct.endTime.Sub(ct.dnsStart)
 	}
 
 	// Only calcuate on successful connections

--- a/request_test.go
+++ b/request_test.go
@@ -1602,6 +1602,7 @@ func TestTraceInfo(t *testing.T) {
 		assertEqual(t, true, tr.ServerTime >= 0)
 		assertEqual(t, true, tr.ResponseTime >= 0)
 		assertEqual(t, true, tr.TotalTime >= 0)
+		assertEqual(t, true, tr.TotalTime < time.Hour)
 		assertEqual(t, true, tr.TotalTime == resp.Time())
 	}
 


### PR DESCRIPTION
When a connection is reused, the normal trace hooks are skipped, which
led to an incorrect calculation of TotalTime (essentially doing a zero
minus now calculation). Detect connection reuse and use a different
calculation for TotalTime.

Fixes #346