### PR TITLE
feature: add OnError hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,28 @@ client.OnAfterResponse(func(c *resty.Client, resp *resty.Response) error {
   })
 ```
 
+#### OnError Hooks
+
+Resty provides OnError hooks that may be called because:
+
+- The client failed to send the request due to connection timeout, TLS handshake failure, etc...
+- The request was retried the maximum amount of times, and still failed.
+
+If there was a response from the server, the original error will be wrapped in `*resty.ResponseError` which contains the last response received.
+
+```go
+// Create a Resty Client
+client := resty.New()
+
+client.OnError(func(req *resty.Request, err error) {
+  if v, ok := err.(*resty.ResponseError); ok {
+    // v.Response contains the last response from the server
+    // v.Err contains the original error
+  }
+  // Log the error, increment a metric, etc...
+})
+```
+
 #### Redirect Policy
 
 Resty provides few ready to use redirect policy(s) also it supports multiple policies together.

--- a/client.go
+++ b/client.go
@@ -388,7 +388,7 @@ func (c *Client) OnAfterResponse(m ResponseMiddleware) *Client {
 	return c
 }
 
-// OnError method adds a callback that will be run whenever a request execution fails
+// OnError method adds a callback that will be run whenever a request execution fails.
 // This is called after all retries have been attempted (if any).
 // If there was a response from the server, the error will be wrapped in *ResponseError
 // which has the last response received from the server.
@@ -922,8 +922,8 @@ func (c *Client) outputLogTo(w io.Writer) *Client {
 	return c
 }
 
-// ResponseError is a wrapper for including the server response with an error
-// neither the err nor the response should be nil
+// ResponseError is a wrapper for including the server response with an error.
+// Neither the err nor the response should be nil.
 type ResponseError struct {
 	Response *Response
 	Err      error
@@ -937,8 +937,8 @@ func (e *ResponseError) Unwrap() error {
 	return e.Err
 }
 
-// helper to run onErrorHooks hooks.
-// it wraps the error in a ResponseError if the resp is not nil
+// Helper to run onErrorHooks hooks.
+// It wraps the error in a ResponseError if the resp is not nil
 // so hooks can access it.
 func (c *Client) onErrorHooks(req *Request, resp *Response, err error) {
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -84,7 +84,7 @@ type (
 	ResponseLogCallback func(*ResponseLog) error
 
 	// ErrorHook type is for reacting to request errors, called after all retries were attempted
-	ErrorHook func(error)
+	ErrorHook func(*Request, error)
 )
 
 // Client struct is used to create Resty client with client level settings,
@@ -393,7 +393,7 @@ func (c *Client) OnAfterResponse(m ResponseMiddleware) *Client {
 // If there was a response from the server, the error will be wrapped in *ResponseError
 // which has the last response received from the server.
 //
-//		client.OnError(func(err error) {
+//		client.OnError(func(req *resty.Request, err error) {
 //			if v, ok := err.(*resty.ResponseError); ok {
 //				// Do something with v.Response
 //			}
@@ -940,13 +940,13 @@ func (e *ResponseError) Unwrap() error {
 // helper to run onErrorHooks hooks.
 // it wraps the error in a ResponseError if the resp is not nil
 // so hooks can access it.
-func (c *Client) onErrorHooks(resp *Response, err error) {
+func (c *Client) onErrorHooks(req *Request, resp *Response, err error) {
 	if err != nil {
 		if resp != nil { // wrap with ResponseError
 			err = &ResponseError{Response: resp, Err: err}
 		}
 		for _, h := range c.errorHooks {
-			h(err)
+			h(req, err)
 		}
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -699,3 +699,13 @@ func TestClientOnResponseError(t *testing.T) {
 		})
 	}
 }
+
+func TestResponseError(t *testing.T) {
+	err := errors.New("error message")
+	re := &ResponseError{
+		Response: &Response{},
+		Err:      err,
+	}
+	assertNotNil(t, re.Unwrap())
+	assertEqual(t, err.Error(), re.Error())
+}

--- a/client_test.go
+++ b/client_test.go
@@ -683,7 +683,7 @@ func TestClientOnResponseError(t *testing.T) {
 					}
 					return response.IsError()
 				}).
-				OnError(func(err error) {
+				OnError(func(r *Request, err error) {
 					errs++
 				})
 			if test.setup != nil {

--- a/request.go
+++ b/request.go
@@ -680,12 +680,14 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 	var err error
 
 	if r.isMultiPart && !(method == MethodPost || method == MethodPut || method == MethodPatch) {
+		// No OnError hook here since this is a request validation error
 		return nil, fmt.Errorf("multipart content is not allowed in HTTP verb [%v]", method)
 	}
 
 	if r.SRV != nil {
 		_, addrs, err = net.LookupSRV(r.SRV.Service, "tcp", r.SRV.Domain)
 		if err != nil {
+			r.client.onErrorHooks(r, nil, err)
 			return nil, err
 		}
 	}

--- a/request.go
+++ b/request.go
@@ -696,6 +696,7 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 	if r.client.RetryCount == 0 {
 		r.Attempt = 1
 		resp, err = r.client.execute(r)
+		r.client.onErrorHooks(unwrapNoRetryErr(err))
 		return resp, unwrapNoRetryErr(err)
 	}
 
@@ -717,6 +718,8 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 		MaxWaitTime(r.client.RetryMaxWaitTime),
 		RetryConditions(r.client.RetryConditions),
 	)
+
+	r.client.onErrorHooks(unwrapNoRetryErr(err))
 
 	return resp, unwrapNoRetryErr(err)
 }

--- a/request.go
+++ b/request.go
@@ -696,7 +696,7 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 	if r.client.RetryCount == 0 {
 		r.Attempt = 1
 		resp, err = r.client.execute(r)
-		r.client.onErrorHooks(unwrapNoRetryErr(err))
+		r.client.onErrorHooks(resp, unwrapNoRetryErr(err))
 		return resp, unwrapNoRetryErr(err)
 	}
 
@@ -719,7 +719,7 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 		RetryConditions(r.client.RetryConditions),
 	)
 
-	r.client.onErrorHooks(unwrapNoRetryErr(err))
+	r.client.onErrorHooks(resp, unwrapNoRetryErr(err))
 
 	return resp, unwrapNoRetryErr(err)
 }

--- a/request.go
+++ b/request.go
@@ -696,7 +696,7 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 	if r.client.RetryCount == 0 {
 		r.Attempt = 1
 		resp, err = r.client.execute(r)
-		r.client.onErrorHooks(resp, unwrapNoRetryErr(err))
+		r.client.onErrorHooks(r, resp, unwrapNoRetryErr(err))
 		return resp, unwrapNoRetryErr(err)
 	}
 
@@ -719,7 +719,7 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 		RetryConditions(r.client.RetryConditions),
 	)
 
-	r.client.onErrorHooks(resp, unwrapNoRetryErr(err))
+	r.client.onErrorHooks(r, resp, unwrapNoRetryErr(err))
 
 	return resp, unwrapNoRetryErr(err)
 }


### PR DESCRIPTION
Adds a new hook that is called when a rest request returns an error.
This is called when the err returned by client.execute is non-nil, and
it is only called after all retry attempts have been exhausted.

This feature is intended to support logging, metrics, tracing on request
errors that otherwise cannot be captured with OnAfterResponse, such as
TLS Connection errors. It also provides a way to report response errors
only once after retries have been attempted, to avoid emitting error
logs when a request ultimately succeeds.