### PR TITLE
fix: get body size 0 (#300)

### DIFF
--- a/client.go
+++ b/client.go
@@ -54,6 +54,7 @@ var (
 	hdrContentLengthKey   = http.CanonicalHeaderKey("Content-Length")
 	hdrContentEncodingKey = http.CanonicalHeaderKey("Content-Encoding")
 	hdrAuthorizationKey   = http.CanonicalHeaderKey("Authorization")
+	hdrLocationKey        = http.CanonicalHeaderKey("Location")
 
 	plainTextType   = "text/plain; charset=utf-8"
 	jsonContentType = "application/json"

--- a/resty_test.go
+++ b/resty_test.go
@@ -287,6 +287,9 @@ func createPostServer(t *testing.T) *httptest.Server {
 
 					return
 				}
+			} else if r.URL.Path == "/redirect" {
+				w.Header().Set(hdrLocationKey, "/login")
+				w.WriteHeader(http.StatusTemporaryRedirect)
 			}
 		}
 	})


### PR DESCRIPTION
when the http status code is 307 or 308, the request.Body will be closed, after that the func GetBody will be called but the bodyBuf was closed, then we will get an error http: ContentLength=xxx with Body length 0