### PR TITLE
fix:when SetRetryCount -1, both resp and error are nil.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -590,6 +590,7 @@ func TestLogCallbacks(t *testing.T) {
 		Get(ts.URL + "/profile")
 	assertEqual(t, errors.New("request test error"), err)
 	assertNil(t, resp)
+	assertNotNil(t, err)
 
 	c.OnRequestLog(nil)
 	c.OnResponseLog(func(r *ResponseLog) error { return errors.New("response test error") })

--- a/request_test.go
+++ b/request_test.go
@@ -48,6 +48,16 @@ func TestGet(t *testing.T) {
 	logResponse(t, resp)
 }
 
+func TestIllegalRetryCount(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	resp, err := dc().SetRetryCount(-1).R().Get(ts.URL + "/")
+
+	assertNil(t, err)
+	assertNil(t, resp)
+}
+
 func TestGetCustomUserAgent(t *testing.T) {
 	ts := createGetServer(t)
 	defer ts.Close()


### PR DESCRIPTION
I add a test for this behavior, I think it is a bug.