### PR TITLE
feat!: enhance credentials usage and update warning message for credentials requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -76,6 +76,8 @@ var (
 	jsonKey = "json"
 	xmlKey  = "xml"
 
+	defaultAuthScheme = "Bearer"
+
 	hdrUserAgentValue = "go-resty/" + Version + " (https://github.com/go-resty/resty)"
 	bufPool           = &sync.Pool{New: func() any { return &bytes.Buffer{} }}
 )

--- a/client_test.go
+++ b/client_test.go
@@ -1381,8 +1381,8 @@ func TestClientClone(t *testing.T) {
 	// assert non-interface type
 	assertEqual(t, "http://localhost", parent.BaseURL())
 	assertEqual(t, "https://local.host", clone.BaseURL())
-	assertEqual(t, "parent", parent.UserInfo().Username)
-	assertEqual(t, "clone", clone.UserInfo().Username)
+	assertEqual(t, "parent", parent.credentials.Username)
+	assertEqual(t, "clone", clone.credentials.Username)
 
 	// assert interface/pointer type
 	assertEqual(t, parent.Client(), clone.Client())

--- a/example_test.go
+++ b/example_test.go
@@ -99,9 +99,12 @@ func Example_post() {
 
 	printOutput(resp1, err1)
 
+	type User struct {
+		Username, Password string
+	}
 	// POST Struct, default is JSON content type. No need to set one
 	resp2, err2 := client.R().
-		SetBody(resty.User{Username: "testuser", Password: "testpass"}).
+		SetBody(User{Username: "testuser", Password: "testpass"}).
 		SetResult(&AuthSuccess{}). // or SetResult(AuthSuccess{}).
 		SetError(&AuthError{}).    // or SetError(AuthError{}).
 		Post("https://myapp.com/login")

--- a/middleware.go
+++ b/middleware.go
@@ -312,11 +312,7 @@ func addCredentials(c *Client, r *Request) error {
 	// Build the token Auth header
 	if !isStringEmpty(r.AuthToken) {
 		credentialsAdded = true
-		authScheme := r.AuthScheme
-		if isStringEmpty(authScheme) {
-			authScheme = "Bearer"
-		}
-		r.RawRequest.Header.Set(c.HeaderAuthorizationKey(), authScheme+" "+r.AuthToken)
+		r.RawRequest.Header.Set(c.HeaderAuthorizationKey(), r.AuthScheme+" "+r.AuthToken)
 	}
 
 	if !c.IsDisableWarn() && credentialsAdded {

--- a/request_test.go
+++ b/request_test.go
@@ -220,7 +220,8 @@ func TestPostJSONStructSuccess(t *testing.T) {
 	ts := createPostServer(t)
 	defer ts.Close()
 
-	user := &User{Username: "testuser", Password: "testpass"}
+	user := &credentials{Username: "testuser", Password: "testpass"}
+	assertEqual(t, "Username: **********, Password: **********", user.String())
 
 	c := dcnl().SetJSONEscapeHTML(false)
 	r := c.R().
@@ -246,7 +247,8 @@ func TestPostJSONRPCStructSuccess(t *testing.T) {
 	ts := createPostServer(t)
 	defer ts.Close()
 
-	user := &User{Username: "testuser", Password: "testpass"}
+	user := &credentials{Username: "testuser", Password: "testpass"}
+	assertEqual(t, "Username: **********, Password: **********", user.String())
 
 	c := dcnl().SetJSONEscapeHTML(false)
 	r := c.R().
@@ -276,7 +278,7 @@ func TestPostJSONStructInvalidLogin(t *testing.T) {
 
 	resp, err := c.R().
 		SetHeader(hdrContentTypeKey, "application/json; charset=utf-8").
-		SetBody(User{Username: "testuser", Password: "testpass1"}).
+		SetBody(credentials{Username: "testuser", Password: "testpass1"}).
 		SetError(AuthError{}).
 		SetJSONEscapeHTML(false).
 		Post(ts.URL + "/login")
@@ -299,7 +301,7 @@ func TestPostJSONErrorRFC7807(t *testing.T) {
 	c := dcnl()
 	resp, err := c.R().
 		SetHeader(hdrContentTypeKey, "application/json; charset=utf-8").
-		SetBody(User{Username: "testuser", Password: "testpass1"}).
+		SetBody(credentials{Username: "testuser", Password: "testpass1"}).
 		SetError(AuthError{}).
 		Post(ts.URL + "/login?ct=problem")
 
@@ -493,7 +495,7 @@ func TestPostXMLStructSuccess(t *testing.T) {
 
 	resp, err := dcnldr().
 		SetHeader(hdrContentTypeKey, "application/xml").
-		SetBody(User{Username: "testuser", Password: "testpass"}).
+		SetBody(credentials{Username: "testuser", Password: "testpass"}).
 		SetContentLength(true).
 		SetResult(&AuthSuccess{}).
 		Post(ts.URL + "/login")
@@ -515,7 +517,7 @@ func TestPostXMLStructInvalidLogin(t *testing.T) {
 
 	resp, err := c.R().
 		SetHeader(hdrContentTypeKey, "application/xml").
-		SetBody(User{Username: "testuser", Password: "testpass1"}).
+		SetBody(credentials{Username: "testuser", Password: "testpass1"}).
 		Post(ts.URL + "/login")
 
 	assertError(t, err)
@@ -533,7 +535,7 @@ func TestPostXMLStructInvalidResponseXml(t *testing.T) {
 
 	resp, err := dcnldr().
 		SetHeader(hdrContentTypeKey, "application/xml").
-		SetBody(User{Username: "testuser", Password: "invalidxml"}).
+		SetBody(credentials{Username: "testuser", Password: "invalidxml"}).
 		SetResult(&AuthSuccess{}).
 		Post(ts.URL + "/login")
 
@@ -617,7 +619,8 @@ func TestRequestInsecureBasicAuth(t *testing.T) {
 
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
-	assertEqual(t, true, strings.Contains(logBuf.String(), "WARN RESTY Using Basic Auth in HTTP mode is not secure, use HTTPS"))
+	assertEqual(t, true, strings.Contains(logBuf.String(),
+		"WARN RESTY Using sensitive credentials in HTTP mode is not secure. Use HTTPS"))
 
 	t.Logf("Result Success: %q", resp.Result().(*AuthSuccess))
 	logResponse(t, resp)
@@ -1157,7 +1160,7 @@ func TestDetectContentTypeForPointer(t *testing.T) {
 	ts := createPostServer(t)
 	defer ts.Close()
 
-	user := &User{Username: "testuser", Password: "testpass"}
+	user := &credentials{Username: "testuser", Password: "testpass"}
 
 	resp, err := dcnldr().
 		SetBody(user).
@@ -1987,7 +1990,7 @@ func TestRequestClone(t *testing.T) {
 	// update value of http header - change will only happen on clone
 	clone.SetHeader("X-Header", "clone")
 	// update value of interface type - change will only happen on clone
-	clone.UserInfo.Username = "clone"
+	clone.credentials.Username = "clone"
 	clone.bodyBuf.Reset()
 	clone.bodyBuf.WriteString("clone")
 
@@ -2002,8 +2005,8 @@ func TestRequestClone(t *testing.T) {
 	assertEqual(t, "parent", parent.Header.Get("X-Header"))
 	assertEqual(t, "clone", clone.Header.Get("X-Header"))
 	// assert interface type
-	assertEqual(t, "parent", parent.UserInfo.Username)
-	assertEqual(t, "clone", clone.UserInfo.Username)
+	assertEqual(t, "parent", parent.credentials.Username)
+	assertEqual(t, "clone", clone.credentials.Username)
 	assertEqual(t, "", parent.bodyBuf.String())
 	assertEqual(t, "clone", clone.bodyBuf.String())
 
@@ -2017,7 +2020,7 @@ func TestResponseBodyUnlimitedReads(t *testing.T) {
 	ts := createPostServer(t)
 	defer ts.Close()
 
-	user := &User{Username: "testuser", Password: "testpass"}
+	user := &credentials{Username: "testuser", Password: "testpass"}
 
 	c := dcnl().
 		SetJSONEscapeHTML(false).
@@ -2183,7 +2186,7 @@ func TestRequestSetResultAndSetOutputFile(t *testing.T) {
 
 	res, err := c.R().
 		SetHeader(hdrContentTypeKey, "application/json; charset=utf-8").
-		SetBody(&User{Username: "testuser", Password: "testpass"}).
+		SetBody(&credentials{Username: "testuser", Password: "testpass"}).
 		SetResponseBodyUnlimitedReads(true).
 		SetResult(&AuthSuccess{}).
 		SetOutputFile(outputFile).

--- a/resty.go
+++ b/resty.go
@@ -163,6 +163,7 @@ func createClient(hc *http.Client) *Client {
 		queryParams:              url.Values{},
 		formData:                 url.Values{},
 		header:                   http.Header{},
+		authScheme:               defaultAuthScheme,
 		cookies:                  make([]*http.Cookie, 0),
 		retryWaitTime:            defaultWaitTime,
 		retryMaxWaitTime:         defaultMaxWaitTime,

--- a/resty_test.go
+++ b/resty_test.go
@@ -167,7 +167,7 @@ func createGetServer(t *testing.T) *httptest.Server {
 
 func handleLoginEndpoint(t *testing.T, w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path == "/login" {
-		user := &User{}
+		user := &credentials{}
 
 		// JSON
 		if isJSONContentType(r.Header.Get(hdrContentTypeKey)) {

--- a/util.go
+++ b/util.go
@@ -69,6 +69,23 @@ func (l *logger) output(format string, v ...any) {
 	l.l.Printf(format, v...)
 }
 
+// credentials type is to hold an username and password information
+type credentials struct {
+	Username, Password string
+}
+
+// Clone method returns clone of c.
+func (c *credentials) Clone() *credentials {
+	cc := new(credentials)
+	*cc = *c
+	return cc
+}
+
+// String method returns masked value of username and password
+func (c credentials) String() string {
+	return "Username: **********, Password: **********"
+}
+
 //‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
 // Package Helper methods
 //_______________________________________________________________________


### PR DESCRIPTION
- User type become unexported 
- HTTP not secure warning message added for auth token flow too
- Intialize the default auth scheme value `Bearer` during client creation