### PR TITLE
feat: use context timeout instead of http client timeout option #545

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -135,10 +135,9 @@ func TestClientTimeout(t *testing.T) {
 	ts := createGetServer(t)
 	defer ts.Close()
 
-	c := dcnl().SetTimeout(time.Millisecond * 200)
+	c := dcnl().SetTimeout(200 * time.Millisecond)
 	_, err := c.R().Get(ts.URL + "/set-timeout-test")
-
-	assertEqual(t, true, strings.Contains(err.Error(), "Client.Timeout"))
+	assertEqual(t, true, errors.Is(err, context.DeadlineExceeded))
 }
 
 func TestClientTimeoutWithinThreshold(t *testing.T) {

--- a/context_test.go
+++ b/context_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -212,8 +211,7 @@ func TestClientRetryWithSetContext(t *testing.T) {
 
 	assertNotNil(t, ts)
 	assertNotNil(t, err)
-	assertEqual(t, true, (strings.HasPrefix(err.Error(), "Get "+ts.URL+"/") ||
-		strings.HasPrefix(err.Error(), "Get \""+ts.URL+"/\"")))
+	assertEqual(t, true, errors.Is(err, context.DeadlineExceeded))
 }
 
 func TestRequestContext(t *testing.T) {


### PR DESCRIPTION
- add Request.SetTimeout method

closes #545 