### PR TITLE
Benchmarks and Improvements for parseRequestURL function

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -32,9 +32,7 @@ func parseRequestURL(c *Client, r *Request) error {
 
 		// GitHub #103 Path Params
 		for p, v := range r.PathParams {
-			if _, ok := params[p]; !ok {
-				params[p] = url.PathEscape(v)
-			}
+			params[p] = url.PathEscape(v)
 		}
 		for p, v := range c.PathParams {
 			if _, ok := params[p]; !ok {

--- a/middleware.go
+++ b/middleware.go
@@ -133,30 +133,25 @@ func parseRequestURL(c *Client, r *Request) error {
 	}
 
 	// Adding Query Param
-	if l := len(c.QueryParam) + len(r.QueryParam); l > 0 {
-		query := make(url.Values, l)
-		for k, v := range r.QueryParam {
-			query[k] = v[:]
-		}
-
+	if len(c.QueryParam)+len(r.QueryParam) > 0 {
 		for k, v := range c.QueryParam {
-			// skip query parameter if it was set from request
-			if _, ok := query[k]; ok {
+			// skip query parameter if it was set in request
+			if _, ok := r.QueryParam[k]; ok {
 				continue
 			}
 
-			query[k] = v[:]
+			r.QueryParam[k] = v[:]
 		}
 
 		// GitHub #123 Preserve query string order partially.
 		// Since not feasible in `SetQuery*` resty methods, because
 		// standard package `url.Encode(...)` sorts the query params
 		// alphabetically
-		if len(query) > 0 {
+		if len(r.QueryParam) > 0 {
 			if IsStringEmpty(reqURL.RawQuery) {
-				reqURL.RawQuery = query.Encode()
+				reqURL.RawQuery = r.QueryParam.Encode()
 			} else {
-				reqURL.RawQuery = reqURL.RawQuery + "&" + query.Encode()
+				reqURL.RawQuery = reqURL.RawQuery + "&" + r.QueryParam.Encode()
 			}
 		}
 	}

--- a/middleware.go
+++ b/middleware.go
@@ -55,11 +55,9 @@ func parseRequestURL(c *Client, r *Request) error {
 		}
 
 		if len(params) > 0 {
-			var (
-				prev int
-				buf  bytes.Buffer
-			)
-			buf.Grow(len(r.URL))
+			var prev int
+			buf := acquireBuffer()
+			defer releaseBuffer(buf)
 			// search for the next or first opened curly bracket
 			for curr := strings.Index(r.URL, "{"); curr > prev; curr = prev + strings.Index(r.URL[prev:], "{") {
 				// write everything form the previous position up to the current

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -229,12 +229,31 @@ func Test_parseRequestURL(t *testing.T) {
 					"foo": "1", // ignored, because of the "foo" parameter in request
 					"bar": "2",
 				})
-				c.SetQueryParams(map[string]string{
+				r.SetQueryParams(map[string]string{
 					"foo": "3",
 				})
 				r.URL = "https://example.com/"
 			},
 			expectedURL: "https://example.com/?foo=3&bar=2",
+		},
+		{
+			name: "adding query parameters by request to URL with existent",
+			init: func(c *Client, r *Request) {
+				r.SetQueryParams(map[string]string{
+					"bar": "2",
+				})
+				r.URL = "https://example.com/?foo=1"
+			},
+			expectedURL: "https://example.com/?foo=1&bar=2",
+		},
+		{
+			name: "adding query parameters by request with multiple values",
+			init: func(c *Client, r *Request) {
+				r.QueryParam.Add("foo", "1")
+				r.QueryParam.Add("foo", "2")
+				r.URL = "https://example.com/"
+			},
+			expectedURL: "https://example.com/?foo=1&foo=2",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -237,6 +237,30 @@ func Test_parseRequestURL(t *testing.T) {
 	}
 }
 
+func Benchmark_parseRequestURL_PathParams(b *testing.B) {
+	c := New().SetPathParams(map[string]string{
+		"foo": "1",
+		"bar": "2",
+	}).SetRawPathParams(map[string]string{
+		"foo": "3",
+		"xyz": "4",
+	})
+	r := c.R().SetPathParams(map[string]string{
+		"foo": "5",
+		"qwe": "6",
+	}).SetRawPathParams(map[string]string{
+		"foo": "7",
+		"asd": "8",
+	})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r.URL = "https://example.com/{foo}/{bar}/{xyz}/{qwe}/{asd}"
+		if err := parseRequestURL(c, r); err != nil {
+			b.Errorf("parseRequestURL() error = %v", err)
+		}
+	}
+}
+
 func Test_parseRequestHeader(t *testing.T) {
 	for _, tt := range []struct {
 		name           string
@@ -865,6 +889,7 @@ func Benchmark_parseRequestBody_reader_with_SetContentLength(b *testing.B) {
 		}
 	}
 }
+
 func Benchmark_parseRequestBody_reader_without_SetContentLength(b *testing.B) {
 	c := New()
 	r := c.R()

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -106,6 +106,46 @@ func Test_parseRequestURL(t *testing.T) {
 			expectedURL: "https://example.com/4%2F5/6/7",
 		},
 		{
+			name: "empty path parameter in URL",
+			init: func(c *Client, r *Request) {
+				r.SetPathParams(map[string]string{
+					"bar": "4",
+				})
+				r.URL = "https://example.com/{}/{bar}"
+			},
+			expectedURL: "https://example.com/%7B%7D/4",
+		},
+		{
+			name: "not closed path parameter in URL",
+			init: func(c *Client, r *Request) {
+				r.SetPathParams(map[string]string{
+					"foo": "4",
+				})
+				r.URL = "https://example.com/{foo}/{bar/1"
+			},
+			expectedURL: "https://example.com/4/%7Bbar/1",
+		},
+		{
+			name: "extra path parameter in URL",
+			init: func(c *Client, r *Request) {
+				r.SetPathParams(map[string]string{
+					"foo": "1",
+				})
+				r.URL = "https://example.com/{foo}/{bar}"
+			},
+			expectedURL: "https://example.com/1/%7Bbar%7D",
+		},
+		{
+			name: " path parameter with remainder",
+			init: func(c *Client, r *Request) {
+				r.SetPathParams(map[string]string{
+					"foo": "1",
+				})
+				r.URL = "https://example.com/{foo}/2"
+			},
+			expectedURL: "https://example.com/1/2",
+		},
+		{
 			name: "using BaseURL with absolute URL in request",
 			init: func(c *Client, r *Request) {
 				c.SetBaseURL("https://foo.bar") // ignored

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -275,22 +275,8 @@ func Test_parseRequestURL(t *testing.T) {
 			if expectedURL.String() != actualURL.String() {
 				t.Errorf("r.URL = %q does not match expected %q", r.URL, tt.expectedURL)
 			}
-			if len(expectedQuery) != len(actualQuery) {
+			if !reflect.DeepEqual(expectedQuery, actualQuery) {
 				t.Errorf("r.URL = %q does not match expected %q", r.URL, tt.expectedURL)
-			}
-			for name, expected := range expectedQuery {
-				actual, ok := actualQuery[name]
-				if !ok {
-					t.Errorf("r.URL = %q does not match expected %q", r.URL, tt.expectedURL)
-				}
-				if len(expected) != len(actual) {
-					t.Errorf("r.URL = %q does not match expected %q", r.URL, tt.expectedURL)
-				}
-				for i, v := range expected {
-					if v != actual[i] {
-						t.Errorf("r.URL = %q does not match expected %q", r.URL, tt.expectedURL)
-					}
-				}
 			}
 		})
 	}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -261,6 +261,24 @@ func Benchmark_parseRequestURL_PathParams(b *testing.B) {
 	}
 }
 
+func Benchmark_parseRequestURL_QueryParams(b *testing.B) {
+	c := New().SetQueryParams(map[string]string{
+		"foo": "1",
+		"bar": "2",
+	})
+	r := c.R().SetQueryParams(map[string]string{
+		"foo": "5",
+		"qwe": "6",
+	})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r.URL = "https://example.com/"
+		if err := parseRequestURL(c, r); err != nil {
+			b.Errorf("parseRequestURL() error = %v", err)
+		}
+	}
+}
+
 func Test_parseRequestHeader(t *testing.T) {
 	for _, tt := range []struct {
 		name           string


### PR DESCRIPTION
The benchmarks for the applying PathParams and adding QueryParams.

Original results:
```shell
% go test -benchmem -bench=. -run=^Benchmark
goos: darwin
goarch: amd64
pkg: github.com/go-resty/resty/v2
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
Benchmark_parseRequestURL_PathParams-16    524658    2260 ns/op    448 B/op     9 allocs/op
Benchmark_parseRequestURL_QueryParams-16   865923    1371 ns/op    416 B/op    13 allocs/op
```

After the improvements:
```shell
% go test -benchmem -bench=. -run=^Benchmark
goos: darwin
goarch: amd64
pkg: github.com/go-resty/resty/v2
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
Benchmark_parseRequestURL_PathParams-16     753834    1367 ns/op    256 B/op    5 allocs/op
Benchmark_parseRequestURL_QueryParams-16   1000000    1167 ns/op    352 B/op    9 allocs/op
```

The applying of PathParams has been improved by using O(1) logic instead of O(N). (N the number of PathParams + RawPathParams in both client and request). Instead of calling `strings.Replace` for each path parameter, the current logic collects all needed parameters in a map then replaces all parameters in URL by searching for the curly brackets and replacing. It scans the whole URL just once, from first to last positions.

The improvements of adding the QueryParams have been done by swapping the processing order. First - process the request's QueryParams, only then process the client's QueryParams and skip already existed instead of deleting.
