### PR TITLE
Add request Scopes api, user can add parameters dynamically.

### DIFF
--- a/request.go
+++ b/request.go
@@ -604,6 +604,28 @@ func (r *Request) AddRetryCondition(condition RetryConditionFunc) *Request {
 	return r
 }
 
+// Scopes pass current request instance to arguments `func(*Request) *Request`,
+// which could be used to add parameters dynamically
+//     func TransferContentType(r *Request) *Request {
+//          return r.SetHeader("Content-Type", "application/json").
+//              SetHeader("Accept", "application/json")
+//     }
+//
+//     func PageParam(page, size int) func (r *Request) *Request  {
+//         return func(r *Request) *Request {
+//             return r.SetQueryParam("page", strconv.FormatInt(int64(page), 10)).
+//                  SetQueryParam("size", strconv.FormatInt(int64(size), 10))
+//         }
+//     }
+//
+//     r.Scopes(TransferContentType, PageParam(1, 100)).Get("https://localhost:8080/bar")
+func (r *Request) Scopes(funcs ...func(r *Request) *Request) *Request {
+	for _, f := range funcs {
+		r = f(r)
+	}
+	return r
+}
+
 //‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 // HTTP request tracing
 //_______________________________________________________________________


### PR DESCRIPTION
I want the Scopes api, which could be used to add parameters dynamically. It will be more flexible.
```go
func TransferContentType(r *resty.Request) *resty.Request {
	return r.SetHeader("Content-Type", "application/json").
		SetHeader("Accept", "application/json")
}

func PageParam(page, size int) func(r *resty.Request) *resty.Request {
	return func(r *resty.Request) *resty.Request {
		return r.SetQueryParam("page", strconv.FormatInt(int64(page), 10)).
			SetQueryParam("size", strconv.FormatInt(int64(size), 10))
	}
}

func main() {
	client := resty.New()

	client.Scopes(TransferContentType, PageParam(1, 100)).
		Get("https://localhost:8080/bar")
}
```