### PR TITLE
Fix/missing content length header on empty post req

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -188,12 +188,12 @@ func parseRequestHeader(c *Client, r *Request) error {
 }
 
 func parseRequestBody(c *Client, r *Request) error {
-	// Go http library omits Content-Length if body is nil; use http.NoBody to force it when SetContentLength is true
-	if r.Body == nil && (c.setContentLength || r.setContentLength) {
-		r.Body = http.NoBody
-	}
-
 	if isPayloadSupported(r.Method, c.AllowGetMethodPayload) {
+		// Go http library omits Content-Length if body is nil; use http.NoBody to force it when SetContentLength is true
+		if (r.Body == nil && r.bodyBuf == nil) && (c.setContentLength || r.setContentLength) {
+			r.Body = http.NoBody
+		}
+
 		switch {
 		case r.isMultiPart: // Handling Multipart
 			if err := handleMultipart(c, r); err != nil {

--- a/middleware.go
+++ b/middleware.go
@@ -188,6 +188,11 @@ func parseRequestHeader(c *Client, r *Request) error {
 }
 
 func parseRequestBody(c *Client, r *Request) error {
+	// Go http library omits Content-Length if body is nil; use http.NoBody to force it when SetContentLength is true
+	if r.Body == nil && (c.setContentLength || r.setContentLength) {
+		r.Body = http.NoBody
+	}
+
 	if isPayloadSupported(r.Method, c.AllowGetMethodPayload) {
 		switch {
 		case r.isMultiPart: // Handling Multipart
@@ -315,6 +320,7 @@ func createCurlCmd(c *Client, r *Request) (err error) {
 		}
 		*r.resultCurlCmd = buildCurlRequest(r.RawRequest, c.httpClient.Jar)
 	}
+
 	return nil
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -189,11 +189,6 @@ func parseRequestHeader(c *Client, r *Request) error {
 
 func parseRequestBody(c *Client, r *Request) error {
 	if isPayloadSupported(r.Method, c.AllowGetMethodPayload) {
-		// Go http library omits Content-Length if body is nil; use http.NoBody to force it when SetContentLength is true
-		if (r.Body == nil && r.bodyBuf == nil) && (c.setContentLength || r.setContentLength) {
-			r.Body = http.NoBody
-		}
-
 		switch {
 		case r.isMultiPart: // Handling Multipart
 			if err := handleMultipart(c, r); err != nil {
@@ -201,6 +196,10 @@ func parseRequestBody(c *Client, r *Request) error {
 			}
 		case len(c.FormData) > 0 || len(r.FormData) > 0: // Handling Form Data
 			handleFormData(c, r)
+		case r.Body == nil && r.bodyBuf == nil: // Handling Request body when nil body
+			// Go http library omits Content-Length if body is nil; use http.NoBody to force it if SetContentLength is true
+			r.Body = http.NoBody
+			fallthrough
 		case r.Body != nil: // Handling Request body
 			handleContentType(c, r)
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -513,6 +513,7 @@ func Test_parseRequestBody(t *testing.T) {
 				r.SetContentLength(true)
 			},
 			expectedContentLength: "0",
+			expectedBodyBuf:       []byte{},
 		},
 		{
 			name: "empty body with SetContentLength by client",
@@ -520,6 +521,7 @@ func Test_parseRequestBody(t *testing.T) {
 				c.SetContentLength(true)
 			},
 			expectedContentLength: "0",
+			expectedBodyBuf:       []byte{},
 		},
 		{
 			name: "string body",

--- a/request_test.go
+++ b/request_test.go
@@ -2282,3 +2282,27 @@ func TestRequestGH917(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestSetContentLengthTrueWithNilBody(t *testing.T) {
+	ts := createPostServer(t)
+	defer ts.Close()
+
+	c := dc()
+
+	c.OnBeforeRequest(func(client *Client, request *Request) error {
+		request.
+			SetBody(nil).
+			SetContentLength(true)
+
+		return nil
+	})
+
+	c = c.SetBaseURL(ts.URL)
+
+	resp, err := c.R().Execute("POST", "/check-request-content-length")
+
+	assertNil(t, err)
+
+	// when body is nil and SetContentLength is true expect Content-Length == "0"
+	assertEqual(t, "0", resp.Header().Get("Request-Content-Length"))
+}

--- a/resty_test.go
+++ b/resty_test.go
@@ -326,6 +326,10 @@ func createPostServer(t *testing.T) *httptest.Server {
 				}
 				http.SetCookie(w, &cookie)
 				w.WriteHeader(http.StatusOK)
+			case "/check-request-content-length":
+				// test endpoint for checking the server receives the correct Content-Length Header from a request
+				w.Header().Add("Request-Content-Length", r.Header.Get("Content-Length"))
+				w.WriteHeader(http.StatusOK)
 			}
 		}
 	})


### PR DESCRIPTION
This change aims to resolve issue #996 by changing requests that contain nil body to http.NoBody when they have also specified to "SetContentLength" as true. 

Validity as to whether to merge this or not depends on multiple factors.

1. The root issue as to why Content-Length was ommitted when requests were created with a nil body ultimately originates from within the go http standard library. The library explicitly states that Content-Length will be omitted when body is nil unless Transfer-Encoding header is explicitly set to "identity". Where exactly does this happen in the http library? I have no idea, despite trying to find it. However I have found similar issues that reference to this: https://github.com/golang/go/issues/40978.

Setting the bodyBuf value to http.NoBody signals to the http library when creating the request that the body is no longer nil and a Content-Length header component can be created for the request.

3. Considering this is a feature, albeit a poorly documented one in the standard http library it does seem to be behaving as intended?

4. In resty setting SetContentLength(true) and r.Body = nil, could be considered as the user intentionally overriding this requirement to force the Content-Length header on whilst passing in a nil body.

Ultimately, either the intention of the http libraries functionality should be obeyed or we should consider this unique resty request setting combination as an intentional force override to achieve a valid Content-Length header with a nil body.

Additional Notes:

I have had to update middleware_test.go:Test_parseRequestBody() for the reason being that now that nil body + SetContentLength(true) is supported in this PR change this now results in the expectedBodyBuf value to change since in this scenario the bodyBuf changes to http.NoBody.