### PR TITLE
fix: trailing NULL bytes in buffer while detecting a content type

### DIFF
--- a/middleware_test.go
+++ b/middleware_test.go
@@ -756,7 +756,7 @@ func Test_parseRequestBody(t *testing.T) {
 			expectedContentLength: "744",
 		},
 		{
-			name: "mulipart fields",
+			name: "multipart fields",
 			init: func(c *Client, r *Request) {
 				r.SetMultipartFields(
 					&MultipartField{
@@ -776,7 +776,7 @@ func Test_parseRequestBody(t *testing.T) {
 			expectedContentLength: "344",
 		},
 		{
-			name: "mulipart files",
+			name: "multipart files",
 			init: func(c *Client, r *Request) {
 				r.SetFileReader("foo", "foo.txt", strings.NewReader("1")).
 					SetFileReader("bar", "bar.txt", strings.NewReader("2")).
@@ -784,7 +784,7 @@ func Test_parseRequestBody(t *testing.T) {
 			},
 			expectedBodyBuf:       []byte(`{"bar":"2","foo":"1"}`),
 			expectedContentType:   "multipart/form-data; boundary=",
-			expectedContentLength: "412",
+			expectedContentLength: "414",
 		},
 		{
 			name: "body with errorReader",

--- a/util.go
+++ b/util.go
@@ -216,7 +216,7 @@ func writeMultipartFormFile(w *multipart.Writer, fieldName, fileName string, r i
 		return err
 	}
 
-	partWriter, err := w.CreatePart(createMultipartHeader(fieldName, fileName, http.DetectContentType(cbuf)))
+	partWriter, err := w.CreatePart(createMultipartHeader(fieldName, fileName, http.DetectContentType(cbuf[:size])))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #754 