### PR TITLE
fix: Improve Digest WWW-Authenticate response header parsing compatibility

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -133,14 +133,17 @@ func parseChallenge(input string) (*challenge, error) {
 		return nil, ErrDigestBadChallenge
 	}
 	s = strings.Trim(s[7:], ws)
-	sl := strings.Split(s, ", ")
+	sl := strings.Split(s, ",")
 	c := &challenge{}
 	var r []string
 	for i := range sl {
+		sl[i] = strings.TrimSpace(sl[i])
 		r = strings.SplitN(sl[i], "=", 2)
 		if len(r) != 2 {
 			return nil, ErrDigestBadChallenge
 		}
+		r[0] = strings.TrimSpace(r[0])
+		r[1] = strings.TrimSpace(r[1])
 		switch r[0] {
 		case "realm":
 			c.realm = strings.Trim(r[1], qs)
@@ -151,9 +154,9 @@ func parseChallenge(input string) (*challenge, error) {
 		case "opaque":
 			c.opaque = strings.Trim(r[1], qs)
 		case "stale":
-			c.stale = r[1]
+			c.stale = strings.Trim(r[1], qs)
 		case "algorithm":
-			c.algorithm = r[1]
+			c.algorithm = strings.Trim(r[1], qs)
 		case "qop":
 			c.qop = strings.Trim(r[1], qs)
 		case "charset":


### PR DESCRIPTION
Improve Digest WWW-Authenticate response header parsing compatibility

1. Use commas to disassemble WWW-Authenticate instead of commas and spaces.
2. Clear the spaces before and after each key-value pair.
3. Added double quote clearing operation for stale and algorithm values.