### PR TITLE
Fix SetAllowGetMethodPayload option ignored for io.Reader payload

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -468,6 +468,21 @@ func TestClientAllowsGetMethodPayload(t *testing.T) {
 	assertEqual(t, payload, resp.String())
 }
 
+func TestClientAllowsGetMethodPayloadDisabled(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	c := dc()
+	c.SetAllowGetMethodPayload(false)
+
+	payload := bytes.NewReader([]byte("test-payload"))
+	resp, err := c.R().SetBody(payload).Get(ts.URL + "/get-method-payload-test")
+
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
+	assertEqual(t, "", resp.String())
+}
+
 func TestClientRoundTripper(t *testing.T) {
 	c := NewWithClient(&http.Client{})
 	c.outputLogTo(ioutil.Discard)

--- a/middleware.go
+++ b/middleware.go
@@ -164,9 +164,7 @@ CL:
 
 func createHTTPRequest(c *Client, r *Request) (err error) {
 	if r.bodyBuf == nil {
-		if reader, ok := r.Body.(io.Reader); ok {
-			r.RawRequest, err = http.NewRequest(r.Method, r.URL, reader)
-		} else if c.setContentLength || r.setContentLength {
+		if c.setContentLength || r.setContentLength {
 			r.RawRequest, err = http.NewRequest(r.Method, r.URL, http.NoBody)
 		} else {
 			r.RawRequest, err = http.NewRequest(r.Method, r.URL, nil)
@@ -442,14 +440,9 @@ func handleRequestBody(c *Client, r *Request) (err error) {
 	r.bodyBuf = nil
 
 	if reader, ok := r.Body.(io.Reader); ok {
-		if c.setContentLength || r.setContentLength { // keep backward compatibility
-			r.bodyBuf = acquireBuffer()
-			_, err = r.bodyBuf.ReadFrom(reader)
-			r.Body = nil
-		} else {
-			// Otherwise buffer less processing for `io.Reader`, sounds good.
-			return
-		}
+		r.bodyBuf = acquireBuffer()
+		_, err = r.bodyBuf.ReadFrom(reader)
+		r.Body = nil
 	} else if b, ok := r.Body.([]byte); ok {
 		bodyBytes = b
 	} else if s, ok := r.Body.(string); ok {


### PR DESCRIPTION
Hi 👋 !

We detect some inconsistent behaviour of the current implementation of the  `SetAllowGetMethodPayload` based on the input type passed to `SetBody` option:

- SetAllowGetMethodPayload = false
  - Body type = io.Reader => body is sent in GET
  - Body type = non io.Reader => body is not sent in GET
   
 - SetAllowGetMethodPayload = true
   - Body type = io.Reader => body is sent in GET
   - Body type = non io.Reader => body is sent in GET
   
Basically you can bypass the option AllowGetMethodPayload if you send an io.Reader as a Body, this fixes that for be consistent to all types and add a test case for test disabled option