### PR TITLE
Fix incorrect response time when saving the response file

### DIFF
--- a/client.go
+++ b/client.go
@@ -859,9 +859,10 @@ func (c *Client) execute(req *Request) (*Response, error) {
 			return response, err
 		}
 
-		response.setReceivedAt() // after we read the body
 		response.size = int64(len(response.body))
 	}
+
+	response.setReceivedAt() // after we read the body
 
 	// Apply Response middleware
 	for _, f := range c.afterResponse {

--- a/request_test.go
+++ b/request_test.go
@@ -1312,6 +1312,7 @@ func TestOutputFileWithBaseDirAndRelativePath(t *testing.T) {
 
 	assertError(t, err)
 	assertEqual(t, true, resp.Size() != 0)
+	assertEqual(t, true, resp.Time() > 0)
 }
 
 func TestOutputFileWithBaseDirError(t *testing.T) {
@@ -1336,6 +1337,7 @@ func TestOutputPathDirNotExists(t *testing.T) {
 
 	assertError(t, err)
 	assertEqual(t, true, resp.Size() != 0)
+	assertEqual(t, true, resp.Time() > 0)
 }
 
 func TestOutputFileAbsPath(t *testing.T) {


### PR DESCRIPTION
When saving the response file, it was not recorded time.
as a result, incorrect calculation of response time.