### PR TITLE
Fix off-by-one error in key/value resolution

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -57,7 +57,7 @@ func parseRequestURL(c *Client, r *Request) error {
 			buf := acquireBuffer()
 			defer releaseBuffer(buf)
 			// search for the next or first opened curly bracket
-			for curr := strings.Index(r.URL, "{"); curr == 0 || curr > prev; curr = prev + strings.Index(r.URL[prev:], "{") {
+			for curr := strings.Index(r.URL, "{"); curr == 0 || curr >= prev; curr = prev + strings.Index(r.URL[prev:], "{") {
 				// write everything from the previous position up to the current
 				if curr > prev {
 					buf.WriteString(r.URL[prev:curr])

--- a/request_test.go
+++ b/request_test.go
@@ -1827,10 +1827,11 @@ func TestGetPathParamAndPathParams(t *testing.T) {
 
 	c := dc().
 		SetBaseURL(ts.URL).
-		SetPathParam("userId", "sample@sample.com")
+		SetPathParam("userId", "sample@sample.com").
+		SetRawPathParam("details", "/details")
 
 	resp, err := c.R().SetPathParam("subAccountId", "100002").
-		Get("/v1/users/{userId}/{subAccountId}/details")
+		Get("/v1/users/{userId}/{subAccountId}{details}")
 
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())


### PR DESCRIPTION
Added a test to demonstrate the problem, which yielded this failure in test output: --- FAIL: TestGetPathParamAndPathParams (0.00s)
    resty_test.go:44: Method: GET
    resty_test.go:45: Path: /v1/users/sample@sample.com/100002{details}
    request_test.go:1838: Expected [true], got [false]
    request_test.go:1839: Expected [true], got [false]
    resty_test.go:900: Response Status: 200 OK
    resty_test.go:901: Response Time: 215.375µs
    resty_test.go:902: Response Headers: map[Content-Length:[85] Content-Type:[text/plain; charset=utf-8] Date:[Sat, 22 Feb 2025 01:31:45 GMT]]
    resty_test.go:903: Response Cookies: []
    resty_test.go:904: Response Body: TestPathParamURLInput: text response: /v1/users/sample@sample.com/100002%7Bdetails%7D

Once fix was applied, test passed.