### PR TITLE
fix: client panic on missing digest value

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -133,6 +133,7 @@ func TestClientDigestErrors(t *testing.T) {
 		{mutateConf: func(c *digestServerConfig) { c.charset = "utf-16" }, expect: ErrDigestCharset},
 		{mutateConf: func(c *digestServerConfig) { c.uri = "/bad" }, expect: ErrDigestBadChallenge},
 		{mutateConf: func(c *digestServerConfig) { c.uri = "/unknown_param" }, expect: ErrDigestBadChallenge},
+		{mutateConf: func(c *digestServerConfig) { c.uri = "/missing_value" }, expect: ErrDigestBadChallenge},
 		{mutateConf: func(c *digestServerConfig) { c.uri = "/no_challenge" }, expect: ErrDigestBadChallenge},
 		{mutateConf: func(c *digestServerConfig) { c.uri = "/status_500" }, expect: nil},
 	}

--- a/digest.go
+++ b/digest.go
@@ -121,6 +121,9 @@ func parseChallenge(input string) (*challenge, error) {
 	var r []string
 	for i := range sl {
 		r = strings.SplitN(sl[i], "=", 2)
+		if len(r) != 2 {
+			return nil, ErrDigestBadChallenge
+		}
 		switch r[0] {
 		case "realm":
 			c.realm = strings.Trim(r[1], qs)


### PR DESCRIPTION
After splitting key=value pairs, we check that there are really key AND value. A maliciously crafted response header can cause the client to panic.