### PR TITLE
Fix redirect request body mismatch with origin request body caused by buffer reused by mistake

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -514,7 +514,7 @@ func saveResponseIntoFile(c *Client, res *Response) error {
 func getBodyCopy(r *Request) (*bytes.Buffer, error) {
 	// If r.bodyBuf present, return the copy
 	if r.bodyBuf != nil {
-		bodyCopy := &bytes.Buffer{}
+		bodyCopy := acquireBuffer()
 		if _, err := io.Copy(bodyCopy, bytes.NewReader(r.bodyBuf.Bytes())); err != nil {
 			// cannot use io.Copy(bodyCopy, r.bodyBuf) because io.Copy reset r.bodyBuf
 			return nil, err

--- a/middleware.go
+++ b/middleware.go
@@ -514,7 +514,12 @@ func saveResponseIntoFile(c *Client, res *Response) error {
 func getBodyCopy(r *Request) (*bytes.Buffer, error) {
 	// If r.bodyBuf present, return the copy
 	if r.bodyBuf != nil {
-		return bytes.NewBuffer(r.bodyBuf.Bytes()), nil
+		bodyCopy := &bytes.Buffer{}
+		if _, err := io.Copy(bodyCopy, bytes.NewReader(r.bodyBuf.Bytes())); err != nil {
+			// cannot use io.Copy(bodyCopy, r.bodyBuf) because io.Copy reset r.bodyBuf
+			return nil, err
+		}
+		return bodyCopy, nil
 	}
 
 	// Maybe body is `io.Reader`.


### PR DESCRIPTION
As issue #567 described.

Copy the body buffer by buffer.Write to fix body mismatch with origin request when 307 or 308 redirect.

closes #567