### PR TITLE
feat(curl): generate curl cmd for request && example for curl cmd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: diff -u <(echo -n) <(go fmt $(go list ./...))
 
       - name: Test
-        run: go test ./... -race -coverprofile=coverage.txt -covermode=atomic
+        run: go test ./... -race -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... 
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -29,7 +29,7 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Test
-        run: go test ./... -race -coverprofile=coverage.txt -covermode=atomic
+        run: go test ./... -race -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...
 
       - name: Coverage
         run: bash <(curl -s https://codecov.io/bash)

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@ _testmain.go
 coverage.out
 coverage.txt
 
-# Exclude intellij IDE folders
+# Exclude IDE folders
 .idea/*
+.vscode/*

--- a/README.md
+++ b/README.md
@@ -126,11 +126,16 @@ import "github.com/go-resty/resty/v2"
 
 ```go
 // Create a Resty Client
+var curlCmdExecuted string
 client := resty.New()
 
 resp, err := client.R().
+    SetResultCurlCmd(&curlCmdExecuted).
     EnableTrace().
     Get("https://httpbin.org/get")
+
+// Explore curl command
+fmt.Println("Curl Command:\n  ", curlCmdExecuted+"\n")
 
 // Explore response object
 fmt.Println("Response Info:")
@@ -160,6 +165,9 @@ fmt.Println("  RequestAttempt:", ti.RequestAttempt)
 fmt.Println("  RemoteAddr    :", ti.RemoteAddr.String())
 
 /* Output
+Curl Command:
+  curl -X GET -H 'User-Agent: go-resty/2.12.0 (https://github.com/go-resty/resty)'  https://httpbin.org/get
+
 Response Info:
   Error      : <nil>
   Status Code: 200

--- a/README.md
+++ b/README.md
@@ -126,13 +126,13 @@ import "github.com/go-resty/resty/v2"
 
 ```go
 // Create a Resty Client
-var curlCmdExecuted string
 client := resty.New()
 
 resp, err := client.R().
-    SetResultCurlCmd(&curlCmdExecuted).
     EnableTrace().
     Get("https://httpbin.org/get")
+curlCmdExecuted := resp.Request.GenerateCurlCommand()
+
 
 // Explore curl command
 fmt.Println("Curl Command:\n  ", curlCmdExecuted+"\n")

--- a/client.go
+++ b/client.go
@@ -1148,7 +1148,7 @@ func (c *Client) Clone() *Client {
 // Client Unexported methods
 //_______________________________________________________________________
 
-func (c *Client) executeBefore(req *Request) (error) {
+func (c *Client) executeBefore(req *Request) error {
 	// Lock the user-defined pre-request hooks.
 	c.udBeforeRequestLock.RLock()
 	defer c.udBeforeRequestLock.RUnlock()
@@ -1190,7 +1190,7 @@ func (c *Client) executeBefore(req *Request) (error) {
 	// call pre-request if defined
 	if c.preReqHook != nil {
 		if err = c.preReqHook(c, req.RawRequest); err != nil {
-			return  wrapNoRetryErr(err)
+			return wrapNoRetryErr(err)
 		}
 	}
 
@@ -1205,7 +1205,7 @@ func (c *Client) executeBefore(req *Request) (error) {
 // Executes method executes the given `Request` object and returns response
 // error.
 func (c *Client) execute(req *Request) (*Response, error) {
-	if err:= c.executeBefore(req);err!=nil{
+	if err := c.executeBefore(req); err != nil {
 		return nil, err
 	}
 

--- a/examples/debug_curl_test.go
+++ b/examples/debug_curl_test.go
@@ -1,15 +1,17 @@
 package examples
 
 import (
+	"io"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
 )
 
-// Example about generating curl command
-func TestDebugCurl(t *testing.T) {
+// 1. Generate curl for unexecuted request(dry-run)
+func TestGenerateUnexcutedCurl(t *testing.T) {
 	ts := createHttpbinServer(0)
 	defer ts.Close()
 
@@ -17,27 +19,108 @@ func TestDebugCurl(t *testing.T) {
 		"name": "Alex",
 	}).SetCookies(
 		[]*http.Cookie{
-			{ Name:  "count", Value: "1", }, 
+			{Name: "count", Value: "1"},
 		},
 	)
 
-	// 1. Generate curl for request(dry-run: request isn't executed)
-	curlCmdUnexecuted := req.GetCurlCmd()
-	if !strings.Contains(curlCmdUnexecuted, "Cookie: count=1") || !strings.Contains(curlCmdUnexecuted, "curl -X GET") {
-		t.Fatal("bad curl:", curlCmdUnexecuted)
-	}else{
-		t.Log("curlCmdUnexecuted: \n",curlCmdUnexecuted)
+	curlCmdUnexecuted := req.GenerateCurlCommand()
+
+	if !strings.Contains(curlCmdUnexecuted, "Cookie: count=1") ||
+		!strings.Contains(curlCmdUnexecuted, "curl -X GET") ||
+		!strings.Contains(curlCmdUnexecuted, `-d '{"name":"Alex"}'`) {
+		t.Fatal("Incomplete curl:", curlCmdUnexecuted)
+	} else {
+		t.Log("curlCmdUnexecuted: \n", curlCmdUnexecuted)
 	}
 
-	// 2. Generate curl for request(request is executed)
-	var curlCmdExecuted string
-	req.SetResultCurlCmd(&curlCmdExecuted)
-	if _, err := req.Post(ts.URL+"/post"); err != nil {
+}
+
+// 2. Generate curl for executed request
+func TestGenerateExecutedCurl(t *testing.T) {
+	ts := createHttpbinServer(0)
+	defer ts.Close()
+
+	data := map[string]string{
+		"name": "Alex",
+	}
+	req := resty.New().R().SetBody(data).SetCookies(
+		[]*http.Cookie{
+			{Name: "count", Value: "1"},
+		},
+	)
+
+	url := ts.URL + "/post"
+	resp, err := req.
+		EnableTrace().
+		Post(url)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(curlCmdExecuted, "Cookie: count=1") || !strings.Contains(curlCmdExecuted, "curl -X POST") {
-		t.Fatal("bad curl:", curlCmdExecuted)
-	}else{
-		t.Log("curlCmdExecuted: \n",curlCmdExecuted)
+	curlCmdExecuted := resp.Request.GenerateCurlCommand()
+	if !strings.Contains(curlCmdExecuted, "Cookie: count=1") ||
+		!strings.Contains(curlCmdExecuted, "curl -X POST") ||
+		!strings.Contains(curlCmdExecuted, `-d '{"name":"Alex"}'`) ||
+		!strings.Contains(curlCmdExecuted, url) {
+		t.Fatal("Incomplete curl:", curlCmdExecuted)
+	} else {
+		t.Log("curlCmdExecuted: \n", curlCmdExecuted)
 	}
+}
+
+// 3. Generate curl in debug mode
+func TestDebugModeCurl(t *testing.T) {
+	ts := createHttpbinServer(0)
+	defer ts.Close()
+
+	// 1. Capture stderr
+	getOutput, restore := captureStderr()
+	defer restore()
+
+	// 2. Build request
+	req := resty.New().R().SetBody(map[string]string{
+		"name": "Alex",
+	}).SetCookies(
+		[]*http.Cookie{
+			{Name: "count", Value: "1"},
+		},
+	)
+
+	// 3. Execute request: set debug mode
+	url := ts.URL + "/post"
+	_, err := req.SetDebug(true).Post(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 4. test output curl
+	output := getOutput()
+	if !strings.Contains(output, "Cookie: count=1") ||
+		!strings.Contains(output, `-d '{"name":"Alex"}'`) {
+		t.Fatal("Incomplete debug curl info:", output)
+	} else {
+		t.Log("Normal debug curl info: \n", output)
+	}
+}
+
+func captureStderr() (getOutput func() string, restore func()) {
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	os.Stderr = w
+	getOutput = func() string {
+		w.Close()
+		buf := make([]byte, 2048)
+		n, err := r.Read(buf)
+		if err != nil && err != io.EOF {
+			panic(err)
+		}
+		return string(buf[:n])
+	}
+	restore = func() {
+		os.Stderr = old
+		w.Close()
+	}
+	return getOutput, restore
 }

--- a/examples/debug_curl_test.go
+++ b/examples/debug_curl_test.go
@@ -1,0 +1,43 @@
+package examples
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+)
+
+// Example about generating curl command
+func TestDebugCurl(t *testing.T) {
+	ts := createHttpbinServer(0)
+	defer ts.Close()
+
+	req := resty.New().R().SetBody(map[string]string{
+		"name": "Alex",
+	}).SetCookies(
+		[]*http.Cookie{
+			{ Name:  "count", Value: "1", }, 
+		},
+	)
+
+	// 1. Generate curl for request(dry-run: request isn't executed)
+	curlCmdUnexecuted := req.GetCurlCmd()
+	if !strings.Contains(curlCmdUnexecuted, "Cookie: count=1") || !strings.Contains(curlCmdUnexecuted, "curl -X GET") {
+		t.Fatal("bad curl:", curlCmdUnexecuted)
+	}else{
+		t.Log("curlCmdUnexecuted: \n",curlCmdUnexecuted)
+	}
+
+	// 2. Generate curl for request(request is executed)
+	var curlCmdExecuted string
+	req.SetResultCurlCmd(&curlCmdExecuted)
+	if _, err := req.Post(ts.URL+"/post"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(curlCmdExecuted, "Cookie: count=1") || !strings.Contains(curlCmdExecuted, "curl -X POST") {
+		t.Fatal("bad curl:", curlCmdExecuted)
+	}else{
+		t.Log("curlCmdExecuted: \n",curlCmdExecuted)
+	}
+}

--- a/examples/server_test.go
+++ b/examples/server_test.go
@@ -1,0 +1,162 @@
+package examples
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	ioutil "io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+)
+
+const maxMultipartMemory = 4 << 30 // 4MB
+
+// tlsCert:
+//
+//	0 No certificate
+//	1 With self-signed certificate
+//	2 With custom certificate from CA(todo)
+func createHttpbinServer(tlsCert int) (ts *httptest.Server) {
+	ts = createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		httpbinHandler(w, r)
+	}, tlsCert)
+
+	return ts
+}
+
+func httpbinHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	body, _ := ioutil.ReadAll(r.Body)
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(body)) // important!!
+	m := map[string]interface{}{
+		"args":    parseRequestArgs(r),
+		"headers": dumpRequestHeader(r),
+		"data":    string(body),
+		"json": nil,
+		"form":   map[string]string{},
+		"files":   map[string]string{},
+		"method":  r.Method,
+		"origin":  r.RemoteAddr,
+		"url":     r.URL.String(),
+	}
+
+	// 1. parse text/plain
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "text/plain") {
+		m["data"] = string(body)
+	}
+
+	// 2. parse application/json
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
+		var data interface{}
+		if err := json.Unmarshal(body, &data); err != nil {
+			m["err"] = err.Error()
+		} else {
+			m["json"] = data
+		}
+	}
+
+	// 3. parse application/x-www-form-urlencoded
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
+		m["form"] = parseQueryString(string(body))
+	}
+
+	// 4. parse multipart/form-data
+	if strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data") {
+		form, files := readMultipartForm(r)
+		m["form"] = form
+		m["files"] = files
+	}
+	buf, _ := json.Marshal(m)
+	_, _ = w.Write(buf)
+}
+
+func readMultipartForm(r *http.Request) (map[string]string, map[string]string) {
+	if err := r.ParseMultipartForm(maxMultipartMemory); err != nil {
+		if err != http.ErrNotMultipart {
+			panic(fmt.Sprintf("error on parse multipart form array: %v", err))
+		}
+	}
+	// parse form data
+	formData := make(map[string]string)
+	for k, vs := range r.PostForm {
+		for _, v := range vs {
+			formData[k] = v
+		}
+	}
+	// parse files
+	files := make(map[string]string)
+	if r.MultipartForm != nil && r.MultipartForm.File != nil {
+		for key, fhs := range r.MultipartForm.File {
+			// if len(fhs)>0
+			// f, err := fhs[0].Open()
+			files[key] = fhs[0].Filename
+		}
+	}
+	return formData, files
+}
+
+func dumpRequestHeader(req *http.Request) string {
+	var res strings.Builder
+	headers := sortHeaders(req)
+	for _, kv := range headers {
+		res.WriteString(kv[0] + ": " + kv[1] + "\n")
+	}
+	return res.String()
+}
+
+// sortHeaders
+func sortHeaders(request *http.Request) [][2]string {
+	headers := [][2]string{}
+	for k, vs := range request.Header {
+		for _, v := range vs {
+			headers = append(headers, [2]string{k, v})
+		}
+	}
+	n := len(headers)
+	for i := 0; i < n; i++ {
+		for j := n - 1; j > i; j-- {
+			jj := j - 1
+			h1, h2 := headers[j], headers[jj]
+			if h1[0] < h2[0] {
+				headers[jj], headers[j] = headers[j], headers[jj]
+			}
+		}
+	}
+	return headers
+}
+
+func parseRequestArgs(request *http.Request) map[string]string {
+	query := request.URL.RawQuery
+	return parseQueryString(query)
+}
+
+func parseQueryString(query string) map[string]string {
+	params := map[string]string{}
+	paramsList, _ := url.ParseQuery(query)
+	for key, vals := range paramsList {
+		// params[key] = vals[len(vals)-1]
+		params[key] = strings.Join(vals, ",")
+	}
+	return params
+}
+
+/*
+*
+  - tlsCert:
+    0 no certificate
+    1 with self-signed certificate
+    2 with custom certificate from CA(todo)
+*/
+func createTestServer(fn func(w http.ResponseWriter, r *http.Request), tlsCert int) (ts *httptest.Server) {
+	if tlsCert == 0 {
+		// 1. http test server
+		ts = httptest.NewServer(http.HandlerFunc(fn))
+	} else if tlsCert == 1{
+		// 2. https test server: https://stackoverflow.com/questions/54899550/create-https-test-server-for-any-client
+		ts = httptest.NewUnstartedServer(http.HandlerFunc(fn))
+		ts.StartTLS()
+	}
+	return ts
+}

--- a/examples/server_test.go
+++ b/examples/server_test.go
@@ -34,8 +34,8 @@ func httpbinHandler(w http.ResponseWriter, r *http.Request) {
 		"args":    parseRequestArgs(r),
 		"headers": dumpRequestHeader(r),
 		"data":    string(body),
-		"json": nil,
-		"form":   map[string]string{},
+		"json":    nil,
+		"form":    map[string]string{},
 		"files":   map[string]string{},
 		"method":  r.Method,
 		"origin":  r.RemoteAddr,
@@ -153,7 +153,7 @@ func createTestServer(fn func(w http.ResponseWriter, r *http.Request), tlsCert i
 	if tlsCert == 0 {
 		// 1. http test server
 		ts = httptest.NewServer(http.HandlerFunc(fn))
-	} else if tlsCert == 1{
+	} else if tlsCert == 1 {
 		// 2. https test server: https://stackoverflow.com/questions/54899550/create-https-test-server-for-any-client
 		ts = httptest.NewUnstartedServer(http.HandlerFunc(fn))
 		ts.StartTLS()

--- a/middleware.go
+++ b/middleware.go
@@ -308,8 +308,11 @@ func addCredentials(c *Client, r *Request) error {
 }
 
 func createCurlCmd(c *Client, r *Request) (err error) {
-	if r.resultCurlCmd!=nil{
-		*r.resultCurlCmd = BuildCurlRequest(r.RawRequest, c.httpClient.Jar)
+	if r.trace {
+		if r.resultCurlCmd == nil {
+			r.resultCurlCmd = new(string)
+		}
+		*r.resultCurlCmd = buildCurlRequest(r.RawRequest, c.httpClient.Jar)
 	}
 	return nil
 }
@@ -337,7 +340,7 @@ func requestLogger(c *Client, r *Request) error {
 
 		reqLog := "\n==============================================================================\n" +
 			"~~~ REQUEST(curl) ~~~\n" +
-			fmt.Sprintf("CURL:\n	%v\n", BuildCurlRequest(r.RawRequest, r.client.httpClient.Jar)) +
+			fmt.Sprintf("CURL:\n	%v\n", buildCurlRequest(r.RawRequest, r.client.httpClient.Jar)) +
 			"~~~ REQUEST ~~~\n" +
 			fmt.Sprintf("%s  %s  %s\n", r.Method, rr.URL.RequestURI(), rr.Proto) +
 			fmt.Sprintf("HOST   : %s\n", rr.URL.Host) +

--- a/middleware.go
+++ b/middleware.go
@@ -307,6 +307,13 @@ func addCredentials(c *Client, r *Request) error {
 	return nil
 }
 
+func createCurlCmd(c *Client, r *Request) (err error) {
+	if r.resultCurlCmd!=nil{
+		*r.resultCurlCmd = BuildCurlRequest(r.RawRequest, c.httpClient.Jar)
+	}
+	return nil
+}
+
 func requestLogger(c *Client, r *Request) error {
 	if r.Debug {
 		rr := r.RawRequest
@@ -329,6 +336,8 @@ func requestLogger(c *Client, r *Request) error {
 		}
 
 		reqLog := "\n==============================================================================\n" +
+			"~~~ REQUEST(curl) ~~~\n" +
+			fmt.Sprintf("CURL:\n	%v\n", BuildCurlRequest(r.RawRequest, r.client.httpClient.Jar)) +
 			"~~~ REQUEST ~~~\n" +
 			fmt.Sprintf("%s  %s  %s\n", r.Method, rr.URL.RequestURI(), rr.Proto) +
 			fmt.Sprintf("HOST   : %s\n", rr.URL.Host) +

--- a/request.go
+++ b/request.go
@@ -39,6 +39,7 @@ type Request struct {
 	Time          time.Time
 	Body          interface{}
 	Result        interface{}
+	resultCurlCmd *string
 	Error         interface{}
 	RawRequest    *http.Request
 	SRV           *SRVRecord
@@ -71,6 +72,20 @@ type Request struct {
 	multipartFiles      []*File
 	multipartFields     []*MultipartField
 	retryConditions     []RetryConditionFunc
+}
+
+func (r *Request) GetCurlCmd() string {
+	// trigger beforeRequest from middleware
+	if r.RawRequest == nil {
+		r.client.executeBefore(r) // mock r.Get("/")
+	}
+	if r.resultCurlCmd == nil {
+		r.resultCurlCmd = new(string)
+	}
+	if *r.resultCurlCmd == "" {
+		*r.resultCurlCmd = BuildCurlRequest(r.RawRequest, r.client.httpClient.Jar)
+	}
+	return *r.resultCurlCmd
 }
 
 // Context method returns the Context if its already set in request
@@ -330,6 +345,12 @@ func (r *Request) SetResult(res interface{}) *Request {
 	if res != nil {
 		r.Result = getPointer(res)
 	}
+	return r
+}
+
+// This method is to register curl cmd for request executed.
+func (r *Request) SetResultCurlCmd(curlCmd *string) *Request {
+	r.resultCurlCmd = curlCmd
 	return r
 }
 

--- a/shellescape/shellescape.go
+++ b/shellescape/shellescape.go
@@ -6,7 +6,7 @@ POSIX shells.
 The original Python package which this work was inspired by can be found
 at https://pypi.python.org/pypi/shellescape.
 */
-package shellescape // "import gopkg.in/alessio/shellescape.v1"
+package shellescape
 
 import (
 	"regexp"

--- a/shellescape/shellescape.go
+++ b/shellescape/shellescape.go
@@ -1,0 +1,34 @@
+/*
+Package shellescape provides the shellescape.Quote to escape arbitrary
+strings for a safe use as command line arguments in the most common
+POSIX shells.
+
+The original Python package which this work was inspired by can be found
+at https://pypi.python.org/pypi/shellescape.
+*/
+package shellescape // "import gopkg.in/alessio/shellescape.v1"
+
+import (
+	"regexp"
+	"strings"
+)
+
+var pattern *regexp.Regexp
+
+func init() {
+	pattern = regexp.MustCompile(`[^\w@%+=:,./-]`)
+}
+
+// Quote returns a shell-escaped version of the string s. The returned value
+// is a string that can safely be used as one token in a shell command line.
+func Quote(s string) string {
+	if len(s) == 0 {
+		return "''"
+	}
+
+	if pattern.MatchString(s) {
+		return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+	}
+
+	return s
+}

--- a/util_curl.go
+++ b/util_curl.go
@@ -1,0 +1,77 @@
+package resty
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+
+	"net/url"
+	"strings"
+
+	"github.com/go-resty/resty/v2/shellescape"
+)
+
+func BuildCurlRequest(req *http.Request, httpCookiejar http.CookieJar) (curl string) {
+	// 1. Generate curl raw headers
+	curl = "curl -X " + req.Method + " "
+	// req.Host + req.URL.Path + "?" + req.URL.RawQuery + " " + req.Proto + " "
+	headers := dumpCurlHeaders(req)
+	for _, kv := range *headers {
+		curl += `-H ` + shellescape.Quote(kv[0]+": "+kv[1]) + ` `
+	}
+
+	// 2. Generate curl cookies
+	if cookieJar, ok := httpCookiejar.(*cookiejar.Jar); ok{
+		cookies := cookieJar.Cookies(req.URL)
+		if len(cookies) > 0 {
+			curl += ` -H ` + shellescape.Quote(dumpCurlCookies(cookies)) + " "
+		}
+	}
+
+
+	// 3. Generate curl body
+	if req.Body != nil {
+		buf, _ := io.ReadAll(req.Body)
+		req.Body = io.NopCloser(bytes.NewBuffer(buf)) // important!!
+		curl += `-d ` + shellescape.Quote(string(buf))
+	}
+
+	urlString := shellescape.Quote(req.URL.String())
+	if urlString == "''"{
+		urlString = "'http://unexecuted-url'"
+	}
+	curl += " " + urlString
+	return curl
+}
+
+// dumpCurlCookies dumps cookies to curl format
+func dumpCurlCookies(cookies []*http.Cookie) string {
+	sb := strings.Builder{}
+	sb.WriteString("Cookie: ")
+	for _, cookie := range cookies {
+		sb.WriteString(cookie.Name + "=" + url.QueryEscape(cookie.Value) + "&")
+	}
+	return strings.TrimRight(sb.String(), "&")
+}
+
+// dumpCurlHeaders dumps headers to curl format
+func dumpCurlHeaders(req *http.Request) *[][2]string {
+	headers := [][2]string{}
+	for k, vs := range req.Header {
+		for _, v := range vs {
+			headers = append(headers, [2]string{k, v})
+		}
+	}
+	n := len(headers)
+	for i := 0; i < n; i++ {
+		for j := n - 1; j > i; j-- {
+			jj := j - 1
+			h1, h2 := headers[j], headers[jj]
+			if h1[0] < h2[0] {
+				headers[jj], headers[j] = headers[j], headers[jj]
+			}
+		}
+	}
+	return &headers
+}

--- a/util_curl.go
+++ b/util_curl.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-resty/resty/v2/shellescape"
 )
 
-func BuildCurlRequest(req *http.Request, httpCookiejar http.CookieJar) (curl string) {
+func buildCurlRequest(req *http.Request, httpCookiejar http.CookieJar) (curl string) {
 	// 1. Generate curl raw headers
 	curl = "curl -X " + req.Method + " "
 	// req.Host + req.URL.Path + "?" + req.URL.RawQuery + " " + req.Proto + " "
@@ -22,13 +22,12 @@ func BuildCurlRequest(req *http.Request, httpCookiejar http.CookieJar) (curl str
 	}
 
 	// 2. Generate curl cookies
-	if cookieJar, ok := httpCookiejar.(*cookiejar.Jar); ok{
+	if cookieJar, ok := httpCookiejar.(*cookiejar.Jar); ok {
 		cookies := cookieJar.Cookies(req.URL)
 		if len(cookies) > 0 {
 			curl += ` -H ` + shellescape.Quote(dumpCurlCookies(cookies)) + " "
 		}
 	}
-
 
 	// 3. Generate curl body
 	if req.Body != nil {
@@ -38,8 +37,8 @@ func BuildCurlRequest(req *http.Request, httpCookiejar http.CookieJar) (curl str
 	}
 
 	urlString := shellescape.Quote(req.URL.String())
-	if urlString == "''"{
-		urlString = "'http://unexecuted-url'"
+	if urlString == "''" {
+		urlString = "'http://unexecuted-request'"
 	}
 	curl += " " + urlString
 	return curl


### PR DESCRIPTION
I've extracted curl code from my previous PR(https://github.com/go-resty/resty/pull/734). 
Could you review this code?

## New feature: generate curl command
Example: https://github.com/ahuigo/resty/blob/curl/v2/examples/debug_curl_test.go

```
var curlCmdExecuted string
client := resty.New()
_, err := client.R().
    SetResultCurlCmd(&curlCmdExecuted).
    Get("https://httpbin.org/get")

// Explore curl command
fmt.Println("Curl Command:", curlCmdExecuted)
```

## Output
```
$ go test -run '^TestDebugCurl$' github.com/go-resty/resty/v2/examples -v
=== RUN   TestDebugCurl
    debug_curl_test.go:29: curlCmdUnexecuted:  
    curl -X GET -H 'Content-Type: application/json' -H 'Cookie: count=1' -H 'User-Agent: go-resty/2.12.0 (https://github.com/go-resty/resty)' -d '{"name":"Alex"}' 'http://unexecuted-url'

    debug_curl_test.go:41: curlCmdExecuted:  
    curl -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'Cookie: count=1; count=1' -H 'User-Agent: go-resty/2.12.0 (https://github.com/go-resty/resty)' -d '{"name":"Alex"}' http://127.0.0.1:56426/post
--- PASS: TestDebugCurl (0.00s)
```