### PR TITLE
Security: Don't put the same bytes.Buffer into sync.Pool twice

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -481,7 +481,6 @@ func handleContentType(c *Client, r *Request) {
 
 func handleRequestBody(c *Client, r *Request) error {
 	var bodyBytes []byte
-	releaseBuffer(r.bodyBuf)
 	r.bodyBuf = nil
 
 	switch body := r.Body.(type) {


### PR DESCRIPTION
This fixes #743, possibly #739.

Discovered this while tracking down an issue in https://github.com/linode/terraform-provider-linode.

The removed call to sync.Pool.Put is handled by the request body wrapper that puts the buffer back in the pool when the body is closed.

