### PR TITLE
Improve parseRequestHeader function and add the unit tests and benchmarks

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -116,27 +116,20 @@ func parseRequestURL(c *Client, r *Request) error {
 }
 
 func parseRequestHeader(c *Client, r *Request) error {
-	hdr := make(http.Header)
-	for k := range c.Header {
-		hdr[k] = append(hdr[k], c.Header[k]...)
+	for k, v := range c.Header {
+		if _, ok := r.Header[k]; ok {
+			continue
+		}
+		r.Header[k] = v[:]
 	}
 
-	for k := range r.Header {
-		hdr.Del(k)
-		hdr[k] = append(hdr[k], r.Header[k]...)
+	if IsStringEmpty(r.Header.Get(hdrUserAgentKey)) {
+		r.Header.Set(hdrUserAgentKey, hdrUserAgentValue)
 	}
 
-	if IsStringEmpty(hdr.Get(hdrUserAgentKey)) {
-		hdr.Set(hdrUserAgentKey, hdrUserAgentValue)
+	if ct := r.Header.Get(hdrContentTypeKey); IsStringEmpty(r.Header.Get(hdrAcceptKey)) && !IsStringEmpty(ct) && (IsJSONType(ct) || IsXMLType(ct)) {
+		r.Header.Set(hdrAcceptKey, r.Header.Get(hdrContentTypeKey))
 	}
-
-	ct := hdr.Get(hdrContentTypeKey)
-	if IsStringEmpty(hdr.Get(hdrAcceptKey)) && !IsStringEmpty(ct) &&
-		(IsJSONType(ct) || IsXMLType(ct)) {
-		hdr.Set(hdrAcceptKey, hdr.Get(hdrContentTypeKey))
-	}
-
-	r.Header = hdr
 
 	return nil
 }


### PR DESCRIPTION
Original benchmarks:
```shell
% go test -benchmem -bench=. -run=^Benchmark
goos: darwin
goarch: amd64
pkg: github.com/go-resty/resty/v2
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
Benchmark_parseRequestHeader-16    1168611    1042 ns/op    496 B/op    8 allocs/op
```

After the improvements:
```shell
% go test -benchmem -bench=. -run=^Benchmark
goos: darwin
goarch: amd64
pkg: github.com/go-resty/resty/v2
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
Benchmark_parseRequestHeader-16    7956481    155.6 ns/op    0 B/op    0 allocs/op
```

Improved by modifying the original request headers instead of creating a new object