### PR TITLE
fix(circuit breaker): protect access to lastFailureAt by atomic operations to avoid race conditions

### DIFF
--- a/circuit_breaker.go
+++ b/circuit_breaker.go
@@ -31,7 +31,7 @@ type CircuitBreaker struct {
 	state            atomic.Value // circuitBreakerState
 	failureCount     atomic.Uint32
 	successCount     atomic.Uint32
-	openStartAt      atomic.Value // time.Time
+	lastFailureAt    atomic.Value // time.Time
 }
 
 // NewCircuitBreaker method creates a new [CircuitBreaker] with default settings.
@@ -134,7 +134,7 @@ func (cb *CircuitBreaker) applyPolicies(resp *http.Response) {
 	}
 
 	if failed {
-		if cb.failureCount.Load() > 0 && time.Since(cb.openStartAt.Load().(time.Time)) > cb.timeout {
+		if cb.failureCount.Load() > 0 && time.Since(cb.lastFailureAt.Load().(time.Time)) > cb.timeout {
 			cb.failureCount.Store(0)
 		}
 
@@ -144,14 +144,10 @@ func (cb *CircuitBreaker) applyPolicies(resp *http.Response) {
 			if failCount >= cb.failureThreshold {
 				cb.open()
 			} else {
-				cb.openStartAt.Store(time.Now())
+				cb.lastFailureAt.Store(time.Now())
 			}
 		case circuitBreakerStateHalfOpen:
 			cb.open()
-		case circuitBreakerStateOpen:
-			if time.Since(cb.openStartAt.Load().(time.Time)) >= cb.timeout {
-				cb.changeState(circuitBreakerStateHalfOpen)
-			}
 		}
 	} else {
 		switch cb.getState() {
@@ -162,17 +158,16 @@ func (cb *CircuitBreaker) applyPolicies(resp *http.Response) {
 			if successCount >= cb.successThreshold {
 				cb.changeState(circuitBreakerStateClosed)
 			}
-		case circuitBreakerStateOpen:
-			if time.Since(cb.openStartAt.Load().(time.Time)) >= cb.timeout {
-				cb.changeState(circuitBreakerStateHalfOpen)
-			}
 		}
 	}
 }
 
 func (cb *CircuitBreaker) open() {
 	cb.changeState(circuitBreakerStateOpen)
-	cb.openStartAt.Store(time.Now())
+	go func() {
+		time.Sleep(cb.timeout)
+		cb.changeState(circuitBreakerStateHalfOpen)
+	}()
 }
 
 func (cb *CircuitBreaker) changeState(state circuitBreakerState) {

--- a/circuit_breaker.go
+++ b/circuit_breaker.go
@@ -31,7 +31,7 @@ type CircuitBreaker struct {
 	state            atomic.Value // circuitBreakerState
 	failureCount     atomic.Uint32
 	successCount     atomic.Uint32
-	lastFailureAt    atomic.Value // time.Time
+	openStartAt      atomic.Value // time.Time
 }
 
 // NewCircuitBreaker method creates a new [CircuitBreaker] with default settings.
@@ -134,7 +134,7 @@ func (cb *CircuitBreaker) applyPolicies(resp *http.Response) {
 	}
 
 	if failed {
-		if cb.failureCount.Load() > 0 && time.Since(cb.lastFailureAt.Load().(time.Time)) > cb.timeout {
+		if cb.failureCount.Load() > 0 && time.Since(cb.openStartAt.Load().(time.Time)) > cb.timeout {
 			cb.failureCount.Store(0)
 		}
 
@@ -144,10 +144,14 @@ func (cb *CircuitBreaker) applyPolicies(resp *http.Response) {
 			if failCount >= cb.failureThreshold {
 				cb.open()
 			} else {
-				cb.lastFailureAt.Store(time.Now())
+				cb.openStartAt.Store(time.Now())
 			}
 		case circuitBreakerStateHalfOpen:
 			cb.open()
+		case circuitBreakerStateOpen:
+			if time.Since(cb.openStartAt.Load().(time.Time)) >= cb.timeout {
+				cb.changeState(circuitBreakerStateHalfOpen)
+			}
 		}
 	} else {
 		switch cb.getState() {
@@ -158,16 +162,17 @@ func (cb *CircuitBreaker) applyPolicies(resp *http.Response) {
 			if successCount >= cb.successThreshold {
 				cb.changeState(circuitBreakerStateClosed)
 			}
+		case circuitBreakerStateOpen:
+			if time.Since(cb.openStartAt.Load().(time.Time)) >= cb.timeout {
+				cb.changeState(circuitBreakerStateHalfOpen)
+			}
 		}
 	}
 }
 
 func (cb *CircuitBreaker) open() {
 	cb.changeState(circuitBreakerStateOpen)
-	go func() {
-		time.Sleep(cb.timeout)
-		cb.changeState(circuitBreakerStateHalfOpen)
-	}()
+	cb.openStartAt.Store(time.Now())
 }
 
 func (cb *CircuitBreaker) changeState(state circuitBreakerState) {

--- a/client.go
+++ b/client.go
@@ -2240,8 +2240,10 @@ func (c *Client) executeRequestMiddlewares(req *Request) (err error) {
 // Executes method executes the given `Request` object and returns
 // response or error.
 func (c *Client) execute(req *Request) (*Response, error) {
-	if err := c.circuitBreaker.allow(); err != nil {
-		return nil, err
+	if c.circuitBreaker != nil {
+		if err := c.circuitBreaker.allow(); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := c.executeRequestMiddlewares(req); err != nil {
@@ -2268,7 +2270,9 @@ func (c *Client) execute(req *Request) (*Response, error) {
 		}
 	}
 	if resp != nil {
-		c.circuitBreaker.applyPolicies(resp)
+		if c.circuitBreaker != nil {
+			c.circuitBreaker.applyPolicies(resp)
+		}
 
 		response.Body = resp.Body
 		if err = response.wrapContentDecompresser(); err != nil {


### PR DESCRIPTION
-  Remove unnecessary nil checks for the receiver. it is the caller's responsibility to ensure that  circuit breaker  is not nil.
