### PR TITLE
fix: Cookie Clone Issue in Client.Clone()

### DIFF
--- a/client.go
+++ b/client.go
@@ -2208,7 +2208,7 @@ func (c *Client) Clone(ctx context.Context) *Client {
 	}
 	// clone cookies
 	if l := len(c.cookies); l > 0 {
-		cc.cookies = make([]*http.Cookie, l)
+		cc.cookies = make([]*http.Cookie, 0, l)
 		for _, cookie := range c.cookies {
 			cc.cookies = append(cc.cookies, cloneCookie(cookie))
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -1348,6 +1348,15 @@ func TestClientClone(t *testing.T) {
 
 	// assert interface/pointer type
 	assertEqual(t, parent.Client(), clone.Client())
+
+	// assert cookies
+	parentCookies := parent.Cookies()
+	cloneCookies := clone.Cookies()
+	assertEqual(t, len(parentCookies), len(cloneCookies))
+	for i := range parentCookies {
+		assertEqual(t, parentCookies[i].Name, cloneCookies[i].Name)
+		assertEqual(t, parentCookies[i].Value, cloneCookies[i].Value)
+	}
 }
 
 func TestResponseBodyLimit(t *testing.T) {


### PR DESCRIPTION
## Problem
There is a critical bug in the cookie cloning logic of Client.Clone() . The current implementation:

```Go
cc.cookies = make([]*http.Cookie, l)
for _, cookie := range c.cookies {
    cc.cookies = append(cc.cookies, cloneCookie(cookie))
}
```

This creates two issues:

1. The initial make([]*http.Cookie, l) creates a slice with l nil elements
2. append then adds the actual cookies after these nil elements

**Result**: A slice with 2l length where:

- First l elements are nil
- Last l elements are the actual cookies

![image](https://github.com/user-attachments/assets/dadc2a38-9859-4a4e-9562-b4cc2de3a6a4)


## Panic Example
The following code will trigger a panic:
```Go
resty.New().SetCookie(&http.Cookie{
  Name:  "k",
  Value: "v",
 }).Clone(context.Background()).R().Get("about:blank")
```

This happens because operations like `AddCookie` may attempt to access the nil cookies, leading to a panic.


## Changes Made
- Fixed cookie cloning in Client.Clone() method
- Added test cases to verify cookie cloning behavior
## Test Coverage
Added new test assertions in TestClientClone to verify:

- Cookie length equality between parent and clone
- Cookie name and value equality for each cookie
## Impact
This fix ensures that when a client is cloned, all cookies are properly copied to the new instance, maintaining the exact same cookie state as the parent client.

## Testing
All existing tests pass, and new test cases have been added to verify the fix.