### PR TITLE
fix: 'invalid memory address or nil pointer dereference' in response logger

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -375,7 +375,7 @@ func responseLogger(c *Client, res *Response) error {
 		debugLog := res.Request.values[debugRequestLogKey].(string)
 		debugLog += "~~~ RESPONSE ~~~\n" +
 			fmt.Sprintf("STATUS       : %s\n", res.Status()) +
-			fmt.Sprintf("PROTO        : %s\n", res.RawResponse.Proto) +
+			fmt.Sprintf("PROTO        : %s\n", res.Proto()) +
 			fmt.Sprintf("RECEIVED AT  : %v\n", res.ReceivedAt().Format(time.RFC3339Nano)) +
 			fmt.Sprintf("TIME DURATION: %v\n", res.Time()) +
 			"HEADERS      :\n" +


### PR DESCRIPTION
An error like ‘dial tcp 10.66.0.229:80: connect: connection refused’ when request and response logging is activated causes an ‘invalid memory address or nil pointer dereference’. This is due to changes from version 2.14 to 2.15, where the logging call was moved up in the execute function. In version 2.14, the function returned early on this error, so the logging call was not made. Now, the logging call is made, and res.RawResponseProto is used without a nil check on RawResponse.

The fix is simple: use res.Proto(), which performs the nil check.

fixes #873
