### PR TITLE
fix: jitter maxWaitTime must be >= 1ns

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -209,6 +209,9 @@ func jitterBackoff(min, max time.Duration, attempt int) time.Duration {
 
 	temp := math.Min(capLevel, base*math.Exp2(float64(attempt)))
 	ri := time.Duration(temp / 2)
+	if ri == 0 {
+		ri = time.Nanosecond
+	}
 	result := randDuration(ri)
 
 	if result < min {

--- a/retry_test.go
+++ b/retry_test.go
@@ -295,6 +295,20 @@ func TestClientRetryWaitMaxInfinite(t *testing.T) {
 	}
 }
 
+func TestClientRetryWaitMaxMinimum(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	const retryMaxWaitTime = time.Nanosecond // minimal duration value
+
+	c := dc().
+		SetRetryCount(1).
+		SetRetryMaxWaitTime(retryMaxWaitTime).
+		AddRetryCondition(func(*Response, error) bool { return true })
+	_, err := c.R().Get(ts.URL + "/set-retrywaittime-test")
+	assertError(t, err)
+}
+
 func TestClientRetryWaitCallbackError(t *testing.T) {
 	ts := createGetServer(t)
 	defer ts.Close()


### PR DESCRIPTION
rand.Rand.Int63n panics when passed a non-positive int. When maxWaitTime is 1ns, max/2 is zero.

Fixes #624 