### PR TITLE
Set ContentLength to 0 when Body is nil

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -488,6 +488,17 @@ func TestClientOptions(t *testing.T) {
 	assertEqual(t, client.closeConnection, true)
 }
 
+func TestContentLengthWhenBodyIsNil(t *testing.T) {
+	client := dc()
+
+	client.SetPreRequestHook(func(c *Client, r *http.Request) error {
+		assertEqual(t, "0", r.Header.Get(hdrContentLengthKey))
+		return nil
+	})
+
+	client.R().SetContentLength(true).SetBody(nil).Get("http://localhost")
+}
+
 func TestClientPreRequestHook(t *testing.T) {
 	client := dc()
 	client.SetPreRequestHook(func(c *Client, r *http.Request) error {

--- a/middleware.go
+++ b/middleware.go
@@ -167,11 +167,10 @@ func parseRequestBody(c *Client, r *Request) (err error) {
 CL:
 	// by default resty won't set content length, you can if you want to :)
 	if c.setContentLength || r.setContentLength {
-		if r.bodyBuf != nil {
-			r.Header.Set(hdrContentLengthKey, fmt.Sprintf("%d", r.bodyBuf.Len()))
-		} else {
+		if r.bodyBuf == nil {
 			r.Header.Set(hdrContentLengthKey, "0")
-
+		} else {
+			r.Header.Set(hdrContentLengthKey, fmt.Sprintf("%d", r.bodyBuf.Len()))
 		}
 	}
 

--- a/middleware.go
+++ b/middleware.go
@@ -166,8 +166,13 @@ func parseRequestBody(c *Client, r *Request) (err error) {
 
 CL:
 	// by default resty won't set content length, you can if you want to :)
-	if (c.setContentLength || r.setContentLength) && r.bodyBuf != nil {
-		r.Header.Set(hdrContentLengthKey, fmt.Sprintf("%d", r.bodyBuf.Len()))
+	if c.setContentLength || r.setContentLength {
+		if r.bodyBuf != nil {
+			r.Header.Set(hdrContentLengthKey, fmt.Sprintf("%d", r.bodyBuf.Len()))
+		} else {
+			r.Header.Set(hdrContentLengthKey, "0")
+
+		}
 	}
 
 	return


### PR DESCRIPTION
To address the issue https://github.com/go-resty/resty/issues/671 set `ContentLength` header to 0 when Body is `nil` and `setContentLength` was set to `true`.

Closes #671 