### PR TITLE
Update Bazel build to work with 4.0.0

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,36 +1,48 @@
-package(default_visibility = ["//visibility:private"])
-
-load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@bazel_gazelle//:def.bzl", "gazelle")
 
-gazelle(
-    name = "gazelle",
-    command = "fix",
-    prefix = "github.com/go-resty/resty/v2",
-)
+# gazelle:prefix github.com/go-resty/resty/v2
+# gazelle:go_naming_convention import_alias
+gazelle(name = "gazelle")
 
 go_library(
-    name = "go_default_library",
-    srcs = glob(
-        ["*.go"],
-        exclude = ["*_test.go"],
-    ),
+    name = "resty",
+    srcs = [
+        "client.go",
+        "middleware.go",
+        "redirect.go",
+        "request.go",
+        "response.go",
+        "resty.go",
+        "retry.go",
+        "trace.go",
+        "transport.go",
+        "transport112.go",
+        "util.go",
+    ],
     importpath = "github.com/go-resty/resty/v2",
     visibility = ["//visibility:public"],
     deps = ["@org_golang_x_net//publicsuffix:go_default_library"],
 )
 
 go_test(
-    name = "go_default_test",
-    srcs =
-        glob(
-            ["*_test.go"],
-            exclude = ["example_test.go"],
-        ),
-    data = glob([".testdata/*"]),
-    embed = [":go_default_library"],
-    importpath = "github.com/go-resty/resty/v2",
-    deps = [
-        "@org_golang_x_net//proxy:go_default_library",
+    name = "resty_test",
+    srcs = [
+        "client_test.go",
+        "context_test.go",
+        "example_test.go",
+        "request_test.go",
+        "resty_test.go",
+        "retry_test.go",
+        "util_test.go",
     ],
+    data = glob([".testdata/*"]),
+    embed = [":resty"],
+    deps = ["@org_golang_x_net//proxy:go_default_library"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":resty",
+    visibility = ["//visibility:public"],
 )

--- a/README.md
+++ b/README.md
@@ -835,7 +835,7 @@ Resty can be built, tested and depended upon via [Bazel](https://bazel.build).
 For example, to run all tests:
 
 ```shell
-bazel test :go_default_test
+bazel test :resty_test
 ```
 
 #### Mocking http requests using [httpmock](https://github.com/jarcoal/httpmock) library

--- a/README.md
+++ b/README.md
@@ -829,7 +829,7 @@ client.SetTransport(&transport).SetScheme("http").SetHostURL(unixSocket)
 client.R().Get("/index.html")
 ```
 
-#### Bazel support
+#### Bazel Support
 
 Resty can be built, tested and depended upon via [Bazel](https://bazel.build).
 For example, to run all tests:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,26 +1,30 @@
 workspace(name = "resty")
 
-git_repository(
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
     name = "io_bazel_rules_go",
-    remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.13.0",
+    sha256 = "69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+    ],
 )
 
-git_repository(
+http_archive(
     name = "bazel_gazelle",
-    remote = "https://github.com/bazelbuild/bazel-gazelle.git",
-    tag = "0.13.0",
+    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+    ],
 )
 
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_rules_dependencies",
-    "go_register_toolchains",
-)
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
-go_register_toolchains()
+go_register_toolchains(version = "1.16")
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 


### PR DESCRIPTION
This includes several updates to the BUILD and WORKSPACE files, so that they now work with Bazel 4.0.0, Gazelle 0.23 and rules_go 0.27.

By default, [Gazelle now uses](https://github.com/bazelbuild/bazel-gazelle/pull/863) the last component of the Bazel package, rather than `go_default_library` as the `go_library name`.

This causes problems when the naming conventions do not match.
https://github.com/bazelbuild/bazel-gazelle/issues/890#issuecomment-685145667

Adding support for the new naming convention should not break anything that depends on using the old naming convention, because the Gazelle option `import_alias` makes aliases to the libraries and this allows the old naming convention to still work.