### PR TITLE
fix: encode path params with BaseURL and the first param at index zero (#781)

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -57,7 +57,7 @@ func parseRequestURL(c *Client, r *Request) error {
 			buf := acquireBuffer()
 			defer releaseBuffer(buf)
 			// search for the next or first opened curly bracket
-			for curr := strings.Index(r.URL, "{"); curr > prev; curr = prev + strings.Index(r.URL[prev:], "{") {
+			for curr := strings.Index(r.URL, "{"); curr == 0 || curr > prev; curr = prev + strings.Index(r.URL[prev:], "{") {
 				// write everything from the previous position up to the current
 				if curr > prev {
 					buf.WriteString(r.URL[prev:curr])

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -146,6 +146,16 @@ func Test_parseRequestURL(t *testing.T) {
 			expectedURL: "https://example.com/1/2",
 		},
 		{
+			name: "using base url with path param at index 0",
+			init: func(c *Client, r *Request) {
+				c.SetBaseURL("https://example.com/prefix")
+				r.SetPathParam("first", "1").
+					SetPathParam("second", "2")
+				r.URL = "{first}/{second}"
+			},
+			expectedURL: "https://example.com/prefix/1/2",
+		},
+		{
 			name: "using BaseURL with absolute URL in request",
 			init: func(c *Client, r *Request) {
 				c.SetBaseURL("https://foo.bar") // ignored


### PR DESCRIPTION
Related issue https://github.com/go-resty/resty/issues/781