### PR TITLE
move udBeforeRequest before beforeRequest again & preReqHooks instead…

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -266,25 +266,30 @@ func TestClientOnBeforeRequestModification(t *testing.T) {
 
 func TestClientOnPreRequestModification(t *testing.T) {
 	tc := dc()
+
 	tc.OnPreRequest(func(c *Client, r *http.Request) error {
-		r.Header.Set("aaa", "bbb")
+		r.Header.Set("aaa", "000")
+		return nil
+	})
+	tc.SetPreRequestHook(func(c *Client, r *http.Request) error {
+		r.Header.Set("bbb", "111")
 		return nil
 	})
 	tc.OnPreRequest(func(c *Client, r *http.Request) error {
-		r.Header.Set("ccc", "ddd")
+		r.Header.Set("ccc", "222")
 		return nil
 	})
 
 	ts := createGetServer(t)
 	defer ts.Close()
 
-	resp, err := tc.R().Get(ts.URL + "/get-headers?headers=aaa,ccc")
+	resp, err := tc.R().Get(ts.URL + "/get-headers?headers=aaa,bbb,ccc")
 
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
 	assertEqual(t, "200 OK", resp.Status())
 	assertNotNil(t, resp.Body())
-	assertEqual(t, "bbb,ddd", resp.String())
+	assertEqual(t, ",111,222", resp.String())
 
 	logResponse(t, resp)
 }

--- a/resty_test.go
+++ b/resty_test.go
@@ -111,6 +111,13 @@ func createGetServer(t *testing.T) *httptest.Server {
 				_, _ = w.Write(body)
 			case "/host-header":
 				_, _ = w.Write([]byte(r.Host))
+			case "/get-headers":
+				keys := strings.Split(r.FormValue("headers"), ",")
+				var values []string
+				for _, key := range keys {
+					values = append(values, r.Header.Get(key))
+				}
+				_, _ = io.WriteString(w, strings.Join(values, ","))
 			}
 
 			switch {


### PR DESCRIPTION
As #408 reported, many RequestMiddlewares will be invalid when move udBeforeRequest after beforeRequest introduced in v2.4.0, thus all RequestMiddlewares have to change to modify RawReqest directly while not the Request. In the mean time, I noticed that for RequestMiddleware in v2.3.0, there is no way to access or manipulate the RawRequest, but there is another hook: PreRequestHook can meet the requirement, but I think it's better to support a list of PeRequestHook, so I modify the preRequestHook to preRequestHooks.