### PR TITLE
feat(enhancement): remove unnecessary map for raw path params instead use path params

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches:
+      - v3
       - v2
     paths-ignore:
       - '**.md'
@@ -11,6 +12,7 @@ on:
   pull_request:
     branches:
       - main
+      - v3
       - v2
     paths-ignore:
       - '**.md'
@@ -47,7 +49,7 @@ jobs:
         run: diff -u <(echo -n) <(go fmt $(go list ./...))
 
       - name: Test
-        run: go test ./... -race -count=1 -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... -shuffle=on
+        run: go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=1 -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... -shuffle=on
 
       - name: Upload coverage to Codecov
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.go == 'stable' }}

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -36,7 +36,7 @@ jobs:
         run: diff -u <(echo -n) <(go fmt $(go list ./...))
 
       - name: Test
-        run: go test ./... -race -count=1 -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... -shuffle=on
+        run: go run gotest.tools/gotestsum@latest -f testname -- ./... -race -count=1 -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... -shuffle=on
 
       - name: Upload coverage to Codecov
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.go == 'stable' }}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,205 @@
+// Copyright (c) 2015-present Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
+// resty source code and usage is governed by a MIT style
+// license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package resty
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func Benchmark_parseRequestURL_PathParams(b *testing.B) {
+	c := New().SetPathParams(map[string]string{
+		"foo": "1",
+		"bar": "2",
+	}).SetRawPathParams(map[string]string{
+		"foo": "3",
+		"xyz": "4",
+	})
+	r := c.R().SetPathParams(map[string]string{
+		"foo": "5",
+		"qwe": "6",
+	}).SetRawPathParams(map[string]string{
+		"foo": "7",
+		"asd": "8",
+	})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r.URL = "https://example.com/{foo}/{bar}/{xyz}/{qwe}/{asd}"
+		if err := parseRequestURL(c, r); err != nil {
+			b.Errorf("parseRequestURL() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestURL_QueryParams(b *testing.B) {
+	c := New().SetQueryParams(map[string]string{
+		"foo": "1",
+		"bar": "2",
+	})
+	r := c.R().SetQueryParams(map[string]string{
+		"foo": "5",
+		"qwe": "6",
+	})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r.URL = "https://example.com/"
+		if err := parseRequestURL(c, r); err != nil {
+			b.Errorf("parseRequestURL() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestHeader(b *testing.B) {
+	c := New()
+	r := c.R()
+	c.SetHeaders(map[string]string{
+		"foo": "1", // ignored, because of the same header in the request
+		"bar": "2",
+	})
+	r.SetHeaders(map[string]string{
+		"foo": "3",
+		"xyz": "4",
+	})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestHeader(c, r); err != nil {
+			b.Errorf("parseRequestHeader() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_string(b *testing.B) {
+	c := New()
+	r := c.R()
+	r.SetBody("foo").SetContentLength(true)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_byte(b *testing.B) {
+	c := New()
+	r := c.R()
+	r.SetBody([]byte("foo")).SetContentLength(true)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_reader(b *testing.B) {
+	c := New()
+	r := c.R()
+	r.SetBody(bytes.NewBufferString("foo"))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_struct(b *testing.B) {
+	type FooBar struct {
+		Foo string `json:"foo"`
+		Bar string `json:"bar"`
+	}
+	c := New()
+	r := c.R()
+	r.SetBody(FooBar{Foo: "1", Bar: "2"}).SetContentLength(true).SetHeader(hdrContentTypeKey, jsonContentType)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_struct_xml(b *testing.B) {
+	type FooBar struct {
+		Foo string `xml:"foo"`
+		Bar string `xml:"bar"`
+	}
+	c := New()
+	r := c.R()
+	r.SetBody(FooBar{Foo: "1", Bar: "2"}).SetContentLength(true).SetHeader(hdrContentTypeKey, "text/xml")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_map(b *testing.B) {
+	c := New()
+	r := c.R()
+	r.SetBody(map[string]string{
+		"foo": "1",
+		"bar": "2",
+	}).SetContentLength(true).SetHeader(hdrContentTypeKey, jsonContentType)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_slice(b *testing.B) {
+	c := New()
+	r := c.R()
+	r.SetBody([]string{"1", "2"}).SetContentLength(true).SetHeader(hdrContentTypeKey, jsonContentType)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_FormData(b *testing.B) {
+	c := New()
+	r := c.R()
+	c.SetFormData(map[string]string{"foo": "1", "bar": "2"})
+	r.SetFormData(map[string]string{"foo": "3", "baz": "4"}).SetContentLength(true)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}
+
+func Benchmark_parseRequestBody_MultiPart(b *testing.B) {
+	c := New()
+	r := c.R()
+	c.SetFormData(map[string]string{"foo": "1", "bar": "2"})
+	r.SetFormData(map[string]string{"foo": "3", "baz": "4"}).
+		SetMultipartFormData(map[string]string{"foo": "5", "xyz": "6"}).
+		SetFileReader("qwe", "qwe.txt", strings.NewReader("7")).
+		SetMultipartFields(
+			&MultipartField{
+				Name:        "sdj",
+				ContentType: "text/plain",
+				Reader:      strings.NewReader("8"),
+			},
+		).
+		SetContentLength(true).
+		SetMethod(MethodPost)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := parseRequestBody(c, r); err != nil {
+			b.Errorf("parseRequestBody() error = %v", err)
+		}
+	}
+}

--- a/curl_test.go
+++ b/curl_test.go
@@ -198,7 +198,7 @@ func TestCurl_buildCurlCmd(t *testing.T) {
 				req.SetHeader(k, v)
 			}
 
-			err := createHTTPRequest(c, req)
+			err := createRawRequest(c, req)
 			assertNil(t, err)
 
 			if len(tt.cookies) > 0 {
@@ -249,7 +249,20 @@ func TestCurlRequestGetBodyError(t *testing.T) {
 	} else {
 		t.Log("curlCmdUnexecuted: \n", curlCmdUnexecuted)
 	}
+}
 
+func TestCurlRequestMiddlewaresError(t *testing.T) {
+	errMsg := "middleware error"
+	c := dcnl().EnableDebug().
+		SetRequestMiddlewares(
+			func(c *Client, r *Request) error {
+				return errors.New(errMsg)
+			},
+			PrepareRequestMiddleware,
+		)
+
+	curlCmdUnexecuted := c.R().EnableGenerateCurlOnDebug().GenerateCurlCommand()
+	assertEqual(t, "", curlCmdUnexecuted)
 }
 
 func TestCurlMiscTestCoverage(t *testing.T) {

--- a/digest.go
+++ b/digest.go
@@ -59,15 +59,18 @@ func (dt *digestTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
 	// make a request to get the 401 that contains the challenge.
 	res, err := dt.transport.RoundTrip(req1)
-	if err != nil || res.StatusCode != http.StatusUnauthorized {
-		return res, err
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != http.StatusUnauthorized {
+		return res, nil
 	}
 	_, _ = ioCopy(io.Discard, res.Body)
 	closeq(res.Body)
 
 	chaHdrValue := strings.TrimSpace(res.Header.Get(hdrWwwAuthenticateKey))
 	if chaHdrValue == "" {
-		return res, ErrDigestBadChallenge
+		return nil, ErrDigestBadChallenge
 	}
 
 	cha, err := dt.parseChallenge(chaHdrValue)

--- a/digest_test.go
+++ b/digest_test.go
@@ -160,6 +160,24 @@ func TestClientDigestAuthWithBodyQopAuthIntIoCopyError(t *testing.T) {
 	assertEqual(t, 0, resp.StatusCode())
 }
 
+func TestClientDigestAuthRoundTripError(t *testing.T) {
+	conf := *defaultDigestServerConf()
+	ts := createDigestServer(t, &conf)
+	defer ts.Close()
+
+	c := dcnl().SetTransport(&CustomRoundTripper2{returnErr: true})
+	c.SetDigestAuth(conf.username, conf.password)
+
+	_, err := c.R().
+		SetResult(&AuthSuccess{}).
+		SetHeader(hdrContentTypeKey, "application/json").
+		SetBody(map[string]any{"zip_code": "00000", "city": "Los Angeles"}).
+		Post(ts.URL + conf.uri)
+
+	assertNotNil(t, err)
+	assertEqual(t, true, strings.Contains(err.Error(), "test req mock error"))
+}
+
 func TestClientDigestAuthWithBodyQopAuthIntGetBodyNil(t *testing.T) {
 	conf := *defaultDigestServerConf()
 	conf.qop = "auth-int"

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module resty.dev/v3
 
 go 1.21
 
-require (
-	golang.org/x/net v0.27.0
-	golang.org/x/time v0.6.0
-)
+require golang.org/x/net v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 golang.org/x/net v0.27.0 h1:5K3Njcw06/l2y9vpGCSdcxWOYHOUk3dVNGDXN+FvAys=
 golang.org/x/net v0.27.0/go.mod h1:dDi0PyhWNoiUOrAS8uXv/vnScO4wnHQO4mj9fn/RytE=
-golang.org/x/time v0.6.0 h1:eTDhh4ZXt5Qf0augr54TN6suAUudPcawVZeIAPU7D4U=
-golang.org/x/time v0.6.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=

--- a/response.go
+++ b/response.go
@@ -247,13 +247,13 @@ func (r *Response) wrapCopyReadCloser() {
 	}
 }
 
-func (r *Response) wrapContentDecompressor() error {
+func (r *Response) wrapContentDecompresser() error {
 	ce := r.Header().Get(hdrContentEncodingKey)
 	if isStringEmpty(ce) {
 		return nil
 	}
 
-	if decFunc, f := r.Request.client.ContentDecompressors()[ce]; f {
+	if decFunc, f := r.Request.client.ContentDecompressers()[ce]; f {
 		dec, err := decFunc(r.Body)
 		if err != nil {
 			if err == io.EOF {
@@ -268,7 +268,7 @@ func (r *Response) wrapContentDecompressor() error {
 		r.Header().Del(hdrContentLengthKey)
 		r.RawResponse.ContentLength = -1
 	} else {
-		return ErrContentDecompressorNotFound
+		return ErrContentDecompresserNotFound
 	}
 
 	return nil

--- a/resty.go
+++ b/resty.go
@@ -169,15 +169,14 @@ func createClient(hc *http.Client) *Client {
 		retryMaxWaitTime:         defaultMaxWaitTime,
 		isRetryDefaultConditions: true,
 		pathParams:               make(map[string]string),
-		rawPathParams:            make(map[string]string),
 		headerAuthorizationKey:   hdrAuthorizationKey,
 		jsonEscapeHTML:           true,
 		httpClient:               hc,
 		debugBodyLimit:           math.MaxInt32,
 		contentTypeEncoders:      make(map[string]ContentTypeEncoder),
 		contentTypeDecoders:      make(map[string]ContentTypeDecoder),
-		contentDecompressorKeys:  make([]string, 0),
-		contentDecompressors:     make(map[string]ContentDecompressor),
+		contentDecompresserKeys:  make([]string, 0),
+		contentDecompressers:     make(map[string]ContentDecompresser),
 		certWatcherStopChan:      make(chan bool),
 	}
 
@@ -191,8 +190,8 @@ func createClient(hc *http.Client) *Client {
 	c.AddContentTypeDecoder(xmlKey, decodeXML)
 
 	// Order matter, giving priority to gzip
-	c.AddContentDecompressor("deflate", decompressDeflate)
-	c.AddContentDecompressor("gzip", decompressGzip)
+	c.AddContentDecompresser("deflate", decompressDeflate)
+	c.AddContentDecompresser("gzip", decompressGzip)
 
 	// request middlewares
 	c.SetRequestMiddlewares(

--- a/resty_test.go
+++ b/resty_test.go
@@ -34,6 +34,7 @@ import (
 
 var (
 	hdrLocationKey = http.CanonicalHeaderKey("Location")
+	hdrAcceptKey   = http.CanonicalHeaderKey("Accept")
 )
 
 //‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
@@ -268,11 +269,6 @@ func handleUsersEndpoint(t *testing.T, w http.ResponseWriter, r *http.Request) {
 
 func createPostServer(t *testing.T) *httptest.Server {
 	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
-		t.Logf("Method: %v", r.Method)
-		t.Logf("Path: %v", r.URL.Path)
-		t.Logf("RawQuery: %v", r.URL.RawQuery)
-		t.Logf("Content-Type: %v", r.Header.Get(hdrContentTypeKey))
-
 		if r.Method == MethodPost {
 			handleLoginEndpoint(t, w, r)
 
@@ -356,18 +352,17 @@ func createPostServer(t *testing.T) *httptest.Server {
 
 func createFormPostServer(t *testing.T) *httptest.Server {
 	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
-		t.Logf("Method: %v", r.Method)
-		t.Logf("Path: %v", r.URL.Path)
-		t.Logf("Content-Type: %v", r.Header.Get(hdrContentTypeKey))
-
 		if r.Method == MethodPost {
 			_ = r.ParseMultipartForm(10e6)
 
 			if r.URL.Path == "/profile" {
-				t.Logf("FirstName: %v", r.FormValue("first_name"))
-				t.Logf("LastName: %v", r.FormValue("last_name"))
-				t.Logf("City: %v", r.FormValue("city"))
-				t.Logf("Zip Code: %v", r.FormValue("zip_code"))
+				if r.MultipartForm == nil {
+					values := r.Form
+					t.Log(values)
+				} else {
+					values := r.MultipartForm.Value
+					t.Log(values)
+				}
 
 				_, _ = w.Write([]byte("Success"))
 				return

--- a/stream.go
+++ b/stream.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	ErrContentDecompressorNotFound = errors.New("resty: content decoder not found")
+	ErrContentDecompresserNotFound = errors.New("resty: content decoder not found")
 )
 
 type (
@@ -26,13 +26,13 @@ type (
 	// ContentTypeDecoder type is for decoding the response body based on header Content-Type
 	ContentTypeDecoder func(io.Reader, any) error
 
-	// ContentDecompressor type is for decompressing response body based on header Content-Encoding
+	// ContentDecompresser type is for decompressing response body based on header Content-Encoding
 	// ([RFC 9110])
 	//
 	// For example, gzip, deflate, etc.
 	//
 	// [RFC 9110]: https://datatracker.ietf.org/doc/html/rfc9110
-	ContentDecompressor func(io.ReadCloser) (io.ReadCloser, error)
+	ContentDecompresser func(io.ReadCloser) (io.ReadCloser, error)
 )
 
 func encodeJSON(w io.Writer, v any) error {
@@ -203,7 +203,7 @@ type nopReadCloser struct {
 func (r *nopReadCloser) Read(p []byte) (int, error) {
 	n, err := r.r.Read(p)
 	if err == io.EOF {
-		r.r.Seek(0, 0)
+		r.r.Seek(0, io.SeekStart)
 	}
 	return n, err
 }


### PR DESCRIPTION
- correct digest roundtrip return value on error scenario
- streamline content-length value on buffer and partial io.Reader flow
- correct typo of ContentDecompressor -> ContentDecompressor
- refactor createHTTPRequest -> createRawRequest
- update c.log -> c.Logger()
- update redundant err check and if conditions
- address curl cmd non-execute request error flow
- prevent reset buffer during buffer copy on request clone
- improve test cases and corner coverage
- move benchmarks into a dedicated file
- update godoc