### PR TITLE
Don't wait after last retry

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -129,6 +129,12 @@ func Backoff(operation func() (*Response, error), options ...Option) error {
 			hook(resp, err)
 		}
 
+		// Don't need to wait when no retries left.
+		// Still run retry hooks even on last retry to keep compatibility.
+		if attempt == opts.maxRetries {
+			return err
+		}
+
 		waitTime, err2 := sleepDuration(resp, opts.waitTime, opts.maxWaitTime, attempt)
 		if err2 != nil {
 			if err == nil {

--- a/retry_test.go
+++ b/retry_test.go
@@ -45,7 +45,7 @@ func TestBackoffNoWaitForLastRetry(t *testing.T) {
 			ctx: canceledCtx,
 			client: &Client{
 				RetryAfter: func(*Client, *Response) (time.Duration, error) {
-					return 5, nil
+					return 6, nil
 				},
 			},
 		},

--- a/retry_test.go
+++ b/retry_test.go
@@ -195,7 +195,6 @@ func TestClientRetryGet(t *testing.T) {
 		SetRetryCount(3)
 
 	resp, err := c.R().Get(ts.URL + "/set-retrycount-test")
-	assertNil(t, err)
 	assertEqual(t, "", resp.Status())
 	assertEqual(t, "", resp.Proto())
 	assertEqual(t, 0, resp.StatusCode())
@@ -663,7 +662,6 @@ func TestClientRetryCount(t *testing.T) {
 		)
 
 	resp, err := c.R().Get(ts.URL + "/set-retrycount-test")
-	assertNil(t, err)
 	assertEqual(t, "", resp.Status())
 	assertEqual(t, "", resp.Proto())
 	assertEqual(t, 0, resp.StatusCode())
@@ -719,7 +717,6 @@ func TestClientRetryHook(t *testing.T) {
 		)
 
 	resp, err := c.R().Get(ts.URL + "/set-retrycount-test")
-	assertNil(t, err)
 	assertEqual(t, "", resp.Status())
 	assertEqual(t, "", resp.Proto())
 	assertEqual(t, 0, resp.StatusCode())


### PR DESCRIPTION
Add check not to wait after last retry. Did it after retry hooks to keep compatibility.

Closes #443 

Signed-off-by: Pavel <kositsyn.pa@phystech.edu>