### PR TITLE
Change noRetryError for temporary errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -900,14 +900,14 @@ func (c *Client) execute(req *Request) (*Response, error) {
 	// to modify the *resty.Request object
 	for _, f := range c.udBeforeRequest {
 		if err = f(c, req); err != nil {
-			return nil, wrapNoRetryErr(err)
+			return nil, err
 		}
 	}
 
 	// resty middlewares
 	for _, f := range c.beforeRequest {
 		if err = f(c, req); err != nil {
-			return nil, wrapNoRetryErr(err)
+			return nil, err
 		}
 	}
 
@@ -918,12 +918,12 @@ func (c *Client) execute(req *Request) (*Response, error) {
 	// call pre-request if defined
 	if c.preReqHook != nil {
 		if err = c.preReqHook(c, req.RawRequest); err != nil {
-			return nil, wrapNoRetryErr(err)
+			return nil, err
 		}
 	}
 
 	if err = requestLogger(c, req); err != nil {
-		return nil, wrapNoRetryErr(err)
+		return nil, err
 	}
 
 	req.RawRequest.Body = newRequestBodyReleaser(req.RawRequest.Body, req.bodyBuf)
@@ -938,7 +938,7 @@ func (c *Client) execute(req *Request) (*Response, error) {
 
 	if err != nil || req.notParseResponse || c.notParseResponse {
 		response.setReceivedAt()
-		return response, err
+		return response, wrapTemporaryError(err)
 	}
 
 	if !req.isSaveResponse {
@@ -951,7 +951,7 @@ func (c *Client) execute(req *Request) (*Response, error) {
 				body, err = gzip.NewReader(body)
 				if err != nil {
 					response.setReceivedAt()
-					return response, err
+					return response, wrapTemporaryError(err)
 				}
 				defer closeq(body)
 			}
@@ -959,7 +959,7 @@ func (c *Client) execute(req *Request) (*Response, error) {
 
 		if response.body, err = ioutil.ReadAll(body); err != nil {
 			response.setReceivedAt()
-			return response, err
+			return response, wrapTemporaryError(err)
 		}
 
 		response.size = int64(len(response.body))
@@ -974,7 +974,7 @@ func (c *Client) execute(req *Request) (*Response, error) {
 		}
 	}
 
-	return response, wrapNoRetryErr(err)
+	return response, err
 }
 
 // getting TLS client config if not exists then create one

--- a/request.go
+++ b/request.go
@@ -745,7 +745,7 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 	if r.SRV != nil {
 		_, addrs, err = net.LookupSRV(r.SRV.Service, "tcp", r.SRV.Domain)
 		if err != nil {
-			r.client.onErrorHooks(r, nil, err)
+			r.client.onErrorHooks(r, resp, err)
 			return nil, err
 		}
 	}
@@ -755,9 +755,8 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 
 	if r.client.RetryCount == 0 {
 		r.Attempt = 1
-		resp, err = r.client.execute(r)
-		r.client.onErrorHooks(r, resp, unwrapNoRetryErr(err))
-		return resp, unwrapNoRetryErr(err)
+		r.client.onErrorHooks(r, resp, err)
+		return r.client.execute(r)
 	}
 
 	err = Backoff(
@@ -780,9 +779,9 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 		RetryHooks(r.client.RetryHooks),
 	)
 
-	r.client.onErrorHooks(r, resp, unwrapNoRetryErr(err))
+	r.client.onErrorHooks(r, resp, err)
 
-	return resp, unwrapNoRetryErr(err)
+	return resp, err
 }
 
 //‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾

--- a/retry.go
+++ b/retry.go
@@ -111,11 +111,10 @@ func Backoff(operation func() (*Response, error), options ...Option) error {
 			return err
 		}
 
-		err1 := unwrapNoRetryErr(err)           // raw error, it used for return users callback.
-		needsRetry := err != nil && err == err1 // retry on a few operation errors by default
+		needsRetry := isTemporaryError(err) // retry on temporary errors by default
 
 		for _, condition := range opts.retryConditions {
-			needsRetry = condition(resp, err1)
+			needsRetry = condition(resp, err)
 			if needsRetry {
 				break
 			}

--- a/retry_test.go
+++ b/retry_test.go
@@ -22,7 +22,7 @@ func TestBackoffSuccess(t *testing.T) {
 	retryErr := Backoff(func() (*Response, error) {
 		externalCounter++
 		if externalCounter < attempts {
-			return nil, errors.New("not yet got the number we're after")
+			return nil, wrapTemporaryError(errors.New("not yet got the number we're after"))
 		}
 
 		return nil, nil
@@ -71,7 +71,7 @@ func TestBackoffTenAttemptsSuccess(t *testing.T) {
 	retryErr := Backoff(func() (*Response, error) {
 		externalCounter++
 		if externalCounter < attempts {
-			return nil, errors.New("not yet got the number we're after")
+			return nil, wrapTemporaryError(errors.New("not yet got the number we're after"))
 		}
 		return nil, nil
 	}, Retries(attempts), WaitTime(5), MaxWaitTime(500))


### PR DESCRIPTION
- Expose an `Unwrap` method to leverage go's standard unwrapping
- Let the error escape, such that hooks and end-users can access the `Temporary` information.
- Do not wrap if the error already exposes `Temporary`, to honour it.

The main benefit is to leverage `net/*`'s standard errors; most of them already expose `Temporary` methods.