### PR TITLE
feat!: add TLSClientConfiger interface to support TLSClientConfig for custom round tripper #377

### DIFF
--- a/cert_watcher_test.go
+++ b/cert_watcher_test.go
@@ -94,7 +94,7 @@ func TestClient_SetRootCertificateWatcher(t *testing.T) {
 		assertNil(t, err)
 
 		// Reset TLS config to ensure that previous root cert is not re-used
-		tr, err := client.Transport()
+		tr, err := client.HTTPTransport()
 		assertNil(t, err)
 		tr.TLSClientConfig = nil
 		client.SetTransport(tr)

--- a/request_test.go
+++ b/request_test.go
@@ -1108,7 +1108,7 @@ func TestRawFileUploadByBody(t *testing.T) {
 func TestProxySetting(t *testing.T) {
 	c := dcnl()
 
-	transport, err := c.Transport()
+	transport, err := c.HTTPTransport()
 
 	assertNil(t, err)
 


### PR DESCRIPTION
Closes #377