### PR TITLE
Add Benchmarks and Unit tests for parseRequestBody and improve it

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -134,45 +135,34 @@ func parseRequestHeader(c *Client, r *Request) error {
 	return nil
 }
 
-func parseRequestBody(c *Client, r *Request) (err error) {
+func parseRequestBody(c *Client, r *Request) error {
 	if isPayloadSupported(r.Method, c.AllowGetMethodPayload) {
-		// Handling Multipart
-		if r.isMultiPart {
-			if err = handleMultipart(c, r); err != nil {
-				return
+		switch {
+		case r.isMultiPart: // Handling Multipart
+			if err := handleMultipart(c, r); err != nil {
+				return err
 			}
-
-			goto CL
-		}
-
-		// Handling Form Data
-		if len(c.FormData) > 0 || len(r.FormData) > 0 {
+		case len(c.FormData) > 0 || len(r.FormData) > 0: // Handling Form Data
 			handleFormData(c, r)
-
-			goto CL
-		}
-
-		// Handling Request body
-		if r.Body != nil {
+		case r.Body != nil: // Handling Request body
 			handleContentType(c, r)
 
-			if err = handleRequestBody(c, r); err != nil {
-				return
+			if err := handleRequestBody(c, r); err != nil {
+				return err
 			}
 		}
 	}
 
-CL:
 	// by default resty won't set content length, you can if you want to :)
 	if c.setContentLength || r.setContentLength {
 		if r.bodyBuf == nil {
 			r.Header.Set(hdrContentLengthKey, "0")
 		} else {
-			r.Header.Set(hdrContentLengthKey, fmt.Sprintf("%d", r.bodyBuf.Len()))
+			r.Header.Set(hdrContentLengthKey, strconv.Itoa(r.bodyBuf.Len()))
 		}
 	}
 
-	return
+	return nil
 }
 
 func createHTTPRequest(c *Client, r *Request) (err error) {
@@ -370,13 +360,13 @@ func parseResponseBody(c *Client, res *Response) (err error) {
 	return
 }
 
-func handleMultipart(c *Client, r *Request) (err error) {
+func handleMultipart(c *Client, r *Request) error {
 	r.bodyBuf = acquireBuffer()
 	w := multipart.NewWriter(r.bodyBuf)
 
 	for k, v := range c.FormData {
 		for _, iv := range v {
-			if err = w.WriteField(k, iv); err != nil {
+			if err := w.WriteField(k, iv); err != nil {
 				return err
 			}
 		}
@@ -385,12 +375,11 @@ func handleMultipart(c *Client, r *Request) (err error) {
 	for k, v := range r.FormData {
 		for _, iv := range v {
 			if strings.HasPrefix(k, "@") { // file
-				err = addFile(w, k[1:], iv)
-				if err != nil {
-					return
+				if err := addFile(w, k[1:], iv); err != nil {
+					return err
 				}
 			} else { // form value
-				if err = w.WriteField(k, iv); err != nil {
+				if err := w.WriteField(k, iv); err != nil {
 					return err
 				}
 			}
@@ -398,28 +387,21 @@ func handleMultipart(c *Client, r *Request) (err error) {
 	}
 
 	// #21 - adding io.Reader support
-	if len(r.multipartFiles) > 0 {
-		for _, f := range r.multipartFiles {
-			err = addFileReader(w, f)
-			if err != nil {
-				return
-			}
+	for _, f := range r.multipartFiles {
+		if err := addFileReader(w, f); err != nil {
+			return err
 		}
 	}
 
 	// GitHub #130 adding multipart field support with content type
-	if len(r.multipartFields) > 0 {
-		for _, mf := range r.multipartFields {
-			if err = addMultipartFormField(w, mf); err != nil {
-				return
-			}
+	for _, mf := range r.multipartFields {
+		if err := addMultipartFormField(w, mf); err != nil {
+			return err
 		}
 	}
 
 	r.Header.Set(hdrContentTypeKey, w.FormDataContentType())
-	err = w.Close()
-
-	return
+	return w.Close()
 }
 
 func handleFormData(c *Client, r *Request) {

--- a/middleware.go
+++ b/middleware.go
@@ -405,20 +405,15 @@ func handleMultipart(c *Client, r *Request) error {
 }
 
 func handleFormData(c *Client, r *Request) {
-	formData := url.Values{}
-	for k, v := range r.FormData {
-		formData[k] = v[:]
-	}
-
 	for k, v := range c.FormData {
-		if _, ok := formData[k]; ok {
+		if _, ok := r.FormData[k]; ok {
 			continue
 		}
-		formData[k] = v[:]
+		r.FormData[k] = v[:]
 	}
 
 	r.bodyBuf = acquireBuffer()
-	r.bodyBuf.WriteString(formData.Encode())
+	r.bodyBuf.WriteString(r.FormData.Encode())
 	r.Header.Set(hdrContentTypeKey, formContentType)
 	r.isFormData = true
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,9 +1,15 @@
 package resty
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -340,6 +346,560 @@ func Benchmark_parseRequestHeader(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		if err := parseRequestHeader(c, r); err != nil {
 			b.Errorf("parseRequestHeader() error = %v", err)
+		}
+	}
+}
+
+func Test_parseRequestBody(t *testing.T) {
+	for _, tt := range []struct {
+		name                  string
+		init                  func(c *Client, r *Request)
+		expectedBodyBuf       []byte
+		expectedContentLength string
+		expectedContentType   string
+	}{
+		{
+			name: "empty body",
+			init: func(c *Client, r *Request) {},
+		},
+		{
+			name: "empty body with SetContentLength by request",
+			init: func(c *Client, r *Request) {
+				r.SetContentLength(true)
+			},
+			expectedContentLength: "0",
+		},
+		{
+			name: "empty body with SetContentLength by client",
+			init: func(c *Client, r *Request) {
+				c.SetContentLength(true)
+			},
+			expectedContentLength: "0",
+		},
+		{
+			name: "string body",
+			init: func(c *Client, r *Request) {
+				r.SetBody("foo")
+			},
+			expectedBodyBuf:     []byte("foo"),
+			expectedContentType: plainTextType,
+		},
+		{
+			name: "string body with GET method",
+			init: func(c *Client, r *Request) {
+				r.SetBody("foo")
+				r.Method = http.MethodGet
+			},
+		},
+		{
+			name: "string body with GET method and AllowGetMethodPayload",
+			init: func(c *Client, r *Request) {
+				c.SetAllowGetMethodPayload(true)
+				r.SetBody("foo")
+				r.Method = http.MethodGet
+			},
+			expectedBodyBuf:     []byte("foo"),
+			expectedContentType: plainTextType,
+		},
+		{
+			name: "string body with HEAD method",
+			init: func(c *Client, r *Request) {
+				r.SetBody("foo")
+				r.Method = http.MethodHead
+			},
+		},
+		{
+			name: "string body with OPTIONS method",
+			init: func(c *Client, r *Request) {
+				r.SetBody("foo")
+				r.Method = http.MethodOptions
+			},
+		},
+		{
+			name: "string body with POST method",
+			init: func(c *Client, r *Request) {
+				r.SetBody("foo")
+				r.Method = http.MethodPost
+			},
+			expectedBodyBuf:     []byte("foo"),
+			expectedContentType: plainTextType,
+		},
+		{
+			name: "string body with PATCH method",
+			init: func(c *Client, r *Request) {
+				r.SetBody("foo")
+				r.Method = http.MethodPatch
+			},
+			expectedBodyBuf:     []byte("foo"),
+			expectedContentType: plainTextType,
+		},
+		{
+			name: "string body with PUT method",
+			init: func(c *Client, r *Request) {
+				r.SetBody("foo")
+				r.Method = http.MethodPut
+			},
+			expectedBodyBuf:     []byte("foo"),
+			expectedContentType: plainTextType,
+		},
+		{
+			name: "string body with DELETE method",
+			init: func(c *Client, r *Request) {
+				r.SetBody("foo")
+				r.Method = http.MethodDelete
+			},
+			expectedBodyBuf:     []byte("foo"),
+			expectedContentType: plainTextType,
+		},
+		{
+			name: "string body with CONNECT method",
+			init: func(c *Client, r *Request) {
+				r.SetBody("foo")
+				r.Method = http.MethodConnect
+			},
+			expectedBodyBuf:     []byte("foo"),
+			expectedContentType: plainTextType,
+		},
+		{
+			name: "string body with TRACE method",
+			init: func(c *Client, r *Request) {
+				r.SetBody("foo")
+				r.Method = http.MethodTrace
+			},
+			expectedBodyBuf:     []byte("foo"),
+			expectedContentType: plainTextType,
+		},
+		{
+			name: "string body with BAR method",
+			init: func(c *Client, r *Request) {
+				r.SetBody("foo")
+				r.Method = "BAR"
+			},
+			expectedBodyBuf:     []byte("foo"),
+			expectedContentType: plainTextType,
+		},
+		{
+			name: "byte body",
+			init: func(c *Client, r *Request) {
+				r.SetBody([]byte("foo"))
+			},
+			expectedBodyBuf:     []byte("foo"),
+			expectedContentType: plainTextType,
+		},
+		{
+			name: "io.Reader body, no bodyBuf",
+			init: func(c *Client, r *Request) {
+				r.SetBody(bytes.NewBufferString("foo"))
+			},
+			expectedContentType: jsonContentType,
+		},
+		{
+			name: "io.Reader body with SetContentLength by request",
+			init: func(c *Client, r *Request) {
+				r.SetBody(bytes.NewBufferString("foo")).
+					SetContentLength(true)
+			},
+			expectedBodyBuf:       []byte("foo"),
+			expectedContentLength: "3",
+			expectedContentType:   jsonContentType,
+		},
+		{
+			name: "io.Reader body with SetContentLength by client",
+			init: func(c *Client, r *Request) {
+				c.SetContentLength(true)
+				r.SetBody(bytes.NewBufferString("foo"))
+			},
+			expectedBodyBuf:       []byte("foo"),
+			expectedContentLength: "3",
+			expectedContentType:   jsonContentType,
+		},
+		{
+			name: "form data by request",
+			init: func(c *Client, r *Request) {
+				r.SetFormData(map[string]string{
+					"foo": "1",
+					"bar": "2",
+				})
+			},
+			expectedBodyBuf:     []byte("foo=1&bar=2"),
+			expectedContentType: formContentType,
+		},
+		{
+			name: "form data by client",
+			init: func(c *Client, r *Request) {
+				c.SetFormData(map[string]string{
+					"foo": "1",
+					"bar": "2",
+				})
+			},
+			expectedBodyBuf:     []byte("foo=1&bar=2"),
+			expectedContentType: formContentType,
+		},
+		{
+			name: "form data by client and request",
+			init: func(c *Client, r *Request) {
+				c.SetFormData(map[string]string{
+					"foo": "1",
+					"bar": "2",
+				})
+				r.SetFormData(map[string]string{
+					"foo": "3",
+					"baz": "4",
+				})
+			},
+			expectedBodyBuf:     []byte("foo=3&bar=2&baz=4"),
+			expectedContentType: formContentType,
+		},
+		{
+			name: "json from struct",
+			init: func(c *Client, r *Request) {
+				r.SetBody(struct {
+					Foo string `json:"foo"`
+					Bar string `json:"bar"`
+				}{
+					Foo: "1",
+					Bar: "2",
+				}).SetContentLength(true)
+			},
+			expectedBodyBuf:       []byte(`{"foo":"1","bar":"2"}`),
+			expectedContentType:   jsonContentType,
+			expectedContentLength: "21",
+		},
+		{
+			name: "json from slice",
+			init: func(c *Client, r *Request) {
+				r.SetBody([]string{"foo", "bar"}).SetContentLength(true)
+			},
+			expectedBodyBuf:       []byte(`["foo","bar"]`),
+			expectedContentType:   jsonContentType,
+			expectedContentLength: "13",
+		},
+		{
+			name: "json from map",
+			init: func(c *Client, r *Request) {
+				r.SetBody(map[string]interface{}{
+					"foo": "1",
+					"bar": []int{1, 2, 3},
+					"baz": map[string]string{
+						"qux": "4",
+					},
+					"xyz": nil,
+				}).SetContentLength(true)
+			},
+			expectedBodyBuf:       []byte(`{"bar":[1,2,3],"baz":{"qux":"4"},"foo":"1","xyz":null}`),
+			expectedContentType:   jsonContentType,
+			expectedContentLength: "54",
+		},
+		{
+			name: "json from map",
+			init: func(c *Client, r *Request) {
+				r.SetBody(map[string]interface{}{
+					"foo": "1",
+					"bar": []int{1, 2, 3},
+					"baz": map[string]string{
+						"qux": "4",
+					},
+					"xyz": nil,
+				}).SetContentLength(true)
+			},
+			expectedBodyBuf:       []byte(`{"bar":[1,2,3],"baz":{"qux":"4"},"foo":"1","xyz":null}`),
+			expectedContentType:   jsonContentType,
+			expectedContentLength: "54",
+		},
+		{
+			name: "json from map",
+			init: func(c *Client, r *Request) {
+				r.SetBody(map[string]interface{}{
+					"foo": "1",
+					"bar": []int{1, 2, 3},
+					"baz": map[string]string{
+						"qux": "4",
+					},
+					"xyz": nil,
+				}).SetContentLength(true)
+			},
+			expectedBodyBuf:       []byte(`{"bar":[1,2,3],"baz":{"qux":"4"},"foo":"1","xyz":null}`),
+			expectedContentType:   jsonContentType,
+			expectedContentLength: "54",
+		},
+		{
+			name: "xml from struct",
+			init: func(c *Client, r *Request) {
+				type FooBar struct {
+					Foo string `xml:"foo"`
+					Bar string `xml:"bar"`
+				}
+				r.SetBody(FooBar{
+					Foo: "1",
+					Bar: "2",
+				}).
+					SetContentLength(true).
+					SetHeader(hdrContentTypeKey, "text/xml")
+			},
+			expectedBodyBuf:       []byte(`<FooBar><foo>1</foo><bar>2</bar></FooBar>`),
+			expectedContentType:   "text/xml",
+			expectedContentLength: "41",
+		},
+		{
+			name: "mulipart form data",
+			init: func(c *Client, r *Request) {
+				c.SetFormData(map[string]string{
+					"foo": "1",
+					"bar": "2",
+				})
+				r.SetFormData(map[string]string{
+					"foo": "3",
+					"baz": "4",
+				})
+				r.SetMultipartFormData(map[string]string{
+					"foo": "5",
+					"xyz": "6",
+				}).SetContentLength(true)
+			},
+			expectedBodyBuf:       []byte(`{"bar":"2", "baz":"4", "foo":"5", "xyz":"6"}`),
+			expectedContentType:   "multipart/form-data; boundary=",
+			expectedContentLength: "744",
+		},
+		{
+			name: "mulipart fields",
+			init: func(c *Client, r *Request) {
+				r.SetMultipartFields(
+					&MultipartField{
+						Param:       "foo",
+						ContentType: "text/plain",
+						Reader:      strings.NewReader("1"),
+					},
+					&MultipartField{
+						Param:       "bar",
+						ContentType: "text/plain",
+						Reader:      strings.NewReader("2"),
+					},
+				).SetContentLength(true)
+			},
+			expectedBodyBuf:       []byte(`{"bar":"2","foo":"1"}`),
+			expectedContentType:   "multipart/form-data; boundary=",
+			expectedContentLength: "344",
+		},
+		{
+			name: "mulipart files",
+			init: func(c *Client, r *Request) {
+				r.SetFileReader("foo", "foo.txt", strings.NewReader("1")).
+					SetFileReader("bar", "bar.txt", strings.NewReader("2")).
+					SetContentLength(true)
+			},
+			expectedBodyBuf:       []byte(`{"bar":"2","foo":"1"}`),
+			expectedContentType:   "multipart/form-data; boundary=",
+			expectedContentLength: "412",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := New()
+			r := c.R()
+			tt.init(c, r)
+			if err := parseRequestBody(c, r); err != nil {
+				t.Errorf("parseRequestBody() error = %v", err)
+			}
+			switch {
+			case r.bodyBuf == nil && tt.expectedBodyBuf != nil:
+				t.Errorf("bodyBuf is nil, but expected: %s", string(tt.expectedBodyBuf))
+			case r.bodyBuf != nil && tt.expectedBodyBuf == nil:
+				t.Errorf("bodyBuf is not nil, but expected nil: %s", r.bodyBuf.String())
+			case r.bodyBuf != nil && tt.expectedBodyBuf != nil:
+				var actual, expected interface{} = r.bodyBuf.Bytes(), tt.expectedBodyBuf
+				if r.isFormData {
+					var err error
+					actual, err = url.ParseQuery(r.bodyBuf.String())
+					if err != nil {
+						t.Errorf("ParseQuery(r.bodyBuf) error = %v", err)
+					}
+					expected, err = url.ParseQuery(string(tt.expectedBodyBuf))
+					if err != nil {
+						t.Errorf("ParseQuery(tt.expectedBodyBuf) error = %v", err)
+					}
+				} else if r.isMultiPart {
+					_, params, err := mime.ParseMediaType(r.Header.Get(hdrContentTypeKey))
+					if err != nil {
+						t.Errorf("ParseMediaType(hdrContentTypeKey) error = %v", err)
+					}
+					boundary, ok := params["boundary"]
+					if !ok {
+						t.Errorf("boundary not found in Content-Type header")
+					}
+					reader := multipart.NewReader(r.bodyBuf, boundary)
+					body := make(map[string]interface{})
+					for part, perr := reader.NextPart(); perr != io.EOF; part, perr = reader.NextPart() {
+						if perr != nil {
+							t.Errorf("NextPart() error = %v", perr)
+						}
+						name := part.FormName()
+						if name == "" {
+							name = part.FileName()
+						}
+						data, err := io.ReadAll(part)
+						if err != nil {
+							t.Errorf("ReadAll(part) error = %v", err)
+						}
+						body[name] = string(data)
+					}
+					actual = body
+					expected = nil
+					if err := json.Unmarshal(tt.expectedBodyBuf, &expected); err != nil {
+						t.Errorf("json.Unmarshal(tt.expectedBodyBuf) error = %v", err)
+					}
+					t.Logf(`in case of an error, the expected body should be set as json for object: %#+v`, actual)
+				}
+				if !reflect.DeepEqual(actual, expected) {
+					t.Errorf("bodyBuf = %q does not match expected %q", r.bodyBuf.String(), string(tt.expectedBodyBuf))
+				}
+			}
+			if tt.expectedContentLength != r.Header.Get(hdrContentLengthKey) {
+				t.Errorf("Content-Length header = %q does not match expected %q", r.Header.Get(hdrContentLengthKey), tt.expectedContentLength)
+			}
+			if ct := r.Header.Get(hdrContentTypeKey); !((tt.expectedContentType == "" && ct != "") || strings.Contains(ct, tt.expectedContentType)) {
+				t.Errorf("Content-Type header = %q does not match expected %q", r.Header.Get(hdrContentTypeKey), tt.expectedContentType)
+			}
+		})
+	}
+}
+
+func Benchmark_parseRequestBody_string(b *testing.B) {
+	c := New()
+	r := c.R()
+	r.SetBody("foo").SetContentLength(true)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_byte(b *testing.B) {
+	c := New()
+	r := c.R()
+	r.SetBody([]byte("foo")).SetContentLength(true)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_reader_with_SetContentLength(b *testing.B) {
+	c := New()
+	r := c.R()
+	r.SetBody(bytes.NewBufferString("foo")).SetContentLength(true)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+func Benchmark_parseRequestBody_reader_without_SetContentLength(b *testing.B) {
+	c := New()
+	r := c.R()
+	r.SetBody(bytes.NewBufferString("foo"))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_struct(b *testing.B) {
+	type FooBar struct {
+		Foo string `json:"foo"`
+		Bar string `json:"bar"`
+	}
+	c := New()
+	r := c.R()
+	r.SetBody(FooBar{Foo: "1", Bar: "2"}).SetContentLength(true).SetHeader(hdrContentTypeKey, jsonContentType)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_struct_xml(b *testing.B) {
+	type FooBar struct {
+		Foo string `xml:"foo"`
+		Bar string `xml:"bar"`
+	}
+	c := New()
+	r := c.R()
+	r.SetBody(FooBar{Foo: "1", Bar: "2"}).SetContentLength(true).SetHeader(hdrContentTypeKey, "text/xml")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_map(b *testing.B) {
+	c := New()
+	r := c.R()
+	r.SetBody(map[string]string{
+		"foo": "1",
+		"bar": "2",
+	}).SetContentLength(true).SetHeader(hdrContentTypeKey, jsonContentType)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_slice(b *testing.B) {
+	c := New()
+	r := c.R()
+	r.SetBody([]string{"1", "2"}).SetContentLength(true).SetHeader(hdrContentTypeKey, jsonContentType)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_FormData(b *testing.B) {
+	c := New()
+	r := c.R()
+	c.SetFormData(map[string]string{"foo": "1", "bar": "2"})
+	r.SetFormData(map[string]string{"foo": "3", "baz": "4"}).SetContentLength(true)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_MultiPart(b *testing.B) {
+	c := New()
+	r := c.R()
+	c.SetFormData(map[string]string{"foo": "1", "bar": "2"})
+	r.SetFormData(map[string]string{"foo": "3", "baz": "4"}).
+		SetMultipartFormData(map[string]string{"foo": "5", "xyz": "6"}).
+		SetFileReader("qwe", "qwe.txt", strings.NewReader("7")).
+		SetMultipartFields(
+			&MultipartField{
+				Param:       "sdj",
+				ContentType: "text/plain",
+				Reader:      strings.NewReader("8"),
+			},
+		).
+		SetContentLength(true)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
 		}
 	}
 }


### PR DESCRIPTION
Improve the `parseRequestBody` function and all nested functions.

Original benchmarks:
```shell
% go test -benchmem -bench=. -run=^Benchmark
goos: darwin
goarch: amd64
pkg: github.com/go-resty/resty/v2
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
Benchmark_parseRequestBody_string-16       2199196    550.3 ns/op     128 B/op      3 allocs/op
Benchmark_parseRequestBody_byte-16         2264421    532.9 ns/op     128 B/op      3 allocs/op
Benchmark_parseRequestBody_reader-16       8307141    141.8 ns/op      16 B/op      1 allocs/op
Benchmark_parseRequestBody_struct-16        931632     1317 ns/op     156 B/op      5 allocs/op
Benchmark_parseRequestBody_struct_xml-16    409074     2921 ns/op    4765 B/op     13 allocs/op
Benchmark_parseRequestBody_map-16           566750     2158 ns/op     570 B/op     15 allocs/op
Benchmark_parseRequestBody_slice-16         957828     1279 ns/op     146 B/op      4 allocs/op
Benchmark_parseRequestBody_FormData-16      954213     1266 ns/op     304 B/op     14 allocs/op
Benchmark_parseRequestBody_MultiPart-16      94276    12538 ns/op    8746 B/op    131 allocs/op
```

After the improvements:
```shell
Benchmark_parseRequestBody_string-16                              7635237    155.7 ns/op      16 B/op      1 allocs/op
Benchmark_parseRequestBody_byte-16                                8453085    140.4 ns/op      16 B/op      1 allocs/op
Benchmark_parseRequestBody_reader_with_SetContentLength-16       17494558    67.62 ns/op      16 B/op      1 allocs/op
Benchmark_parseRequestBody_reader_without_SetContentLength-16    26582679    45.11 ns/op       0 B/op      0 allocs/op
Benchmark_parseRequestBody_struct-16                              1264702    943.9 ns/op      40 B/op      2 allocs/op
Benchmark_parseRequestBody_struct_xml-16                           479361     2496 ns/op    4645 B/op     10 allocs/op
Benchmark_parseRequestBody_map-16                                  685204     1770 ns/op     454 B/op     12 allocs/op
Benchmark_parseRequestBody_slice-16                               1318749    910.2 ns/op      32 B/op      2 allocs/op
Benchmark_parseRequestBody_FormData-16                            1000000     1116 ns/op     272 B/op      9 allocs/op
Benchmark_parseRequestBody_MultiPart-16                             92143    12532 ns/op    8738 B/op    130 allocs/op
```