### PR TITLE
fix: do not use errors.Join, just use custom error approach

### DIFF
--- a/client.go
+++ b/client.go
@@ -1244,10 +1244,10 @@ func (c *Client) execute(req *Request) (*Response, error) {
 
 	if err != nil || req.notParseResponse || c.notParseResponse {
 		response.setReceivedAt()
-		logErr := responseLogger(c, response)
-		if logErr != nil {
+		if logErr := responseLogger(c, response); logErr != nil {
 			return response, wrapErrors(logErr, err)
-		} else if err != nil {
+		}
+		if err != nil {
 			return response, err
 		}
 		return response, nil

--- a/client.go
+++ b/client.go
@@ -1243,12 +1243,14 @@ func (c *Client) execute(req *Request) (*Response, error) {
 	}
 
 	if err != nil || req.notParseResponse || c.notParseResponse {
-		logErr := responseLogger(c, response)
 		response.setReceivedAt()
-		if err != nil {
-			return response, errors.Join(err, logErr)
+		logErr := responseLogger(c, response)
+		if logErr != nil {
+			return response, wrapErrors(logErr, err)
+		} else if err != nil {
+			return response, err
 		}
-		return response, wrapNoRetryErr(logErr)
+		return response, nil
 	}
 
 	if !req.isSaveResponse {
@@ -1260,7 +1262,7 @@ func (c *Client) execute(req *Request) (*Response, error) {
 			if _, ok := body.(*gzip.Reader); !ok {
 				body, err = gzip.NewReader(body)
 				if err != nil {
-					err = errors.Join(err, responseLogger(c, response))
+					err = wrapErrors(responseLogger(c, response), err)
 					response.setReceivedAt()
 					return response, err
 				}
@@ -1269,7 +1271,7 @@ func (c *Client) execute(req *Request) (*Response, error) {
 		}
 
 		if response.body, err = readAllWithLimit(body, req.responseBodyLimit); err != nil {
-			err = errors.Join(err, responseLogger(c, response))
+			err = wrapErrors(responseLogger(c, response), err)
 			response.setReceivedAt()
 			return response, err
 		}

--- a/util.go
+++ b/util.go
@@ -357,6 +357,32 @@ func copyHeaders(hdrs http.Header) http.Header {
 	return nh
 }
 
+func wrapErrors(n error, inner error) error {
+	if inner == nil {
+		return n
+	}
+	if n == nil {
+		return inner
+	}
+	return &restyError{
+		err:   n,
+		inner: inner,
+	}
+}
+
+type restyError struct {
+	err   error
+	inner error
+}
+
+func (e *restyError) Error() string {
+	return e.err.Error()
+}
+
+func (e *restyError) Unwrap() error {
+	return e.inner
+}
+
 type noRetryErr struct {
 	err error
 }

--- a/util_test.go
+++ b/util_test.go
@@ -6,6 +6,7 @@ package resty
 
 import (
 	"bytes"
+	"errors"
 	"mime/multipart"
 	"testing"
 )
@@ -88,4 +89,19 @@ func TestWriteMultipartFormFileReaderError(t *testing.T) {
 	err := writeMultipartFormFile(nil, "", "", &brokenReadCloser{})
 	assertNotNil(t, err)
 	assertEqual(t, "read error", err.Error())
+}
+
+func TestRestyErrorFuncs(t *testing.T) {
+	ne1 := errors.New("new error 1")
+	nie1 := errors.New("inner error 1")
+
+	e := wrapErrors(ne1, nie1)
+	assertEqual(t, "new error 1", e.Error())
+	assertEqual(t, "inner error 1", errors.Unwrap(e).Error())
+
+	e = wrapErrors(ne1, nil)
+	assertEqual(t, "new error 1", e.Error())
+
+	e = wrapErrors(nil, nie1)
+	assertEqual(t, "inner error 1", e.Error())
 }


### PR DESCRIPTION
As it turns out, `errors.Join` is not playing well with simple errors like `errors.New` or `fmt.Errorf`.  For now, let's go with a custom error with `Unwrap`.