### PR TITLE
README: Add clarification on Request.RawRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   * [Request](https://godoc.org/github.com/go-resty/resty#Request) Body can be `string`, `[]byte`, `struct`, `map`, `slice` and `io.Reader` too
     * Auto detects `Content-Type`
     * Buffer less processing for `io.Reader`
+    * Native `*http.Request` instance may be accessed during middleware and request execution via `Request.RawRequest`
     * Request Body can be read multiple times via `Request.RawRequest.GetBody()`
   * [Response](https://godoc.org/github.com/go-resty/resty#Response) object gives you more possibility
     * Access as `[]byte` array - `response.Body()` OR Access as `string` - `response.String()`


### PR DESCRIPTION
This PR adds an additional bullet about `Request.RawRequest`, since consumers may wrongly assume that the native request is available at all times but in fact it is only instantiated once the resty Request starts executing an action