### PR TITLE
feat: add nil check to SetResult (#503)

### DIFF
--- a/request.go
+++ b/request.go
@@ -303,7 +303,9 @@ func (r *Request) SetBody(body interface{}) *Request {
 // Accessing a result value from response instance.
 //		response.Result().(*AuthToken)
 func (r *Request) SetResult(res interface{}) *Request {
-	r.Result = getPointer(res)
+	if res != nil {
+		r.Result = getPointer(res)
+	}
 	return r
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -1891,3 +1891,13 @@ func TestPostBodyError(t *testing.T) {
 	assertEqual(t, "read error", err.Error())
 	assertNil(t, resp)
 }
+
+func TestSetResultMustNotPanicOnNil(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("must not panic")
+		}
+	}()
+	dc().R().SetResult(nil)
+}
+


### PR DESCRIPTION
fixes #503.

Simply adds a `nil` check to `SetResult` to ensure that it can be used fluently. Also adds a simple unit test to ensure that the current panic will not happen any longer.