### PR TITLE
Feat: Add Retry hooks

### DIFF
--- a/client.go
+++ b/client.go
@@ -108,6 +108,7 @@ type Client struct {
 	RetryWaitTime         time.Duration
 	RetryMaxWaitTime      time.Duration
 	RetryConditions       []RetryConditionFunc
+	RetryHooks            []OnRetryFunc
 	RetryAfter            RetryAfterFunc
 	JSONMarshal           func(v interface{}) ([]byte, error)
 	JSONUnmarshal         func(data []byte, v interface{}) error
@@ -588,6 +589,13 @@ func (c *Client) AddRetryAfterErrorCondition() *Client {
 
 		return false
 	})
+	return c
+}
+
+// AddRetryHook adds a side-effecting retry hook to an array of hooks
+// that will be executed on each retry.
+func (c *Client) AddRetryHook(hook OnRetryFunc) *Client {
+	c.RetryHooks = append(c.RetryHooks, hook)
 	return c
 }
 

--- a/request.go
+++ b/request.go
@@ -733,6 +733,7 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 		WaitTime(r.client.RetryWaitTime),
 		MaxWaitTime(r.client.RetryMaxWaitTime),
 		RetryConditions(r.client.RetryConditions),
+		RetryHooks(r.client.RetryHooks),
 	)
 
 	r.client.onErrorHooks(r, resp, unwrapNoRetryErr(err))


### PR DESCRIPTION
Add RetryHooks: side-effecting functions that will be executed whenever a retry is triggered.

RetryHooks give users the ability to add side-effecting operations whenever a retry is triggered, without having to abuse the RetryConditions or using the Backoff directly. For example, RetryHooks allow you to log whenever a retry is triggered.

Fixes #416 