### PR TITLE
feat: Enable to customize unmarshal rule

### DIFF
--- a/client.go
+++ b/client.go
@@ -390,6 +390,7 @@ func (c *Client) R() *Request {
 		multipartFields: []*MultipartField{},
 		PathParams:      map[string]string{},
 		jsonEscapeHTML:  true,
+		forceUnmarshal:  map[string]UnmarshalType{},
 	}
 	return r
 }

--- a/request.go
+++ b/request.go
@@ -60,6 +60,7 @@ type Request struct {
 	outputFile          string
 	fallbackContentType string
 	forceContentType    string
+	forceUnmarshal      map[string]UnmarshalType
 	ctx                 context.Context
 	values              map[string]interface{}
 	client              *Client
@@ -546,6 +547,23 @@ func (r *Request) ExpectContentType(contentType string) *Request {
 // `Request.ForceContentType` is set and the response `Content-Type` is available, `ForceContentType` will win.
 func (r *Request) ForceContentType(contentType string) *Request {
 	r.forceContentType = contentType
+	return r
+}
+
+type UnmarshalType int
+
+const (
+	UnmarshalSkip UnmarshalType = iota
+	UnmarshalAsJSON
+	UnmarshalAsXML
+)
+
+// AddForceUnmarshalRule register automatic unmarshal rule for specific `Content-Type`.
+// Resty consider specified `contentType` as `UnmarshalType`.
+// Decision rule of `Content-Type` is not overrode by `Request.AddForceUnmarshalRule` and `contentType` have
+// to be matched with decided `Content-Type`.
+func (r *Request) AddForceUnmarshalRule(contentType string, unmarshalType UnmarshalType) *Request {
+	r.forceUnmarshal[contentType] = unmarshalType
 	return r
 }
 

--- a/response.go
+++ b/response.go
@@ -159,7 +159,7 @@ func (r *Response) fmtBodyString(sl int64) string {
 			return fmt.Sprintf("***** RESPONSE TOO LARGE (size - %d) *****", len(r.body))
 		}
 		ct := r.Header().Get(hdrContentTypeKey)
-		if IsJSONType(ct) {
+		if IsJSONType(ct) || r.Request.forceUnmarshal[ct] == UnmarshalAsJSON {
 			out := acquireBuffer()
 			defer releaseBuffer(out)
 			err := json.Indent(out, r.body, "", "   ")

--- a/resty_test.go
+++ b/resty_test.go
@@ -496,7 +496,7 @@ func createGenServer(t *testing.T) *httptest.Server {
 				_, _ = w.Write([]byte(`{"response":"json response"}`))
 			} else if r.URL.Path == "/xml" {
 				w.Header().Set(hdrContentTypeKey, "application/xml")
-				_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><Response>XML response</Response>`))
+				_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><Root><Response>XML response</Response></Root>`))
 			}
 			return
 		}

--- a/util.go
+++ b/util.go
@@ -114,6 +114,17 @@ func Unmarshalc(c *Client, ct string, b []byte, d interface{}) (err error) {
 	return
 }
 
+// Unmarshal content into object by specified type
+func Unmarshal(c *Client, t UnmarshalType, b []byte, d interface{}) (err error) {
+	if t == UnmarshalAsJSON {
+		err = c.JSONUnmarshal(b, d)
+	} else if t == UnmarshalAsXML {
+		err = c.XMLUnmarshal(b, d)
+	}
+
+	return
+}
+
 //‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 // RequestLog and ResponseLog type
 //_______________________________________________________________________


### PR DESCRIPTION
I found issue #594 and after looking into it I come up with the idea to deal with it.
I hope you to give me some feedback, because I'm not familiar with this repository.

[Issue #594](#594) can be worked around by set `application/json` as ForceContentType, but content-type may be different depends on response, and ForceContentType assumes that server always return same content type.

AddForceUnmarshalRule enables unmarshal depends on content-type from server.

Note1: Previously createGenServer return xml response without root element and it cannot be unmarshalled because encoding/xml.Unmarshal is only unmarshal chidlren of root element.
Now add root element in response and change assertion in test case accordingly.

Note2: Unmarshalc is no longer used in this repository but preserved for backward compatibility.