### PR TITLE
fix: buildCurlRequest() replace req.Body with req.GetBody()

### DIFF
--- a/util_curl.go
+++ b/util_curl.go
@@ -31,7 +31,12 @@ func buildCurlRequest(req *http.Request, httpCookiejar http.CookieJar) (curl str
 
 	// 3. Generate curl body
 	if req.Body != nil {
-		buf, _ := io.ReadAll(req.Body)
+		// httpclient.Do method will read the entire body and make it empty
+		// thus using req.GetBody() instead of req.Body since req.Body
+		// is empty after Do method.
+		// body here is a copy of original body
+		body, _ := req.GetBody()
+		buf, _ := io.ReadAll(body)
 		req.Body = io.NopCloser(bytes.NewBuffer(buf)) // important!!
 		curl += `-d ` + shellescape.Quote(string(buf))
 	}


### PR DESCRIPTION
```The `TestGenerateExecutedCurl` failure started after I merged from branch `v2` to branch `main`. It needs to investigate why it's failing.```

_Originally posted by @jeevatkm in https://github.com/go-resty/resty/issues/827#issuecomment-2323726014_

Hi jeevatkm, I've found the reason why the test case failed.
In https://github.com/go-resty/resty/blob/6d941ac6f1ed35557b6fb3fb41cf74beeb9be2f0/client.go#L1601 `Do` method will read the `req.RawRequest.Body` and make it empty. When generating curl body it will read an empty string, and that's why it failed.

This commit offers a temporary solution to this problem, I think the ultimate solution is to add a `Clone` method in `Request`, as #718 describes.
            