### PR TITLE
feat(continue)!: add content type encoder and decoder, implement encoder in the request generation flow #439

### DIFF
--- a/client.go
+++ b/client.go
@@ -733,6 +733,17 @@ func (c *Client) AddContentTypeEncoder(ct string, e ContentTypeEncoder) *Client 
 	return c
 }
 
+func (c *Client) inferContentTypeEncoder(ct ...string) (ContentTypeEncoder, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for _, v := range ct {
+		if d, f := c.contentTypeEncoders[v]; f {
+			return d, f
+		}
+	}
+	return nil, false
+}
+
 // ContentTypeDecoders method returns all the registered content type decoders.
 func (c *Client) ContentTypeDecoders() map[string]ContentTypeDecoder {
 	c.lock.RLock()

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -672,18 +672,18 @@ func TestParseRequestBody(t *testing.T) {
 					Bar: "2",
 				}).SetContentLength(true)
 			},
-			expectedBodyBuf:       []byte(`{"foo":"1","bar":"2"}`),
+			expectedBodyBuf:       append([]byte(`{"foo":"1","bar":"2"}`), '\n'),
 			expectedContentType:   jsonContentType,
-			expectedContentLength: "21",
+			expectedContentLength: "22",
 		},
 		{
 			name: "json from slice",
 			initRequest: func(r *Request) {
 				r.SetBody([]string{"foo", "bar"}).SetContentLength(true)
 			},
-			expectedBodyBuf:       []byte(`["foo","bar"]`),
+			expectedBodyBuf:       append([]byte(`["foo","bar"]`), '\n'),
 			expectedContentType:   jsonContentType,
-			expectedContentLength: "13",
+			expectedContentLength: "14",
 		},
 		{
 			name: "json from map",
@@ -697,9 +697,9 @@ func TestParseRequestBody(t *testing.T) {
 					"xyz": nil,
 				}).SetContentLength(true)
 			},
-			expectedBodyBuf:       []byte(`{"bar":[1,2,3],"baz":{"qux":"4"},"foo":"1","xyz":null}`),
+			expectedBodyBuf:       append([]byte(`{"bar":[1,2,3],"baz":{"qux":"4"},"foo":"1","xyz":null}`), '\n'),
 			expectedContentType:   jsonContentType,
-			expectedContentLength: "54",
+			expectedContentLength: "55",
 		},
 		{
 			name: "json from map",
@@ -713,9 +713,9 @@ func TestParseRequestBody(t *testing.T) {
 					"xyz": nil,
 				}).SetContentLength(true)
 			},
-			expectedBodyBuf:       []byte(`{"bar":[1,2,3],"baz":{"qux":"4"},"foo":"1","xyz":null}`),
+			expectedBodyBuf:       append([]byte(`{"bar":[1,2,3],"baz":{"qux":"4"},"foo":"1","xyz":null}`), '\n'),
 			expectedContentType:   jsonContentType,
-			expectedContentLength: "54",
+			expectedContentLength: "55",
 		},
 		{
 			name: "json from map",
@@ -729,9 +729,9 @@ func TestParseRequestBody(t *testing.T) {
 					"xyz": nil,
 				}).SetContentLength(true)
 			},
-			expectedBodyBuf:       []byte(`{"bar":[1,2,3],"baz":{"qux":"4"},"foo":"1","xyz":null}`),
+			expectedBodyBuf:       append([]byte(`{"bar":[1,2,3],"baz":{"qux":"4"},"foo":"1","xyz":null}`), '\n'),
 			expectedContentType:   jsonContentType,
-			expectedContentLength: "54",
+			expectedContentLength: "55",
 		},
 		{
 			name: "xml from struct",

--- a/request.go
+++ b/request.go
@@ -1268,18 +1268,6 @@ func (r *Request) initValuesMap() {
 	}
 }
 
-var noescapeJSONMarshal = func(v any) (*bytes.Buffer, error) {
-	buf := acquireBuffer()
-	encoder := json.NewEncoder(buf)
-	encoder.SetEscapeHTML(false)
-	if err := encoder.Encode(v); err != nil {
-		releaseBuffer(buf)
-		return nil, err
-	}
-
-	return buf, nil
-}
-
 var noescapeJSONMarshalIndent = func(v any) (*bytes.Buffer, error) {
 	buf := acquireBuffer()
 	encoder := json.NewEncoder(buf)

--- a/request_test.go
+++ b/request_test.go
@@ -591,7 +591,7 @@ func TestPostXMLMapNotSupported(t *testing.T) {
 		SetBody(map[string]any{"Username": "testuser", "Password": "testpass"}).
 		Post(ts.URL + "/login")
 
-	assertEqual(t, "unsupported 'Body' type/value", err.Error())
+	assertErrorIs(t, ErrUnsupportedRequestBodyKind, err)
 }
 
 func TestRequestBasicAuth(t *testing.T) {

--- a/resty_test.go
+++ b/resty_test.go
@@ -385,6 +385,17 @@ func createFormPostServer(t *testing.T) *httptest.Server {
 				return
 			}
 		}
+
+		if r.Method == MethodPut {
+
+			if r.URL.Path == "/raw-upload" {
+				body, _ := io.ReadAll(r.Body)
+				bl, _ := strconv.Atoi(r.Header.Get("Content-Length"))
+				assertEqual(t, len(body), bl)
+				w.WriteHeader(http.StatusOK)
+			}
+
+		}
 	})
 
 	return ts

--- a/stream.go
+++ b/stream.go
@@ -20,7 +20,13 @@ type (
 )
 
 func encodeJSON(w io.Writer, v any) error {
-	return json.NewEncoder(w).Encode(v)
+	return encodeJSONEscapeHTML(w, v, true)
+}
+
+func encodeJSONEscapeHTML(w io.Writer, v any, esc bool) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(esc)
+	return enc.Encode(v)
 }
 
 func decodeJSON(r io.Reader, v any) error {

--- a/util.go
+++ b/util.go
@@ -97,7 +97,7 @@ func DetectContentType(body any) string {
 	default:
 		if b, ok := body.([]byte); ok {
 			contentType = http.DetectContentType(b)
-		} else if kind == reflect.Slice {
+		} else if kind == reflect.Slice { // check slice here to differentiate between any slice vs byte slice
 			contentType = jsonContentType
 		}
 	}
@@ -150,24 +150,6 @@ type RequestLog struct {
 type ResponseLog struct {
 	Header http.Header
 	Body   string
-}
-
-// way to disable the HTML escape as opt-in
-func jsonMarshal(c *Client, r *Request, d any) (*bytes.Buffer, error) {
-	if !r.jsonEscapeHTML {
-		return noescapeJSONMarshal(d)
-	}
-
-	c.lock.RLock()
-	data, err := c.jsonMarshal(d)
-	c.lock.RUnlock()
-	if err != nil {
-		return nil, err
-	}
-
-	buf := acquireBuffer()
-	_, _ = buf.Write(data)
-	return buf, nil
 }
 
 func firstNonEmpty(v ...string) string {

--- a/util_curl.go
+++ b/util_curl.go
@@ -35,7 +35,7 @@ func buildCurlRequest(req *http.Request, httpCookiejar http.CookieJar) (curl str
 	if req.Body != nil {
 		buf, _ := io.ReadAll(req.Body)
 		req.Body = io.NopCloser(bytes.NewBuffer(buf)) // important!!
-		curl += `-d ` + shellescape.Quote(string(buf))
+		curl += `-d ` + shellescape.Quote(string(bytes.TrimRight(buf, "\n")))
 	}
 
 	urlString := shellescape.Quote(req.URL.String())


### PR DESCRIPTION
closes #439 