### PR TITLE
feat: add way to set empty header on request #496

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -161,18 +161,18 @@ func parseRequestHeader(c *Client, r *Request) error {
 		r.Header[k] = v[:]
 	}
 
-	if isStringEmpty(r.Header.Get(hdrUserAgentKey)) {
+	if !r.isHeaderExists(hdrUserAgentKey) {
 		r.Header.Set(hdrUserAgentKey, hdrUserAgentValue)
 	}
 
-	if isStringEmpty(r.Header.Get(hdrAcceptKey)) {
+	if !r.isHeaderExists(hdrAcceptKey) {
 		ct := r.Header.Get(hdrContentTypeKey)
 		if isJSONContentType(ct) || isXMLContentType(ct) {
 			r.Header.Set(hdrAcceptKey, ct)
 		}
 	}
 
-	if isStringEmpty(r.Header.Get(hdrAcceptEncodingKey)) {
+	if !r.isHeaderExists(hdrAcceptEncodingKey) {
 		r.Header.Set(hdrAcceptEncodingKey, r.client.ContentDecompressorKeys())
 	}
 
@@ -498,7 +498,10 @@ func handleRequestBody(c *Client, r *Request) error {
 	contentType := r.Header.Get(hdrContentTypeKey)
 	if isStringEmpty(contentType) {
 		// it is highly recommended that the user provide a request content-type
+		// so that we can minimize memory allocation and compute.
 		contentType = detectContentType(r.Body)
+	}
+	if !r.isHeaderExists(hdrContentTypeKey) {
 		r.Header.Set(hdrContentTypeKey, contentType)
 	}
 

--- a/request.go
+++ b/request.go
@@ -1378,6 +1378,11 @@ func (r *Request) initClientTrace() {
 	}
 }
 
+func (r *Request) isHeaderExists(k string) bool {
+	_, f := r.Header[k]
+	return f
+}
+
 func jsonIndent(v []byte) []byte {
 	buf := acquireBuffer()
 	defer releaseBuffer(buf)


### PR DESCRIPTION
closes #496 

The solution is not to use the method `Get` on the Header, which returns an empty string for a non-existing header key. Instead, check directly in the header map