### PR TITLE
client: setters for JSON and XML Marshal/Unmarshal

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,13 +369,13 @@ import jsoniter "github.com/json-iterator/go"
 
 json := jsoniter.ConfigCompatibleWithStandardLibrary
 
-client := resty.New()
-client.JSONMarshal = json.Marshal
-client.JSONUnmarshal = json.Unmarshal
+client := resty.New().
+    SetJSONMarshaler(json.Marshal).
+    SetJSONUnmarshaler(json.Unmarshal)
 
 // similarly user could do for XML too with -
-client.XMLMarshal
-client.XMLUnmarshal
+client.SetXMLMarshaler(xml.Marshal).
+    SetXMLUnmarshaler(xml.Unmarshal)
 ```
 
 ### Multipart File(s) upload

--- a/client.go
+++ b/client.go
@@ -649,6 +649,34 @@ func (c *Client) SetRetryAfter(callback RetryAfterFunc) *Client {
 	return c
 }
 
+// SetJSONMarshaler method sets the JSON marshaler function to marshal the request body.
+// By default, Resty uses `encoding/json` package to marshal the request body.
+func (c *Client) SetJSONMarshaler(marshaler func(v interface{}) ([]byte, error)) *Client {
+	c.JSONMarshal = marshaler
+	return c
+}
+
+// SetJSONUnmarshaler method sets the JSON unmarshaler function to unmarshal the response body.
+// By default, Resty uses `encoding/json` package to unmarshal the response body.
+func (c *Client) SetJSONUnmarshaler(unmarshaler func(data []byte, v interface{}) error) *Client {
+	c.JSONUnmarshal = unmarshaler
+	return c
+}
+
+// SetXMLMarshaler method sets the XML marshaler function to marshal the request body.
+// By default, Resty uses `encoding/xml` package to marshal the request body.
+func (c *Client) SetXMLMarshaler(marshaler func(v interface{}) ([]byte, error)) *Client {
+	c.XMLMarshal = marshaler
+	return c
+}
+
+// SetXMLUnmarshaler method sets the XML unmarshaler function to unmarshal the response body.
+// By default, Resty uses `encoding/xml` package to unmarshal the response body.
+func (c *Client) SetXMLUnmarshaler(unmarshaler func(data []byte, v interface{}) error) *Client {
+	c.XMLUnmarshal = unmarshaler
+	return c
+}
+
 // AddRetryCondition method adds a retry condition function to array of functions
 // that are checked to determine if the request is retried. The request will
 // retry if any of the functions return true and error is nil.

--- a/client_test.go
+++ b/client_test.go
@@ -508,6 +508,39 @@ func TestClientNewRequest(t *testing.T) {
 	assertNotNil(t, request)
 }
 
+
+func TestClientSetJSONMarshaler(t *testing.T) {
+	m := func (v interface{}) ([]byte, error) { return nil,nil }
+	c := New().SetJSONMarshaler(m)
+	p1 := fmt.Sprintf("%p", c.JSONMarshal)
+	p2 := fmt.Sprintf("%p", m)
+	assertEqual(t, p1, p2) // functions can not be compared, we only can compare pointers
+}
+
+func TestClientSetJSONUnmarshaler(t *testing.T) {
+	m := func ([]byte, interface{}) error { return nil }
+	c := New().SetJSONUnmarshaler(m)
+	p1 := fmt.Sprintf("%p", c.JSONUnmarshal)
+	p2 := fmt.Sprintf("%p", m)
+	assertEqual(t, p1, p2) // functions can not be compared, we only can compare pointers
+}
+
+func TestClientSetXMLMarshaler(t *testing.T) {
+	m := func (v interface{}) ([]byte, error) { return nil,nil }
+	c := New().SetXMLMarshaler(m)
+	p1 := fmt.Sprintf("%p", c.XMLMarshal)
+	p2 := fmt.Sprintf("%p", m)
+	assertEqual(t, p1, p2) // functions can not be compared, we only can compare pointers
+}
+
+func TestClientSetXMLUnmarshaler(t *testing.T) {
+	m := func ([]byte, interface{}) error { return nil }
+	c := New().SetXMLUnmarshaler(m)
+	p1 := fmt.Sprintf("%p", c.XMLUnmarshal)
+	p2 := fmt.Sprintf("%p", m)
+	assertEqual(t, p1, p2) // functions can not be compared, we only can compare pointers
+}
+
 func TestDebugBodySizeLimit(t *testing.T) {
 	ts := createGetServer(t)
 	defer ts.Close()


### PR DESCRIPTION
Today I learned that I can set external JSON library for resty to marshal JSON faster. It wasn't so obvious because I haven't read the docs (let's be honest it's not only me who doesn't read docs), but there was no method for `resty.Client` to override JSON marshal function.

I suggest adding these `Set*` functions because this way they will be available through IDEs auto-completion.