### PR TITLE
SSE: add HTTP resopnse header to EventOpenFunc

### DIFF
--- a/sse.go
+++ b/sse.go
@@ -40,7 +40,7 @@ type (
 	// EventOpenFunc is a callback function type used to receive notification
 	// when Resty establishes a connection with the server for the
 	// Server-Sent Events(SSE)
-	EventOpenFunc func(url string)
+	EventOpenFunc func(url string, header http.Header)
 
 	// EventMessageFunc is a callback function type used to receive event details
 	// from the Server-Sent Events(SSE) stream
@@ -385,7 +385,7 @@ func (es *EventSource) Get() error {
 		if err != nil {
 			return err
 		}
-		es.triggerOnOpen()
+		es.triggerOnOpen(res)
 		if err := es.listenStream(res); err != nil {
 			return err
 		}
@@ -411,11 +411,11 @@ func (es *EventSource) isClosed() bool {
 	return es.closed
 }
 
-func (es *EventSource) triggerOnOpen() {
+func (es *EventSource) triggerOnOpen(res *http.Response) {
 	es.lock.RLock()
 	defer es.lock.RUnlock()
 	if es.onOpen != nil {
-		es.onOpen(strings.Clone(es.url))
+		es.onOpen(strings.Clone(es.url), res.Header)
 	}
 }
 

--- a/sse_test.go
+++ b/sse_test.go
@@ -166,8 +166,8 @@ func TestEventSourceOverwriteFuncs(t *testing.T) {
 
 	es.SetURL(ts.URL).
 		OnMessage(messageFunc2, nil).
-		OnOpen(func(url string) {
-			t.Log("from overwrite func", url)
+		OnOpen(func(url string, header http.Header) {
+			t.Log("from overwrite func", url, header)
 		}).
 		OnError(func(err error) {
 			t.Log("from overwrite func", err)
@@ -376,7 +376,7 @@ func createEventSource(t *testing.T, url string, fn EventMessageFunc, rt any) *E
 		SetRetryMaxWaitTime(1000 * time.Millisecond).
 		SetMaxBufSize(1 << 14). // 16kb
 		SetLogger(createLogger()).
-		OnOpen(func(url string) {
+		OnOpen(func(url string, header http.Header) {
 			t.Log("I'm connected:", url)
 		}).
 		OnError(func(err error) {


### PR DESCRIPTION
PR for: https://github.com/go-resty/resty/issues/1060