### PR TITLE
fix: negative trace substraction when using SetTimeout

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -1927,6 +1927,28 @@ func TestTraceInfoOnTimeout(t *testing.T) {
 	assertEqual(t, true, tr.TotalTime == resp.Duration())
 }
 
+func TestTraceInfoOnTimeoutWithSetTimeout(t *testing.T) {
+	client := New().
+		SetTimeout(1 * time.Millisecond).
+		SetBaseURL("http://resty-nowhere.local").
+		EnableTrace()
+
+	resp, err := client.R().Get("/")
+	assertNotNil(t, err)
+	assertNotNil(t, resp)
+
+	tr := resp.Request.TraceInfo()
+
+	assertEqual(t, true, tr.DNSLookup == 0)
+	assertEqual(t, true, tr.ConnTime == 0)
+	assertEqual(t, true, tr.TLSHandshake == 0)
+	assertEqual(t, true, tr.TCPConnTime == 0)
+	assertEqual(t, true, tr.ServerTime == 0)
+	assertEqual(t, true, tr.ResponseTime == 0)
+	assertEqual(t, true, tr.TotalTime > 0)
+	assertEqual(t, true, tr.TotalTime == resp.Duration())
+}
+
 func TestDebugLoggerRequestBodyTooLarge(t *testing.T) {
 	formTs := createFormPostServer(t)
 	defer formTs.Close()

--- a/request_test.go
+++ b/request_test.go
@@ -1928,25 +1928,52 @@ func TestTraceInfoOnTimeout(t *testing.T) {
 }
 
 func TestTraceInfoOnTimeoutWithSetTimeout(t *testing.T) {
-	client := New().
-		SetTimeout(1 * time.Millisecond).
-		SetBaseURL("http://resty-nowhere.local").
-		EnableTrace()
+	t.Run("timeout with very short timeout", func(t *testing.T) {
+		client := New().
+			SetTimeout(1 * time.Millisecond).
+			SetBaseURL("http://resty-nowhere.local").
+			EnableTrace()
 
-	resp, err := client.R().Get("/")
-	assertNotNil(t, err)
-	assertNotNil(t, resp)
+		resp, err := client.R().Get("/")
+		assertNotNil(t, err)
+		assertNotNil(t, resp)
 
-	tr := resp.Request.TraceInfo()
+		tr := resp.Request.TraceInfo()
 
-	assertEqual(t, true, tr.DNSLookup == 0)
-	assertEqual(t, true, tr.ConnTime == 0)
-	assertEqual(t, true, tr.TLSHandshake == 0)
-	assertEqual(t, true, tr.TCPConnTime == 0)
-	assertEqual(t, true, tr.ServerTime == 0)
-	assertEqual(t, true, tr.ResponseTime == 0)
-	assertEqual(t, true, tr.TotalTime > 0)
-	assertEqual(t, true, tr.TotalTime == resp.Duration())
+		assertEqual(t, true, tr.DNSLookup == 0)
+		assertEqual(t, true, tr.ConnTime == 0)
+		assertEqual(t, true, tr.TLSHandshake == 0)
+		assertEqual(t, true, tr.TCPConnTime == 0)
+		assertEqual(t, true, tr.ServerTime == 0)
+		assertEqual(t, true, tr.ResponseTime == 0)
+		assertEqual(t, true, tr.TotalTime > 0)
+		assertEqual(t, true, tr.TotalTime == resp.Duration())
+	})
+
+	t.Run("successful request with SetTimeout", func(t *testing.T) {
+		ts := createGetServer(t)
+		defer ts.Close()
+
+		client := New().
+			SetTimeout(5 * time.Second).
+			SetBaseURL(ts.URL).
+			EnableTrace()
+
+		resp, err := client.R().Get("/")
+		assertNil(t, err)
+		assertNotNil(t, resp)
+
+		tr := resp.Request.TraceInfo()
+
+		assertEqual(t, true, tr.DNSLookup >= 0)
+		assertEqual(t, true, tr.ConnTime >= 0)
+		assertEqual(t, true, tr.TLSHandshake >= 0)
+		assertEqual(t, true, tr.TCPConnTime >= 0)
+		assertEqual(t, true, tr.ServerTime >= 0)
+		assertEqual(t, true, tr.ResponseTime >= 0)
+		assertEqual(t, true, tr.TotalTime > 0)
+		assertEqual(t, true, tr.TotalTime == resp.Duration())
+	})
 }
 
 func TestDebugLoggerRequestBodyTooLarge(t *testing.T) {

--- a/trace.go
+++ b/trace.go
@@ -10,6 +10,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http/httptrace"
+	"sync"
 	"time"
 )
 
@@ -95,6 +96,7 @@ func (ti TraceInfo) Clone() *TraceInfo {
 // with the same naming for easy understanding. Plus additional insights
 // [Request].
 type clientTrace struct {
+	lock                 sync.RWMutex
 	getConn              time.Time
 	dnsStart             time.Time
 	dnsDone              time.Time
@@ -112,37 +114,55 @@ func (t *clientTrace) createContext(ctx context.Context) context.Context {
 		ctx,
 		&httptrace.ClientTrace{
 			DNSStart: func(_ httptrace.DNSStartInfo) {
+				t.lock.Lock()
 				t.dnsStart = time.Now()
+				t.lock.Unlock()
 			},
 			DNSDone: func(_ httptrace.DNSDoneInfo) {
+				t.lock.Lock()
 				t.dnsDone = time.Now()
+				t.lock.Unlock()
 			},
 			ConnectStart: func(_, _ string) {
+				t.lock.Lock()
 				if t.dnsDone.IsZero() {
 					t.dnsDone = time.Now()
 				}
 				if t.dnsStart.IsZero() {
 					t.dnsStart = t.dnsDone
 				}
+				t.lock.Unlock()
 			},
 			ConnectDone: func(net, addr string, err error) {
+				t.lock.Lock()
 				t.connectDone = time.Now()
+				t.lock.Unlock()
 			},
 			GetConn: func(_ string) {
+				t.lock.Lock()
 				t.getConn = time.Now()
+				t.lock.Unlock()
 			},
 			GotConn: func(ci httptrace.GotConnInfo) {
+				t.lock.Lock()
 				t.gotConn = time.Now()
 				t.gotConnInfo = ci
+				t.lock.Unlock()
 			},
 			GotFirstResponseByte: func() {
+				t.lock.Lock()
 				t.gotFirstResponseByte = time.Now()
+				t.lock.Unlock()
 			},
 			TLSHandshakeStart: func() {
+				t.lock.Lock()
 				t.tlsHandshakeStart = time.Now()
+				t.lock.Unlock()
 			},
 			TLSHandshakeDone: func(_ tls.ConnectionState, _ error) {
+				t.lock.Lock()
 				t.tlsHandshakeDone = time.Now()
+				t.lock.Unlock()
 			},
 		},
 	)


### PR DESCRIPTION
In certain cases when using [client](https://pkg.go.dev/resty.dev/v3#Client.SetTimeout) or [request](https://pkg.go.dev/resty.dev/v3#Request.SetTimeout) SetTimeout it is possible that some trace value like `dnsDone`, `tlsHandshakeDone` or `gotConn` are zero, resulting in inaccurate results:

![Screenshot From 2025-06-18 01-19-03](https://github.com/user-attachments/assets/7f07dbb9-2238-4b50-bd4c-c3c5849b7a1d)
![Screenshot From 2025-06-18 01-18-54](https://github.com/user-attachments/assets/bbc1c454-eb2e-45a3-8f11-14e419053ab8)
![Screenshot From 2025-06-18 01-18-12](https://github.com/user-attachments/assets/37618557-0d7f-43dd-93bf-b911fca8597c)

This PR add additional checks in the `TraceInfo` method to avoid negative values.

I'm not sure how to improve the tests for this, as aborting requests with SetTimeout will not always accurately stop the execution at the exact same point. I'm open to ideas.