### PR TITLE
Handle EOF from multipart form file readers

### DIFF
--- a/util.go
+++ b/util.go
@@ -202,7 +202,7 @@ func writeMultipartFormFile(w *multipart.Writer, fieldName, fileName string, r i
 	// Auto detect actual multipart content type
 	cbuf := make([]byte, 512)
 	size, err := r.Read(cbuf)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return err
 	}
 

--- a/util_test.go
+++ b/util_test.go
@@ -5,6 +5,8 @@
 package resty
 
 import (
+	"bytes"
+	"mime/multipart"
 	"testing"
 )
 
@@ -78,4 +80,18 @@ func TestIsXMLType(t *testing.T) {
 			t.Errorf("failed on %q: want %v, got %v", test.input, test.expect, result)
 		}
 	}
+}
+
+func TestWriteMultipartFormFileReaderEmpty(t *testing.T) {
+	w := multipart.NewWriter(bytes.NewBuffer(nil))
+	defer func() { _ = w.Close() }()
+	if err := writeMultipartFormFile(w, "foo", "bar", bytes.NewReader(nil)); err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+}
+
+func TestWriteMultipartFormFileReaderError(t *testing.T) {
+	err := writeMultipartFormFile(nil, "", "", &brokenReadCloser{})
+	assertNotNil(t, err)
+	assertEqual(t, "read error", err.Error())
 }


### PR DESCRIPTION
I stumbled on a bug when trying to send a multipart file that happened to be a gzip reader downloaded from elsewhere. Looks like the multipart content type detection logic doesn't handle `EOF` correctly. This can also be easily reproduced by sending an empty file (`bytes.NewReader(nil)`).

Here's a self contained example that reproduces the issue with a gzipped string:
```go
b := bytes.NewBuffer(nil)
w := gzip.NewWriter(b)
if _, err := w.Write([]byte("foo")); err != nil {
	panic(err)
}
if err := w.Close(); err != nil {
	panic(err)
}
r, err := gzip.NewReader(b)
if err != nil {
	panic(err)
}
_, err = resty.New().NewRequest().SetFileReader("file", "foo.bar", r).Post("http://foo.bar")
if err != nil {
	panic(err) // EOF!
}
```

----

Closes #431 