### PR TITLE
Make PathParams public

### DIFF
--- a/client.go
+++ b/client.go
@@ -95,6 +95,7 @@ type Client struct {
 	HostURL               string
 	QueryParam            url.Values
 	FormData              url.Values
+	PathParams            map[string]string
 	Header                http.Header
 	UserInfo              *User
 	Token                 string
@@ -125,7 +126,6 @@ type Client struct {
 	debugBodySizeLimit int64
 	outputDirectory    string
 	scheme             string
-	pathParams         map[string]string
 	log                Logger
 	httpClient         *http.Client
 	proxyURL           *url.URL
@@ -367,7 +367,7 @@ func (c *Client) R() *Request {
 		client:          c,
 		multipartFiles:  []*File{},
 		multipartFields: []*MultipartField{},
-		pathParams:      map[string]string{},
+		PathParams:      map[string]string{},
 		jsonEscapeHTML:  true,
 	}
 	return r
@@ -796,7 +796,7 @@ func (c *Client) SetDoNotParseResponse(parse bool) *Client {
 // Also it can be overridden at request level Path Params options,
 // see `Request.SetPathParam` or `Request.SetPathParams`.
 func (c *Client) SetPathParam(param, value string) *Client {
-	c.pathParams[param] = value
+	c.PathParams[param] = value
 	return c
 }
 
@@ -1062,7 +1062,7 @@ func createClient(hc *http.Client) *Client {
 		jsonEscapeHTML:         true,
 		httpClient:             hc,
 		debugBodySizeLimit:     math.MaxInt32,
-		pathParams:             make(map[string]string),
+		PathParams:             make(map[string]string),
 	}
 
 	// Logger

--- a/middleware.go
+++ b/middleware.go
@@ -29,13 +29,13 @@ const debugRequestLogKey = "__restyDebugRequestLog"
 
 func parseRequestURL(c *Client, r *Request) error {
 	// GitHub #103 Path Params
-	if len(r.pathParams) > 0 {
-		for p, v := range r.pathParams {
+	if len(r.PathParams) > 0 {
+		for p, v := range r.PathParams {
 			r.URL = strings.Replace(r.URL, "{"+p+"}", url.PathEscape(v), -1)
 		}
 	}
-	if len(c.pathParams) > 0 {
-		for p, v := range c.pathParams {
+	if len(c.PathParams) > 0 {
+		for p, v := range c.PathParams {
 			r.URL = strings.Replace(r.URL, "{"+p+"}", url.PathEscape(v), -1)
 		}
 	}

--- a/request.go
+++ b/request.go
@@ -33,6 +33,7 @@ type Request struct {
 	AuthScheme string
 	QueryParam url.Values
 	FormData   url.Values
+	PathParams map[string]string
 	Header     http.Header
 	Time       time.Time
 	Body       interface{}
@@ -60,7 +61,6 @@ type Request struct {
 	fallbackContentType string
 	forceContentType    string
 	ctx                 context.Context
-	pathParams          map[string]string
 	values              map[string]interface{}
 	client              *Client
 	bodyBuf             *bytes.Buffer
@@ -511,7 +511,7 @@ func (r *Request) SetDoNotParseResponse(parse bool) *Request {
 // It replaces the value of the key while composing the request URL. Also you can
 // override Path Params value, which was set at client instance level.
 func (r *Request) SetPathParam(param, value string) *Request {
-	r.pathParams[param] = value
+	r.PathParams[param] = value
 	return r
 }
 


### PR DESCRIPTION
This PR makes the `PathParams` property public, same as `QueryParam`, `FormData`, `Header`, etc.

I don't really see the value in having it private and it prevents me from adding a middleware to capture all the existing parameters.

Example:
```go
func InjectContextMiddleware(service string) resty.RequestMiddleware {
	return func(c *resty.Client, req *resty.Request) error {
		ctx := req.Context()
		ctx = logger.WithFields(ctx, map[string]interface{}{
			"http_service":         service,
			"http_service_host":    c.HostURL,
			"http_request_method":  req.Method,
			"http_request_uri":     req.URL, // URLs should have fairly low cardinality. Users should use PathParams and QueryParams for variable parts
			"http_request_attempt": req.Attempt,
			"http_request_retry":   req.Attempt > 1,
		})

		for k, v := range req.QueryParam {
			if len(v) > 1 {
				ctx = logger.WithField(ctx, "http_request_query_"+k, v)
			} else {
				// most common scenario, only one value; inline the value instead of serializing an array
				ctx = logger.WithField(ctx, "http_request_query_"+k, v[0])
			}
		}

		// Currently not possible
		for k, v := range req.PathParams {
			ctx = logger.WithField(ctx, "http_request_path_"+k, v)
		}

		req.SetContext(ctx)
		return nil
	}
}
```