### PR TITLE
feat(enhancement): change retry duration from seconds to milliseconds in SSE (#1010)

### DIFF
--- a/sse.go
+++ b/sse.go
@@ -558,7 +558,7 @@ func (es *EventSource) listenStream(res *http.Response) error {
 		if len(ed.Retry) > 0 {
 			if retry, err := strconv.Atoi(string(ed.Retry)); err == nil {
 				es.lock.Lock()
-				es.serverSentRetry = time.Second * time.Duration(retry)
+				es.serverSentRetry = time.Millisecond * time.Duration(retry)
 				es.lock.Unlock()
 			} else {
 				es.triggerOnError(err)


### PR DESCRIPTION
Change the retry duration from seconds to milliseconds for proper handling of client-specified retry intervals. This ensures compatibility with standard SSE behavior and prevents potential timeout issues.
- https://html.spec.whatwg.org/multipage/server-sent-events.html#concept-event-stream-reconnection-time
- https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#retry