### PR TITLE
retry.go: Fix sleep computation for 32bit arch

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -167,11 +167,8 @@ defaultCase:
 	capLevel := float64(max)
 
 	temp := math.Min(capLevel, base*math.Exp2(float64(attempt)))
-	ri := int(temp / 2)
-	if ri <= 0 {
-		ri = maxInt // max int for arch 386
-	}
-	result := time.Duration(math.Abs(float64(ri + rand.Intn(ri))))
+	ri := int64(temp / 2)
+	result := time.Duration(math.Abs(float64(ri + rand.Int63n(ri))))
 
 	if result < min {
 		result = min


### PR DESCRIPTION
Hello there.

The following commit fix the tests execution on 32bits arch. 
I have tested it on a armhf (32bit) Debian machine and confirm it's working.

Cheers!

Closes: https://github.com/go-resty/resty/issues/386