### PR TITLE
Feat: support set querystring from struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/go-resty/resty/v2
 
-require golang.org/x/net v0.0.0-20211029224645-99673261e6eb
+require (
+    github.com/google/go-querystring v1.1.0
+    golang.org/x/net v0.0.0-20211029224645-99673261e6eb
+)
 
 go 1.11

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 golang.org/x/net v0.0.0-20211029224645-99673261e6eb h1:pirldcYWx7rx7kE5r+9WsOXPXK0+WH5+uZ7uPmJ44uM=
 golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -5,3 +9,5 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/request.go
+++ b/request.go
@@ -17,6 +17,9 @@ import (
 	"reflect"
 	"strings"
 	"time"
+	
+	"github.com/google/go-querystring/query"
+
 )
 
 //‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
@@ -159,6 +162,28 @@ func (r *Request) SetHeaderVerbatim(header, value string) *Request {
 // Also you can override query params value, which was set at client instance level.
 func (r *Request) SetQueryParam(param, value string) *Request {
 	r.QueryParam.Set(param, value)
+	return r
+}
+
+// SetQueryStruct method set struct parameter and its value in the current request.
+//
+// For Example:
+// type Options struct {
+//  	Query   string `url:"q"`
+//  	ShowAll bool   `url:"all"`
+//  	Page    int    `url:"page,omitempty"`
+// }
+// opt := Options{Query:"foo", ShowAll: true}
+// client.R().
+//	SetQueryStruct(opt)
+// will output: "q=foo&all=true"
+func (r *Request) SetQueryStruct(param interface{}) *Request {
+	values, err := query.Values(param)
+	if err != nil {
+		r.client.log.Errorf("%v", err)
+		return r
+	}
+	r.SetQueryParamsFromValues(values)
 	return r
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -89,6 +89,11 @@ func TestGetClientParamRequestParam(t *testing.T) {
 	resp, err := c.R().
 		SetQueryParams(map[string]string{"req_1": "req 1 value", "req_2": "req 2 value"}).
 		SetQueryParam("request_no", strconv.FormatInt(time.Now().Unix(), 10)).
+		SetQueryStruct(struct {
+			Req3 string `url:"req_3"`
+			Req4 int    `url:"req_4"`
+			Req5 int    `url:"req_5,omitempty"`
+		}{"req 3 value", 4, 0}).
 		SetHeader(hdrUserAgentKey, "Test Custom User agent").
 		Get(ts.URL + "/")
 


### PR DESCRIPTION
`SetQueryStruct` method set struct parameter and its value in the current request.


For Example:
```go
 type Options struct {
  	Query   string `url:"q"`
  	ShowAll bool   `url:"all"`
  	Page    int    `url:"page,omitempty"`
 }
 opt := Options{Query:"foo", ShowAll: true}
 client.R().
	SetQueryStruct(opt)
```

will output: "q=foo&all=true"