### PR TITLE
[refactor] use AddEventListener check instead of OnMessage check

### DIFF
--- a/sse.go
+++ b/sse.go
@@ -343,8 +343,9 @@ func (es *EventSource) Get() error {
 	if isStringEmpty(es.url) {
 		return fmt.Errorf("resty:sse: event source URL is required")
 	}
-	if _, found := es.onEvent[defaultEventName]; !found {
-		return fmt.Errorf("resty:sse: OnMessage function is required")
+
+	if len(es.onEvent) == 0 {
+		return fmt.Errorf("resty:sse: At least one OnMessage/AddEventListener func is required")
 	}
 
 	// reset to begin

--- a/sse_test.go
+++ b/sse_test.go
@@ -339,7 +339,7 @@ func TestEventSourceCoverage(t *testing.T) {
 
 	es.SetURL("https://sse.dev/test")
 	err2 := es.Get()
-	assertEqual(t, "resty:sse: OnMessage function is required", err2.Error())
+	assertEqual(t, "resty:sse: At least one OnMessage/AddEventListener func is required", err2.Error())
 
 	es.OnMessage(func(a any) {}, nil)
 	es.SetURL("//res%20ty.dev")


### PR DESCRIPTION
Use "len(es.onEvent) == 0 " check instead of "if _, found := es.onEvent[defaultEventName]" check.

Sometimes the implementation of the sse server is not standard, and there is no event with the type of message.
In my opinion, users should be able to use it as long as they have added any eventListener.

Separated from PR https://github.com/go-resty/resty/pull/985 