### PR TITLE
feat: add ability to set custom multipart boundary value

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -429,6 +429,13 @@ func handleMultipart(c *Client, r *Request) error {
 	r.bodyBuf = acquireBuffer()
 	w := multipart.NewWriter(r.bodyBuf)
 
+	// Set boundary if not set by user
+	if r.multipartBoundary != "" {
+		if err := w.SetBoundary(r.multipartBoundary); err != nil {
+			return err
+		}
+	}
+
 	for k, v := range c.FormData {
 		for _, iv := range v {
 			if err := w.WriteField(k, iv); err != nil {

--- a/request.go
+++ b/request.go
@@ -69,6 +69,7 @@ type Request struct {
 	bodyBuf             *bytes.Buffer
 	clientTrace         *clientTrace
 	log                 Logger
+	multipartBoundary   string
 	multipartFiles      []*File
 	multipartFields     []*MultipartField
 	retryConditions     []RetryConditionFunc
@@ -455,6 +456,13 @@ func (r *Request) SetMultipartField(param, fileName, contentType string, reader 
 func (r *Request) SetMultipartFields(fields ...*MultipartField) *Request {
 	r.isMultiPart = true
 	r.multipartFields = append(r.multipartFields, fields...)
+	return r
+}
+
+// SetBoundary method sets the multipart boundary for the request
+// By default a random boundary will be generated in `mime/multipart`.
+func (r *Request) SetBoundary(boundary string) *Request {
+	r.multipartBoundary = boundary
 	return r
 }
 

--- a/request.go
+++ b/request.go
@@ -459,9 +459,11 @@ func (r *Request) SetMultipartFields(fields ...*MultipartField) *Request {
 	return r
 }
 
-// SetBoundary method sets the multipart boundary for the request
-// By default a random boundary will be generated in `mime/multipart`.
-func (r *Request) SetBoundary(boundary string) *Request {
+// SetMultipartBoundary method sets the custom multipart boundary for the multipart request.
+// Typically, the `mime/multipart` package generates a random multipart boundary, if not provided.
+//
+// Since v2.15.0
+func (r *Request) SetMultipartBoundary(boundary string) *Request {
 	r.multipartBoundary = boundary
 	return r
 }

--- a/request_test.go
+++ b/request_test.go
@@ -1034,6 +1034,29 @@ func TestMultiPartMultipartFields(t *testing.T) {
 	assertEqual(t, true, strings.Contains(responseStr, "upload-file-2.json"))
 }
 
+func TestMultiPartCustomBoundary(t *testing.T) {
+	ts := createFormPostServer(t)
+	defer ts.Close()
+	defer cleanupFiles(".testdata/upload")
+
+	_, err := dclr().
+		SetMultipartFormData(map[string]string{"first_name": "Jeevanandam", "last_name": "M", "zip_code": "00001"}).
+		SetBoundary(`"my-custom-boundary"`).
+		SetBasicAuth("myuser", "mypass").
+		Post(ts.URL + "/profile")
+
+	assertEqual(t, "mime: invalid boundary character", err.Error())
+
+	resp, err := dclr().
+		SetMultipartFormData(map[string]string{"first_name": "Jeevanandam", "last_name": "M", "zip_code": "00001"}).
+		SetBoundary("my-custom-boundary").
+		Post(ts.URL + "/profile")
+
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
+	assertEqual(t, "Success", resp.String())
+}
+
 func TestGetWithCookie(t *testing.T) {
 	ts := createGetServer(t)
 	defer ts.Close()

--- a/request_test.go
+++ b/request_test.go
@@ -1041,7 +1041,7 @@ func TestMultiPartCustomBoundary(t *testing.T) {
 
 	_, err := dclr().
 		SetMultipartFormData(map[string]string{"first_name": "Jeevanandam", "last_name": "M", "zip_code": "00001"}).
-		SetBoundary(`"my-custom-boundary"`).
+		SetMultipartBoundary(`"my-custom-boundary"`).
 		SetBasicAuth("myuser", "mypass").
 		Post(ts.URL + "/profile")
 
@@ -1049,7 +1049,7 @@ func TestMultiPartCustomBoundary(t *testing.T) {
 
 	resp, err := dclr().
 		SetMultipartFormData(map[string]string{"first_name": "Jeevanandam", "last_name": "M", "zip_code": "00001"}).
-		SetBoundary("my-custom-boundary").
+		SetMultipartBoundary("my-custom-boundary").
 		Post(ts.URL + "/profile")
 
 	assertError(t, err)


### PR DESCRIPTION
### Use case

Integrating with some web service that require a specific boundary format in multipart/form-data requests.

Some legacy service might requires a specific prefix in the boundary value, to ensure the compatibility, we need the ability to set a custom boundary value in the multipart request.

### Example

```go
package main

import (
	"crypto/rand"
	"fmt"
	"io"
	"log"

	"github.com/go-resty/resty/v2"
)

const BoundaryPrefix = "Some_MultiPart_Prefix_"

func randomBoundary() string {
	var buf [4]byte
	_, err := io.ReadFull(rand.Reader, buf[:])
	if err != nil {
		panic(err)
	}
	return fmt.Sprintf("%s_%X", BoundaryPrefix, buf[:])
}

func main() {
    // Initialize the client
    client := resty.New()

    // Perform the file upload
    _, err := client.R().
        SetMultipartFormData(map[string]string{"test": "1"}).
        SetBoundary(randomBoundary()) // Setting the custom boundary
        Post("http://example.com/upload")
    if err != nil {
        log.Fatalf("Failed to upload file: %v", err)
    }
}
```