### PR TITLE
update README.md about Proxy Settings, no Request level setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ if err != nil {
 client.SetCertificates(cert1, cert2, cert3)
 ```
 
-#### Proxy Settings - Client as well as at Request Level
+#### Proxy Settings
 
 Default `Go` supports Proxy via environment variable `HTTP_PROXY`. Resty provides support via `SetProxy` & `RemoveProxy`.
 Choose as per your need.


### PR DESCRIPTION
https://github.com/go-resty/resty/issues/16
https://github.com/go-resty/resty/issues/56
https://github.com/go-resty/resty/pull/107

Looks like `Request level proxy` has been removed, the description in the docs is confusing