### PR TITLE
feat(#432): Implement Easier Adding of Multiple Value HTTP Header

### DIFF
--- a/request.go
+++ b/request.go
@@ -132,9 +132,7 @@ func (r *Request) SetMultiValueHeaders(headers map[string][]string) *Request {
 
 		if len(values) > 1 {
 			headerValue = strings.Join(values, ", ")
-		}
-
-		if len(values) == 1 {
+		} else {
 			headerValue = values[0]
 		}
 

--- a/request.go
+++ b/request.go
@@ -126,7 +126,7 @@ func (r *Request) SetHeaders(headers map[string]string) *Request {
 //				"Accept": []string{"text/html", "application/xhtml+xml", "application/xml;q=0.9", "image/webp", "*/*;q=0.8"},
 //			})
 // Also you can override header value, which was set at client instance level.
-func (r *Request) SetMultiValueHeaders(headers map[string][]string) *Request {
+func (r *Request) SetHeaderMultiValues(headers map[string][]string) *Request {
 	for key, values := range headers {
 		r.SetHeader(key, strings.Join(values, ", "))
 	}

--- a/request.go
+++ b/request.go
@@ -117,6 +117,32 @@ func (r *Request) SetHeaders(headers map[string]string) *Request {
 	return r
 }
 
+// SetMultiValueHeaders sets multiple headers fields and its values is list of strings at one go in the current request.
+//
+// For Example: To set `Accept` as `text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, */*;q=0.8`
+//
+// 		client.R().
+//			SetMultiValueHeaders(map[string][]string{
+//				"Accept": []string{"text/html", "application/xhtml+xml", "application/xml;q=0.9", "image/webp", "*/*;q=0.8"},
+//			})
+// Also you can override header value, which was set at client instance level.
+func (r *Request) SetMultiValueHeaders(headers map[string][]string) *Request {
+	for key, values := range headers {
+		var headerValue string
+
+		if len(values) > 1 {
+			headerValue = strings.Join(values, ", ")
+		}
+
+		if len(values) == 1 {
+			headerValue = values[0]
+		}
+
+		r.SetHeader(key, headerValue)
+	}
+	return r
+}
+
 // SetHeaderVerbatim method is to set a single header field and its value verbatim in the current request.
 //
 // For Example: To set `all_lowercase` and `UPPERCASE` as `available`.

--- a/request.go
+++ b/request.go
@@ -117,12 +117,12 @@ func (r *Request) SetHeaders(headers map[string]string) *Request {
 	return r
 }
 
-// SetMultiValueHeaders sets multiple headers fields and its values is list of strings at one go in the current request.
+// SetHeaderMultiValues sets multiple headers fields and its values is list of strings at one go in the current request.
 //
 // For Example: To set `Accept` as `text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, */*;q=0.8`
 //
 // 		client.R().
-//			SetMultiValueHeaders(map[string][]string{
+//			SetHeaderMultiValues(map[string][]string{
 //				"Accept": []string{"text/html", "application/xhtml+xml", "application/xml;q=0.9", "image/webp", "*/*;q=0.8"},
 //			})
 // Also you can override header value, which was set at client instance level.

--- a/request.go
+++ b/request.go
@@ -128,15 +128,7 @@ func (r *Request) SetHeaders(headers map[string]string) *Request {
 // Also you can override header value, which was set at client instance level.
 func (r *Request) SetMultiValueHeaders(headers map[string][]string) *Request {
 	for key, values := range headers {
-		var headerValue string
-
-		if len(values) > 1 {
-			headerValue = strings.Join(values, ", ")
-		} else {
-			headerValue = values[0]
-		}
-
-		r.SetHeader(key, headerValue)
+		r.SetHeader(key, strings.Join(values, ", "))
 	}
 	return r
 }

--- a/request_test.go
+++ b/request_test.go
@@ -1381,6 +1381,7 @@ func TestSetHeaderMultipleValue(t *testing.T) {
 			"Authorization": []string{"Bearer xyz"},
 		})
 	assertEqual(t, "text/*, text/html, *", r.Header.Get("content"))
+	assertEqual(t, "Bearer xyz", r.Header.Get("authorization"))
 }
 
 func TestOutputFileWithBaseDirAndRelativePath(t *testing.T) {

--- a/request_test.go
+++ b/request_test.go
@@ -1371,6 +1371,18 @@ func TestSetHeaderVerbatim(t *testing.T) {
 	assertEqual(t, "value_standard", r.Header.Get("Header-Lowercase"))
 }
 
+func TestSetHeaderMultipleValue(t *testing.T) {
+	ts := createPostServer(t)
+	defer ts.Close()
+
+	r := dclr().
+		SetMultiValueHeaders(map[string][]string{
+			"Content":       []string{"text/*", "text/html", "*"},
+			"Authorization": []string{"Bearer xyz"},
+		})
+	assertEqual(t, "text/*, text/html, *", r.Header.Get("content"))
+}
+
 func TestOutputFileWithBaseDirAndRelativePath(t *testing.T) {
 	ts := createGetServer(t)
 	defer ts.Close()

--- a/request_test.go
+++ b/request_test.go
@@ -1376,7 +1376,7 @@ func TestSetHeaderMultipleValue(t *testing.T) {
 	defer ts.Close()
 
 	r := dclr().
-		SetMultiValueHeaders(map[string][]string{
+		SetHeaderMultiValues(map[string][]string{
 			"Content":       []string{"text/*", "text/html", "*"},
 			"Authorization": []string{"Bearer xyz"},
 		})


### PR DESCRIPTION
Implement easier adding of multiple value HTTP Header with function `SetMultiValueHeaders`

Closes #432