### PR TITLE
Fix - request: execute user defined middlewares after resty's internal middlewares

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: go
 
-sudo: false
+os: linux
 
 go: # use travis ci resource effectively, keep always latest 2 versions and tip :) 
+  - 1.15.x
   - 1.14.x
-  - 1.13.x
   - tip
 
 install:
@@ -16,6 +16,6 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
-matrix:
+jobs:
   allow_failures:
     - go: tip

--- a/client.go
+++ b/client.go
@@ -795,16 +795,16 @@ func (c *Client) execute(req *Request) (*Response, error) {
 	// Apply Request middleware
 	var err error
 
-	// user defined on before request methods
-	// to modify the *resty.Request object
-	for _, f := range c.udBeforeRequest {
+	// resty middlewares
+	for _, f := range c.beforeRequest {
 		if err = f(c, req); err != nil {
 			return nil, wrapNoRetryErr(err)
 		}
 	}
 
-	// resty middlewares
-	for _, f := range c.beforeRequest {
+	// user defined on before request methods
+	// to modify the *resty.Request object
+	for _, f := range c.udBeforeRequest {
 		if err = f(c, req); err != nil {
 			return nil, wrapNoRetryErr(err)
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -234,6 +234,7 @@ func TestClientSetRootCertificateFromStringErrorTls(t *testing.T) {
 func TestClientOnBeforeRequestModification(t *testing.T) {
 	tc := dc()
 	tc.OnBeforeRequest(func(c *Client, r *Request) error {
+		assertNotNil(t, r.RawRequest)
 		r.SetAuthToken("This is test auth token")
 		return nil
 	})
@@ -610,3 +611,4 @@ func TestNewWithLocalAddr(t *testing.T) {
 	assertNil(t, err)
 	assertEqual(t, resp.String(), "TestGet: text response")
 }
+


### PR DESCRIPTION
This allows middlewares to properly access the RawRequest instance and follow their expected behavior according to OnBeforeRequest:

```
// OnBeforeRequest method appends request middleware into the before request chain.
// Its gets applied after default Resty request middlewares and before request
// been sent from Resty to host server.
```