### PR TITLE
fix TestClientOnResponseError parallel tests

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -780,9 +780,6 @@ func TestNewWithLocalAddr(t *testing.T) {
 }
 
 func TestClientOnResponseError(t *testing.T) {
-	ts := createAuthServer(t)
-	defer ts.Close()
-
 	tests := []struct {
 		name        string
 		setup       func(*Client)
@@ -862,8 +859,12 @@ func TestClientOnResponseError(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
+			ts := createAuthServer(t)
+			defer ts.Close()
+
 			var assertErrorHook = func(r *Request, err error) {
 				assertNotNil(t, r)
 				v, ok := err.(*ResponseError)


### PR DESCRIPTION
In case of using `t.Parallel()` inside a for loop, the loop variables must be copied, otherwise only the last test will be executed.

```go
	for _, test := range tests {
		t.Run(test.name, func(t *testing.T) {
			t.Parallel()
```
changed to
```go
	for _, test := range tests {
		test := test
		t.Run(test.name, func(t *testing.T) {
			t.Parallel()
```

also the AuthServer must be created within the test, otherwise some tests fail.

`t.Log(test.Name)` can be used to verify the issue:
```go
	for _, test := range tests {
		t.Run(test.name, func(t *testing.T) {
			t.Parallel()
			t.Log("Test name:", test.name)
```
<img width="898" alt="Screenshot 2023-09-24 at 8 22 42 PM" src="https://github.com/go-resty/resty/assets/523825/d27f3b5a-d813-40ff-b27c-5b9ad301acea">
