### PR TITLE
Access single request debug dump

### DIFF
--- a/client.go
+++ b/client.go
@@ -71,7 +71,7 @@ var (
 
 type (
 	// RequestDumpFunction is used for dump on request level instead on whole client level
-	RequestDumpFunction func(r *Request, sump string)
+	RequestDumpFunction func(r *Request, dump string)
 
 	// RequestMiddleware type is for request middleware, called before a request is sent
 	RequestMiddleware func(*Client, *Request) error

--- a/client.go
+++ b/client.go
@@ -70,6 +70,9 @@ var (
 )
 
 type (
+	// RequestDumpFunction is used for dump on request level instead on whole client level
+	RequestDumpFunction func(r *Request, sump string)
+
 	// RequestMiddleware type is for request middleware, called before a request is sent
 	RequestMiddleware func(*Client, *Request) error
 

--- a/middleware.go
+++ b/middleware.go
@@ -259,7 +259,7 @@ func addCredentials(c *Client, r *Request) error {
 }
 
 func requestLogger(c *Client, r *Request) error {
-	if c.Debug {
+	if c.Debug || r.requestDumpFunction != nil {
 		rr := r.RawRequest
 		rl := &RequestLog{Header: copyHeaders(rr.Header), Body: r.fmtBodyString(c.debugBodySizeLimit)}
 		if c.requestLog != nil {
@@ -289,7 +289,7 @@ func requestLogger(c *Client, r *Request) error {
 //_______________________________________________________________________
 
 func responseLogger(c *Client, res *Response) error {
-	if c.Debug {
+	if c.Debug || res.Request.requestDumpFunction != nil {
 		rl := &ResponseLog{Header: copyHeaders(res.Header()), Body: res.fmtBodyString(c.debugBodySizeLimit)}
 		if c.responseLog != nil {
 			if err := c.responseLog(rl); err != nil {
@@ -311,8 +311,12 @@ func responseLogger(c *Client, res *Response) error {
 			debugLog += fmt.Sprintf("BODY         :\n%v\n", rl.Body)
 		}
 		debugLog += "==============================================================================\n"
-
-		res.Request.log.Debugf("%s", debugLog)
+		if res.Request.requestDumpFunction != nil {
+			res.Request.requestDumpFunction(res.Request, debugLog)
+		}
+		if c.Debug {
+			res.Request.log.Debugf("%s", debugLog)
+		}
 	}
 
 	return nil

--- a/request.go
+++ b/request.go
@@ -69,6 +69,7 @@ type Request struct {
 	multipartFiles      []*File
 	multipartFields     []*MultipartField
 	retryConditions     []RetryConditionFunc
+	requestDumpFunction RequestDumpFunction
 }
 
 // Context method returns the Context if its already set in request
@@ -881,6 +882,11 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 
 	r.client.onErrorHooks(r, resp, unwrapNoRetryErr(err))
 	return resp, unwrapNoRetryErr(err)
+}
+
+// SetOnRequestDump set the callback to dump request log regardless of client logging
+func (r *Request) SetOnRequestDump(callback RequestDumpFunction) {
+	r.requestDumpFunction = callback
 }
 
 //‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾


### PR DESCRIPTION
I do find the way to dump requests on a resty.Client level with SetDebug call but i did not find the simple way to control it on Request level. This pull request implement the Request level method SetOnRequestDump that can be used to access the dump on particular request regardless of the whole client debuging state.

```go 
request.SetOnRequestDump(func(r *resty.Request, dump string) {
			// TO DO  something with composed dump
		})
```