### PR TITLE
Fix Send() documentation code

### DIFF
--- a/request.go
+++ b/request.go
@@ -724,7 +724,7 @@ func (r *Request) Patch(url string) (*Response, error) {
 //      req := client.R()
 //      req.Method = resty.GET
 //      req.URL = "http://httpbin.org/get"
-// 		resp, err := client.R().Send()
+//      resp, err := req.Send()
 func (r *Request) Send() (*Response, error) {
 	return r.Execute(r.Method, r.URL)
 }


### PR DESCRIPTION
I'm guessing the previous code was a typo and `client.R().Send()` would just send an empty request, not the configured `req`.