### PR TITLE
Add mutex support for Resty V3

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -337,9 +337,9 @@ func TestClientSetHeaderVerbatim(t *testing.T) {
 		SetHeader("header-lowercase", "value_standard")
 
 	//lint:ignore SA1008 valid one, so ignore this!
-	unConventionHdrValue := strings.Join(c.Header["header-lowercase"], "")
+	unConventionHdrValue := strings.Join(c.Header()["header-lowercase"], "")
 	assertEqual(t, "value_lowercase", unConventionHdrValue)
-	assertEqual(t, "value_standard", c.Header.Get("Header-Lowercase"))
+	assertEqual(t, "value_standard", c.Header().Get("header-Lowercase"))
 }
 
 func TestClientSetTransport(t *testing.T) {
@@ -385,20 +385,20 @@ func TestClientOptions(t *testing.T) {
 	assertEqual(t, client.setContentLength, true)
 
 	client.SetHostURL("http://httpbin.org")
-	assertEqual(t, "http://httpbin.org", client.HostURL)
+	assertEqual(t, "http://httpbin.org", client.hostURL)
 
 	client.SetHeader(hdrContentTypeKey, "application/json; charset=utf-8")
 	client.SetHeaders(map[string]string{
 		hdrUserAgentKey: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) go-resty v0.1",
 		"X-Request-Id":  strconv.FormatInt(time.Now().UnixNano(), 10),
 	})
-	assertEqual(t, "application/json; charset=utf-8", client.Header.Get(hdrContentTypeKey))
+	assertEqual(t, "application/json; charset=utf-8", client.header.Get(hdrContentTypeKey))
 
 	client.SetCookie(&http.Cookie{
 		Name:  "default-cookie",
 		Value: "This is cookie default-cookie value",
 	})
-	assertEqual(t, "default-cookie", client.Cookies[0].Name)
+	assertEqual(t, "default-cookie", client.cookies[0].Name)
 
 	cookies := []*http.Cookie{
 		{
@@ -410,45 +410,45 @@ func TestClientOptions(t *testing.T) {
 		},
 	}
 	client.SetCookies(cookies)
-	assertEqual(t, "default-cookie-1", client.Cookies[1].Name)
-	assertEqual(t, "default-cookie-2", client.Cookies[2].Name)
+	assertEqual(t, "default-cookie-1", client.cookies[1].Name)
+	assertEqual(t, "default-cookie-2", client.cookies[2].Name)
 
 	client.SetQueryParam("test_param_1", "Param_1")
 	client.SetQueryParams(map[string]string{"test_param_2": "Param_2", "test_param_3": "Param_3"})
-	assertEqual(t, "Param_3", client.QueryParam.Get("test_param_3"))
+	assertEqual(t, "Param_3", client.queryParam.Get("test_param_3"))
 
 	rTime := strconv.FormatInt(time.Now().UnixNano(), 10)
 	client.SetFormData(map[string]string{"r_time": rTime})
-	assertEqual(t, rTime, client.FormData.Get("r_time"))
+	assertEqual(t, rTime, client.formData.Get("r_time"))
 
 	client.SetBasicAuth("myuser", "mypass")
-	assertEqual(t, "myuser", client.UserInfo.Username)
+	assertEqual(t, "myuser", client.userInfo.Username)
 
 	client.SetAuthToken("AC75BD37F019E08FBC594900518B4F7E")
-	assertEqual(t, "AC75BD37F019E08FBC594900518B4F7E", client.Token)
+	assertEqual(t, "AC75BD37F019E08FBC594900518B4F7E", client.token)
 
 	client.SetDisableWarn(true)
-	assertEqual(t, client.DisableWarn, true)
+	assertEqual(t, client.DisableWarn(), true)
 
 	client.SetRetryCount(3)
-	assertEqual(t, 3, client.RetryCount)
+	assertEqual(t, 3, client.retryCount)
 
 	rwt := time.Duration(1000) * time.Millisecond
 	client.SetRetryWaitTime(rwt)
-	assertEqual(t, rwt, client.RetryWaitTime)
+	assertEqual(t, rwt, client.retryWaitTime)
 
 	mrwt := time.Duration(2) * time.Second
 	client.SetRetryMaxWaitTime(mrwt)
-	assertEqual(t, mrwt, client.RetryMaxWaitTime)
+	assertEqual(t, mrwt, client.retryMaxWaitTime)
 
 	client.AddRetryAfterErrorCondition()
-	equal(client.RetryConditions[0], func(response *Response, err error) bool {
+	equal(client.retryConditions[0], func(response *Response, err error) bool {
 		return response.IsError()
 	})
 
 	err := &AuthError{}
 	client.SetError(err)
-	if reflect.TypeOf(err) == client.Error {
+	if reflect.TypeOf(err) == client.Error() {
 		t.Error("SetError failed")
 	}
 
@@ -474,14 +474,14 @@ func TestClientOptions(t *testing.T) {
 	client.SetContentLength(true)
 
 	client.SetDebug(true)
-	assertEqual(t, client.Debug, true)
+	assertEqual(t, client.debug, true)
 
 	var sl int64 = 1000000
 	client.SetDebugBodyLimit(sl)
 	assertEqual(t, client.debugBodySizeLimit, sl)
 
 	client.SetAllowGetMethodPayload(true)
-	assertEqual(t, client.AllowGetMethodPayload, true)
+	assertEqual(t, client.allowGetMethodPayload, true)
 
 	client.SetScheme("http")
 	assertEqual(t, client.scheme, "http")
@@ -615,7 +615,7 @@ func TestClientNewRequest(t *testing.T) {
 func TestClientSetJSONMarshaler(t *testing.T) {
 	m := func(v interface{}) ([]byte, error) { return nil, nil }
 	c := New().SetJSONMarshaler(m)
-	p1 := fmt.Sprintf("%p", c.JSONMarshal)
+	p1 := fmt.Sprintf("%p", c.JSONMarshaler())
 	p2 := fmt.Sprintf("%p", m)
 	assertEqual(t, p1, p2) // functions can not be compared, we only can compare pointers
 }
@@ -623,7 +623,7 @@ func TestClientSetJSONMarshaler(t *testing.T) {
 func TestClientSetJSONUnmarshaler(t *testing.T) {
 	m := func([]byte, interface{}) error { return nil }
 	c := New().SetJSONUnmarshaler(m)
-	p1 := fmt.Sprintf("%p", c.JSONUnmarshal)
+	p1 := fmt.Sprintf("%p", c.jsonUnmarshal)
 	p2 := fmt.Sprintf("%p", m)
 	assertEqual(t, p1, p2) // functions can not be compared, we only can compare pointers
 }
@@ -631,7 +631,7 @@ func TestClientSetJSONUnmarshaler(t *testing.T) {
 func TestClientSetXMLMarshaler(t *testing.T) {
 	m := func(v interface{}) ([]byte, error) { return nil, nil }
 	c := New().SetXMLMarshaler(m)
-	p1 := fmt.Sprintf("%p", c.XMLMarshal)
+	p1 := fmt.Sprintf("%p", c.xmlMarshal)
 	p2 := fmt.Sprintf("%p", m)
 	assertEqual(t, p1, p2) // functions can not be compared, we only can compare pointers
 }
@@ -639,7 +639,7 @@ func TestClientSetXMLMarshaler(t *testing.T) {
 func TestClientSetXMLUnmarshaler(t *testing.T) {
 	m := func([]byte, interface{}) error { return nil }
 	c := New().SetXMLUnmarshaler(m)
-	p1 := fmt.Sprintf("%p", c.XMLUnmarshal)
+	p1 := fmt.Sprintf("%p", c.xmlUnmarshal)
 	p2 := fmt.Sprintf("%p", m)
 	assertEqual(t, p1, p2) // functions can not be compared, we only can compare pointers
 }
@@ -1059,7 +1059,7 @@ func TestUnixSocket(t *testing.T) {
 	client := New()
 
 	// Set the previous transport that we created, set the scheme of the communication to the
-	// socket and set the unixSocket as the HostURL.
+	// socket and set the unixSocket as the hostURL.
 	client.SetTransport(&transport).SetScheme("http").SetHostURL(unixSocketAddr)
 
 	// No need to write the host's URL on the request, just the path.
@@ -1079,7 +1079,7 @@ func TestClone(t *testing.T) {
 	parent.SetBaseURL("http://localhost")
 
 	// set an interface field
-	parent.UserInfo = &User{
+	parent.userInfo = &User{
 		Username: "parent",
 	}
 
@@ -1087,13 +1087,13 @@ func TestClone(t *testing.T) {
 	// update value of non-interface type - change will only happen on clone
 	clone.SetBaseURL("https://local.host")
 	// update value of interface type - change will also happen on parent
-	clone.UserInfo.Username = "clone"
+	clone.userInfo.Username = "clone"
 
 	// asert non-interface type
-	assertEqual(t, "http://localhost", parent.BaseURL)
-	assertEqual(t, "https://local.host", clone.BaseURL)
+	assertEqual(t, "http://localhost", parent.baseURL)
+	assertEqual(t, "https://local.host", clone.baseURL)
 
 	// assert interface type
-	assertEqual(t, "clone", parent.UserInfo.Username)
-	assertEqual(t, "clone", clone.UserInfo.Username)
+	assertEqual(t, "clone", parent.userInfo.Username)
+	assertEqual(t, "clone", clone.userInfo.Username)
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -98,7 +98,7 @@ func Test_parseRequestURL(t *testing.T) {
 				r.SetPathParams(map[string]string{
 					"foo": "4/5",
 				}).SetRawPathParams(map[string]string{
-					"foo": "4/5", // ignored, because the PathParams takes precedence over the RawPathParams
+					"foo": "4/5", // ignored, because the pathParams takes precedence over the rawPathParams
 					"bar": "6/7",
 				})
 				r.URL = "https://example.com/{foo}/{bar}"
@@ -156,7 +156,7 @@ func Test_parseRequestURL(t *testing.T) {
 			expectedURL: "https://example.com/prefix/1/2",
 		},
 		{
-			name: "using BaseURL with absolute URL in request",
+			name: "using baseURL with absolute URL in request",
 			init: func(c *Client, r *Request) {
 				c.SetBaseURL("https://foo.bar") // ignored
 				r.URL = "https://example.com/"
@@ -164,7 +164,7 @@ func Test_parseRequestURL(t *testing.T) {
 			expectedURL: "https://example.com/",
 		},
 		{
-			name: "using BaseURL with relative path in request URL without leading slash",
+			name: "using baseURL with relative path in request URL without leading slash",
 			init: func(c *Client, r *Request) {
 				c.SetBaseURL("https://example.com")
 				r.URL = "foo/bar"
@@ -172,7 +172,7 @@ func Test_parseRequestURL(t *testing.T) {
 			expectedURL: "https://example.com/foo/bar",
 		},
 		{
-			name: "using BaseURL with relative path in request URL wit leading slash",
+			name: "using baseURL with relative path in request URL wit leading slash",
 			init: func(c *Client, r *Request) {
 				c.SetBaseURL("https://example.com")
 				r.URL = "/foo/bar"
@@ -180,9 +180,9 @@ func Test_parseRequestURL(t *testing.T) {
 			expectedURL: "https://example.com/foo/bar",
 		},
 		{
-			name: "using deprecated HostURL with relative path in request URL",
+			name: "using deprecated hostURL with relative path in request URL",
 			init: func(c *Client, r *Request) {
-				c.HostURL = "https://example.com"
+				c.hostURL = "https://example.com"
 				r.URL = "foo/bar"
 			},
 			expectedURL: "https://example.com/foo/bar",
@@ -195,7 +195,7 @@ func Test_parseRequestURL(t *testing.T) {
 			expectedURL: "/example.com/foo/bar",
 		},
 		{
-			name: "BaseURL without scheme",
+			name: "baseURL without scheme",
 			init: func(c *Client, r *Request) {
 				c.SetBaseURL("example.com")
 				r.URL = "foo/bar"
@@ -203,7 +203,7 @@ func Test_parseRequestURL(t *testing.T) {
 			expectedURL: "example.com/foo/bar",
 		},
 		{
-			name: "using SetScheme and BaseURL without scheme",
+			name: "using SetScheme and baseURL without scheme",
 			init: func(c *Client, r *Request) {
 				c.SetBaseURL("example.com").SetScheme("https")
 				r.URL = "foo/bar"
@@ -423,7 +423,7 @@ func Test_parseRequestHeader(t *testing.T) {
 				t.Errorf("parseRequestHeader() error = %v", err)
 			}
 			if !reflect.DeepEqual(tt.expectedHeader, r.Header) {
-				t.Errorf("r.Header = %#+v does not match expected %#+v", r.Header, tt.expectedHeader)
+				t.Errorf("r.header = %#+v does not match expected %#+v", r.Header, tt.expectedHeader)
 			}
 		})
 	}
@@ -497,7 +497,7 @@ func Test_parseRequestBody(t *testing.T) {
 			},
 		},
 		{
-			name: "string body with GET method and AllowGetMethodPayload",
+			name: "string body with GET method and allowGetMethodPayload",
 			init: func(c *Client, r *Request) {
 				c.SetAllowGetMethodPayload(true)
 				r.SetBody("foo")

--- a/request.go
+++ b/request.go
@@ -960,7 +960,7 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 	r.Method = method
 	r.URL = r.selectAddr(addrs, url, 0)
 
-	if r.client.RetryCount == 0 {
+	if r.client.retryCount == 0 {
 		r.Attempt = 1
 		resp, err = r.client.execute(r)
 		r.client.onErrorHooks(r, resp, unwrapNoRetryErr(err))
@@ -980,12 +980,12 @@ func (r *Request) Execute(method, url string) (*Response, error) {
 
 			return resp, err
 		},
-		Retries(r.client.RetryCount),
-		WaitTime(r.client.RetryWaitTime),
-		MaxWaitTime(r.client.RetryMaxWaitTime),
-		RetryConditions(append(r.retryConditions, r.client.RetryConditions...)),
-		RetryHooks(r.client.RetryHooks),
-		ResetMultipartReaders(r.client.RetryResetReaders),
+		Retries(r.client.retryCount),
+		WaitTime(r.client.retryWaitTime),
+		MaxWaitTime(r.client.retryMaxWaitTime),
+		RetryConditions(append(r.retryConditions, r.client.retryConditions...)),
+		RetryHooks(r.client.retryHooks),
+		ResetMultipartReaders(r.client.retryResetReaders),
 	)
 
 	if err != nil {
@@ -1013,7 +1013,7 @@ type SRVRecord struct {
 
 func (r *Request) fmtBodyString(sl int64) (body string) {
 	body = "***** NO CONTENT *****"
-	if !isPayloadSupported(r.Method, r.client.AllowGetMethodPayload) {
+	if !isPayloadSupported(r.Method, r.client.allowGetMethodPayload) {
 		return
 	}
 

--- a/resty_test.go
+++ b/resty_test.go
@@ -351,7 +351,7 @@ func createFormPostServer(t *testing.T) *httptest.Server {
 				for _, fhdrs := range r.MultipartForm.File {
 					for _, hdr := range fhdrs {
 						t.Logf("Name: %v", hdr.Filename)
-						t.Logf("Header: %v", hdr.Header)
+						t.Logf("header: %v", hdr.Header)
 						dotPos := strings.LastIndex(hdr.Filename, ".")
 
 						fname := fmt.Sprintf("%s-%v%s", hdr.Filename[:dotPos], time.Now().Unix(), hdr.Filename[dotPos:])
@@ -399,7 +399,7 @@ func createFormPatchServer(t *testing.T) *httptest.Server {
 				for _, fhdrs := range r.MultipartForm.File {
 					for _, hdr := range fhdrs {
 						t.Logf("Name: %v", hdr.Filename)
-						t.Logf("Header: %v", hdr.Header)
+						t.Logf("header: %v", hdr.Header)
 						dotPos := strings.LastIndex(hdr.Filename, ".")
 
 						fname := fmt.Sprintf("%s-%v%s", hdr.Filename[:dotPos], time.Now().Unix(), hdr.Filename[dotPos:])
@@ -880,7 +880,7 @@ func logResponse(t *testing.T, resp *Response) {
 	t.Logf("Response Status: %v", resp.Status())
 	t.Logf("Response Time: %v", resp.Time())
 	t.Logf("Response Headers: %v", resp.Header())
-	t.Logf("Response Cookies: %v", resp.Cookies())
+	t.Logf("Response cookies: %v", resp.Cookies())
 	t.Logf("Response Body: %v", resp)
 }
 

--- a/retry.go
+++ b/retry.go
@@ -178,7 +178,7 @@ func sleepDuration(resp *Response, min, max time.Duration, attempt int) (time.Du
 		return jitterBackoff(min, max, attempt), nil
 	}
 
-	retryAfterFunc := resp.Request.client.RetryAfter
+	retryAfterFunc := resp.Request.client.retryAfter
 
 	// Check for custom callback
 	if retryAfterFunc == nil {

--- a/retry_test.go
+++ b/retry_test.go
@@ -47,7 +47,7 @@ func TestBackoffNoWaitForLastRetry(t *testing.T) {
 		Request: &Request{
 			ctx: canceledCtx,
 			client: &Client{
-				RetryAfter: func(*Client, *Response) (time.Duration, error) {
+				retryAfter: func(*Client, *Response) (time.Duration, error) {
 					return 6, nil
 				},
 			},
@@ -543,7 +543,8 @@ func TestClientRetryWaitCallbackSwitchToDefault(t *testing.T) {
 
 		// Ensure that client has slept some duration between
 		// waitTime and maxWaitTime for consequent requests
-		if slept < expected/2-5*time.Millisecond || expected+5*time.Millisecond < slept {
+		// Increase the boundary to adjust the extra time consumption introduced by mutex
+		if slept < expected/2-5*time.Millisecond || expected+20*time.Millisecond < slept {
 			t.Errorf("Client has slept %f seconds before retry %d", slept.Seconds(), i)
 		}
 	}

--- a/util.go
+++ b/util.go
@@ -117,9 +117,9 @@ func IsXMLType(ct string) bool {
 // Unmarshalc content into object from JSON or XML
 func Unmarshalc(c *Client, ct string, b []byte, d interface{}) (err error) {
 	if IsJSONType(ct) {
-		err = c.JSONUnmarshal(b, d)
+		err = c.jsonUnmarshal(b, d)
 	} else if IsXMLType(ct) {
-		err = c.XMLUnmarshal(b, d)
+		err = c.xmlUnmarshal(b, d)
 	}
 
 	return
@@ -155,7 +155,7 @@ func jsonMarshal(c *Client, r *Request, d interface{}) (*bytes.Buffer, error) {
 		return noescapeJSONMarshal(d)
 	}
 
-	data, err := c.JSONMarshal(d)
+	data, err := c.jsonMarshal(d)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR is to fix #812. Add a RWMutex to `Client` and change replace every public property with an exported method. Meanwhile, to pass the retry test, I increase the maxRetryWaitTime to pass the test. 