### PR TITLE
feat: add max reponse body limit

### DIFF
--- a/client.go
+++ b/client.go
@@ -128,7 +128,7 @@ type Client struct {
 	// HeaderAuthorizationKey is used to set/access Request Authorization header
 	// value when `SetAuthToken` option is used.
 	HeaderAuthorizationKey string
-	ResponseBodyLimit      int64
+	ResponseBodyLimit      int
 
 	jsonEscapeHTML      bool
 	setContentLength    bool
@@ -1100,7 +1100,7 @@ func (c *Client) SetJSONEscapeHTML(b bool) *Client {
 //   - "DoNotParseResponse" is set for client or request.
 //
 // this can be overridden at client level with [Request.SetResponseBodyLimit]
-func (c *Client) SetResponseBodyLimit(v int64) *Client {
+func (c *Client) SetResponseBodyLimit(v int) *Client {
 	c.ResponseBodyLimit = v
 	return c
 }
@@ -1278,7 +1278,7 @@ var ErrResponseBodyTooLarge = errors.New("resty: response body too large")
 
 // https://github.com/golang/go/issues/51115
 // [io.LimitedReader] can only return [io.EOF]
-func readAllWithLimit(r io.Reader, maxSize int64) ([]byte, error) {
+func readAllWithLimit(r io.Reader, maxSize int) ([]byte, error) {
 	if maxSize <= 0 {
 		return io.ReadAll(r)
 	}
@@ -1289,7 +1289,7 @@ func readAllWithLimit(r io.Reader, maxSize int64) ([]byte, error) {
 	for {
 		n, err := r.Read(buf)
 		total += n
-		if int64(total) > maxSize {
+		if total > maxSize {
 			return nil, ErrResponseBodyTooLarge
 		}
 

--- a/client.go
+++ b/client.go
@@ -1098,6 +1098,8 @@ func (c *Client) SetJSONEscapeHTML(b bool) *Client {
 //   - ResponseBodyLimit <= 0, which is the default behavior.
 //   - [Request.SetOutput] is called to save a response data to file.
 //   - "DoNotParseResponse" is set for client or request.
+//
+// this can be overridden at client level with [Request.SetResponseBodyLimit]
 func (c *Client) SetResponseBodyLimit(v int64) *Client {
 	c.ResponseBodyLimit = v
 	return c

--- a/client.go
+++ b/client.go
@@ -128,8 +128,7 @@ type Client struct {
 	// HeaderAuthorizationKey is used to set/access Request Authorization header
 	// value when `SetAuthToken` option is used.
 	HeaderAuthorizationKey string
-
-	responseBodyLimit int64
+	ResponseBodyLimit      int64
 
 	jsonEscapeHTML      bool
 	setContentLength    bool
@@ -1091,6 +1090,18 @@ func (c *Client) SetJSONEscapeHTML(b bool) *Client {
 	return c
 }
 
+// SetResponseBodyLimit set a response body size limit, avoid reading too many data to memory.
+//
+// Client will return [ErrResponseBodyTooLarge] if uncompressed response body size if larger than limit.
+// Body size limit will not be enforced in following case:
+// - ResponseBodyLimit is 0, which is the default behavior.
+// - [Response.SetOutput] is called to save a response data to file.
+// - `DoNotParseResponse` is set for client or request.
+func (c *Client) SetResponseBodyLimit(v int64) *Client {
+	c.ResponseBodyLimit = v
+	return c
+}
+
 // EnableTrace method enables the Resty client trace for the requests fired from
 // the client using `httptrace.ClientTrace` and provides insights.
 //
@@ -1240,7 +1251,7 @@ func (c *Client) execute(req *Request) (*Response, error) {
 			}
 		}
 
-		if response.body, err = readAllWithLimit(body, c.responseBodyLimit); err != nil {
+		if response.body, err = readAllWithLimit(body, c.ResponseBodyLimit); err != nil {
 			response.setReceivedAt()
 			return response, err
 		}

--- a/client.go
+++ b/client.go
@@ -1295,6 +1295,7 @@ func readAllWithLimit(r io.Reader, maxSize int) ([]byte, error) {
 
 		if err != nil {
 			if err == io.EOF {
+				result = append(result, buf[:n]...)
 				break
 			}
 			return nil, err

--- a/client.go
+++ b/client.go
@@ -1283,11 +1283,11 @@ func readAllWithLimit(r io.Reader, maxSize int) ([]byte, error) {
 		return io.ReadAll(r)
 	}
 
+	var buf [512]byte // make buf stack allocated
 	result := make([]byte, 0, 512)
 	total := 0
-	buf := make([]byte, 512)
 	for {
-		n, err := r.Read(buf)
+		n, err := r.Read(buf[:])
 		total += n
 		if total > maxSize {
 			return nil, ErrResponseBodyTooLarge

--- a/client.go
+++ b/client.go
@@ -1090,7 +1090,7 @@ func (c *Client) SetJSONEscapeHTML(b bool) *Client {
 	return c
 }
 
-// SetResponseBodyLimit set a response body size limit, avoid reading too many data to memory.
+// SetResponseBodyLimit set a max body size limit on response, avoid reading too many data to memory.
 //
 // Client will return [ErrResponseBodyTooLarge] if uncompressed response body size if larger than limit.
 // Body size limit will not be enforced in following case:

--- a/client.go
+++ b/client.go
@@ -443,11 +443,12 @@ func (c *Client) R() *Request {
 		RawPathParams: map[string]string{},
 		Debug:         c.Debug,
 
-		client:          c,
-		multipartFiles:  []*File{},
-		multipartFields: []*MultipartField{},
-		jsonEscapeHTML:  c.jsonEscapeHTML,
-		log:             c.log,
+		client:            c,
+		multipartFiles:    []*File{},
+		multipartFields:   []*MultipartField{},
+		jsonEscapeHTML:    c.jsonEscapeHTML,
+		log:               c.log,
+		responseBodyLimit: c.ResponseBodyLimit,
 	}
 	return r
 }
@@ -1092,11 +1093,11 @@ func (c *Client) SetJSONEscapeHTML(b bool) *Client {
 
 // SetResponseBodyLimit set a max body size limit on response, avoid reading too many data to memory.
 //
-// Client will return [ErrResponseBodyTooLarge] if uncompressed response body size if larger than limit.
+// Client will return [resty.ErrResponseBodyTooLarge] if uncompressed response body size if larger than limit.
 // Body size limit will not be enforced in following case:
-// - ResponseBodyLimit is 0, which is the default behavior.
-// - [Response.SetOutput] is called to save a response data to file.
-// - `DoNotParseResponse` is set for client or request.
+//   - ResponseBodyLimit <= 0, which is the default behavior.
+//   - [Request.SetOutput] is called to save a response data to file.
+//   - "DoNotParseResponse" is set for client or request.
 func (c *Client) SetResponseBodyLimit(v int64) *Client {
 	c.ResponseBodyLimit = v
 	return c
@@ -1251,7 +1252,7 @@ func (c *Client) execute(req *Request) (*Response, error) {
 			}
 		}
 
-		if response.body, err = readAllWithLimit(body, c.ResponseBodyLimit); err != nil {
+		if response.body, err = readAllWithLimit(body, req.responseBodyLimit); err != nil {
 			response.setReceivedAt()
 			return response, err
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -1148,7 +1148,7 @@ func TestResponseBodyLimit(t *testing.T) {
 
 		c := dc()
 
-		_, err := c.R().Get(tse.URL + "/")
+		_, err := c.R().SetResponseBodyLimit(10240).Get(tse.URL + "/")
 		assertErrorIs(t, err, gzip.ErrHeader)
 	})
 }

--- a/client_test.go
+++ b/client_test.go
@@ -6,6 +6,7 @@ package resty
 
 import (
 	"bytes"
+	"crypto/rand"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -1096,4 +1097,43 @@ func TestClone(t *testing.T) {
 	// assert interface type
 	assertEqual(t, "clone", parent.UserInfo.Username)
 	assertEqual(t, "clone", clone.UserInfo.Username)
+}
+
+func TestResponseBodyLimit(t *testing.T) {
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		io.CopyN(w, rand.Reader, 100*800)
+	})
+	defer ts.Close()
+
+	t.Run("Client body limit", func(t *testing.T) {
+		c := dc().SetResponseBodyLimit(1024)
+
+		_, err := c.R().Get(ts.URL + "/")
+		assertNotNil(t, err)
+		assertEqual(t, err, ErrResponseBodyTooLarge)
+	})
+
+	t.Run("request body limit", func(t *testing.T) {
+		c := dc()
+
+		_, err := c.R().SetResponseBodyLimit(1024).Get(ts.URL + "/")
+		assertNotNil(t, err)
+		assertEqual(t, err, ErrResponseBodyTooLarge)
+	})
+
+	t.Run("body less than limit", func(t *testing.T) {
+		c := dc()
+
+		res, err := c.R().SetResponseBodyLimit(800*100 + 10).Get(ts.URL + "/")
+		assertNil(t, err)
+		assertEqual(t, 800*100, len(res.body))
+	})
+
+	t.Run("no body limit", func(t *testing.T) {
+		c := dc()
+
+		res, err := c.R().Get(ts.URL + "/")
+		assertNil(t, err)
+		assertEqual(t, 800*100, len(res.body))
+	})
 }

--- a/client_test.go
+++ b/client_test.go
@@ -6,6 +6,7 @@ package resty
 
 import (
 	"bytes"
+	"compress/gzip"
 	"crypto/rand"
 	"crypto/tls"
 	"errors"
@@ -1139,24 +1140,15 @@ func TestResponseBodyLimit(t *testing.T) {
 
 	t.Run("read error", func(t *testing.T) {
 		tse := createTestServer(func(w http.ResponseWriter, r *http.Request) {
-			hj, ok := w.(http.Hijacker)
-			if !ok {
-				t.Error("webserver doesn't support hijacking")
-				t.FailNow()
-			}
-			conn, _, err := hj.Hijack()
-			if err != nil {
-				t.Error("failed to hijack connection", err)
-				t.FailNow()
-			}
-
-			conn.Close()
+			w.Header().Set(hdrContentEncodingKey, "gzip")
+			var buf [1024]byte
+			w.Write(buf[:])
 		})
 		defer tse.Close()
 
 		c := dc()
 
 		_, err := c.R().Get(tse.URL + "/")
-		assertNotNil(t, err)
+		assertErrorIs(t, err, gzip.ErrHeader)
 	})
 }

--- a/request.go
+++ b/request.go
@@ -609,7 +609,7 @@ func (r *Request) SetDoNotParseResponse(parse bool) *Request {
 //   - [Request.SetOutput] is called to save a response data to file.
 //   - "DoNotParseResponse" is set for client or request.
 //
-// Request can override Client config with [Request.SetResponseBodyLimit]
+// This will override Client config.
 func (r *Request) SetResponseBodyLimit(v int64) *Request {
 	r.responseBodyLimit = v
 	return r

--- a/request.go
+++ b/request.go
@@ -73,6 +73,7 @@ type Request struct {
 	multipartFiles      []*File
 	multipartFields     []*MultipartField
 	retryConditions     []RetryConditionFunc
+	responseBodyLimit   int64
 }
 
 // Generate curl command for the request.
@@ -597,6 +598,20 @@ func (r *Request) SetSRV(srv *SRVRecord) *Request {
 // taken over the control of response parsing from `Resty`.
 func (r *Request) SetDoNotParseResponse(parse bool) *Request {
 	r.notParseResponse = parse
+	return r
+}
+
+// SetResponseBodyLimit set a max body size limit on response, avoid reading too many data to memory.
+//
+// Request will return [resty.ErrResponseBodyTooLarge] if uncompressed response body size if larger than limit.
+// Body size limit will not be enforced in following case:
+//   - ResponseBodyLimit <= 0, which is the default behavior.
+//   - [Request.SetOutput] is called to save a response data to file.
+//   - "DoNotParseResponse" is set for client or request.
+//
+// Request can override Client config with [Request.SetResponseBodyLimit]
+func (r *Request) SetResponseBodyLimit(v int64) *Request {
+	r.responseBodyLimit = v
 	return r
 }
 

--- a/request.go
+++ b/request.go
@@ -73,7 +73,7 @@ type Request struct {
 	multipartFiles      []*File
 	multipartFields     []*MultipartField
 	retryConditions     []RetryConditionFunc
-	responseBodyLimit   int64
+	responseBodyLimit   int
 }
 
 // Generate curl command for the request.
@@ -610,7 +610,7 @@ func (r *Request) SetDoNotParseResponse(parse bool) *Request {
 //   - "DoNotParseResponse" is set for client or request.
 //
 // This will override Client config.
-func (r *Request) SetResponseBodyLimit(v int64) *Request {
+func (r *Request) SetResponseBodyLimit(v int) *Request {
 	r.responseBodyLimit = v
 	return r
 }

--- a/resty_test.go
+++ b/resty_test.go
@@ -809,6 +809,7 @@ func dclr() *Request {
 }
 
 func assertNil(t *testing.T, v interface{}) {
+	t.Helper()
 	if !isNil(v) {
 		t.Errorf("[%v] was expected to be nil", v)
 	}
@@ -841,6 +842,7 @@ func assertErrorIs(t *testing.T, e, g error) (r bool) {
 }
 
 func assertEqual(t *testing.T, e, g interface{}) (r bool) {
+	t.Helper()
 	if !equal(e, g) {
 		t.Errorf("Expected [%v], got [%v]", e, g)
 	}

--- a/retry_test.go
+++ b/retry_test.go
@@ -7,7 +7,6 @@ package resty
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -823,34 +822,4 @@ func TestResetMultipartReaders(t *testing.T) {
 
 	assertEqual(t, 500, resp.StatusCode())
 	assertNil(t, err)
-}
-
-func TestResponseBodyLimit(t *testing.T) {
-	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
-		io.CopyN(w, rand.Reader, 100*1024)
-	})
-	defer ts.Close()
-
-	t.Run("Client body limit", func(t *testing.T) {
-		c := dc().SetResponseBodyLimit(1024)
-
-		_, err := c.R().Get(ts.URL + "/")
-		assertNotNil(t, err)
-		assertEqual(t, err, ErrResponseBodyTooLarge)
-	})
-
-	t.Run("request body limit", func(t *testing.T) {
-		c := dc()
-
-		_, err := c.R().SetResponseBodyLimit(1024).Get(ts.URL + "/")
-		assertNotNil(t, err)
-		assertEqual(t, err, ErrResponseBodyTooLarge)
-	})
-
-	t.Run("no body limit", func(t *testing.T) {
-		c := dc()
-
-		_, err := c.R().Get(ts.URL + "/")
-		assertNil(t, err)
-	})
 }


### PR DESCRIPTION
Client not will be able to check resposne body size limit.

If server return a large response than expected, it will discard the response and return a err `ErrResponseBodyTooLarge`. 

```golang
c := Client().SetResponseBodyLimit(1024*1024*1024) // do not allow body larger than 1GiB
res, err := c.R().Get(...)
if err != nil{
  if errors.Is(err, resty.ErrResponseBodyTooLarge){
    ...
  }
}
```

close https://github.com/go-resty/resty/issues/819