### PR TITLE
Don't use sync.Pool for json.NewEncoder target buffers

### DIFF
--- a/client.go
+++ b/client.go
@@ -833,7 +833,6 @@ func (c *Client) GetClient() *http.Client {
 // Executes method executes the given `Request` object and returns response
 // error.
 func (c *Client) execute(req *Request) (*Response, error) {
-	defer releaseBuffer(req.bodyBuf)
 	// Apply Request middleware
 	var err error
 
@@ -866,6 +865,8 @@ func (c *Client) execute(req *Request) (*Response, error) {
 	if err = requestLogger(c, req); err != nil {
 		return nil, wrapNoRetryErr(err)
 	}
+
+	req.RawRequest.Body = newRequestBodyReleaser(req.RawRequest.Body, req.bodyBuf)
 
 	req.Time = time.Now()
 	resp, err := c.httpClient.Do(req.RawRequest)

--- a/middleware.go
+++ b/middleware.go
@@ -458,7 +458,7 @@ func handleRequestBody(c *Client, r *Request) (err error) {
 		bodyBytes = []byte(s)
 	} else if IsJSONType(contentType) &&
 		(kind == reflect.Struct || kind == reflect.Map || kind == reflect.Slice) {
-		bodyBytes, err = jsonMarshal(c, r, r.Body)
+		r.bodyBuf, err = jsonMarshal(c, r, r.Body)
 		if err != nil {
 			return
 		}

--- a/request.go
+++ b/request.go
@@ -838,11 +838,14 @@ func (r *Request) initValuesMap() {
 	}
 }
 
-var noescapeJSONMarshal = func(v interface{}) ([]byte, error) {
+var noescapeJSONMarshal = func(v interface{}) (*bytes.Buffer, error) {
 	buf := acquireBuffer()
-	defer releaseBuffer(buf)
 	encoder := json.NewEncoder(buf)
 	encoder.SetEscapeHTML(false)
-	err := encoder.Encode(v)
-	return buf.Bytes(), err
+	if err := encoder.Encode(v); err != nil {
+		releaseBuffer(buf)
+		return nil, err
+	}
+
+	return buf, nil
 }

--- a/util.go
+++ b/util.go
@@ -139,13 +139,19 @@ type ResponseLog struct {
 //_______________________________________________________________________
 
 // way to disable the HTML escape as opt-in
-func jsonMarshal(c *Client, r *Request, d interface{}) ([]byte, error) {
-	if !r.jsonEscapeHTML {
-		return noescapeJSONMarshal(d)
-	} else if !c.jsonEscapeHTML {
+func jsonMarshal(c *Client, r *Request, d interface{}) (*bytes.Buffer, error) {
+	if !r.jsonEscapeHTML || !c.jsonEscapeHTML {
 		return noescapeJSONMarshal(d)
 	}
-	return c.JSONMarshal(d)
+
+	data, err := c.JSONMarshal(d)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := acquireBuffer()
+	_, _ = buf.Write(data)
+	return buf, nil
 }
 
 func firstNonEmpty(v ...string) string {


### PR DESCRIPTION
The slice returned by `noescapeJSONMarshal` continues to be accessed
even after `pool.Put` was called on the buffer. This might lead to
incorrect data being sent in request body if the buffer is acquired and
re-written by a concurrently running goroutine.
