### PR TITLE
fix: handle nil credentials before clone

### DIFF
--- a/client.go
+++ b/client.go
@@ -2193,7 +2193,11 @@ func (c *Client) Clone(ctx context.Context) *Client {
 	cc.formData = cloneURLValues(c.formData)
 	cc.header = c.header.Clone()
 	cc.pathParams = maps.Clone(c.pathParams)
-	cc.credentials = c.credentials.Clone()
+
+	if c.credentials != nil {
+		cc.credentials = c.credentials.Clone()
+	}
+
 	cc.contentTypeEncoders = maps.Clone(c.contentTypeEncoders)
 	cc.contentTypeDecoders = maps.Clone(c.contentTypeDecoders)
 	cc.contentDecompressers = maps.Clone(c.contentDecompressers)


### PR DESCRIPTION
can not clone parent client if not set credentials