### PR TITLE
test: add digest auth post body content check in the test case #1009

### DIFF
--- a/digest_test.go
+++ b/digest_test.go
@@ -111,8 +111,12 @@ func TestClientDigestAuthWithBody(t *testing.T) {
 		SetBody(map[string]any{"zip_code": "00000", "city": "Los Angeles"}).
 		Post(ts.URL + conf.uri)
 
+	resObj := resp.Result().(*AuthSuccess)
+
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
+	assertEqual(t, resObj.ID, "success")
+	assertEqual(t, resObj.Message, "login successful")
 }
 
 func TestClientDigestAuthWithBodyQopAuthInt(t *testing.T) {

--- a/resty_test.go
+++ b/resty_test.go
@@ -804,7 +804,8 @@ func createDigestServer(t *testing.T, conf *digestServerConfig) *httptest.Server
 
 		if authorizationHeaderValid(t, r, conf) {
 			if r.URL.Path == "/dir/index.html" && r.Method == MethodPost {
-				body, _ := io.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
+				assertNil(t, err)
 				assertEqual(t, `{"city":"Los Angeles","zip_code":"00000"}`, strings.TrimSpace(string(body)))
 			}
 
@@ -878,6 +879,7 @@ func authorizationHeaderValid(t *testing.T, r *http.Request, conf *digestServerC
 	// auth-int scenario
 	body, err := io.ReadAll(r.Body)
 	r.Body.Close()
+	r.Body = io.NopCloser(bytes.NewReader(body))
 	assertError(t, err)
 	bodyHash := ""
 	if len(body) > 0 {

--- a/resty_test.go
+++ b/resty_test.go
@@ -803,6 +803,11 @@ func createDigestServer(t *testing.T, conf *digestServerConfig) *httptest.Server
 		w.Header().Set(hdrContentTypeKey, "application/json; charset=utf-8")
 
 		if authorizationHeaderValid(t, r, conf) {
+			if r.URL.Path == "/dir/index.html" && r.Method == MethodPost {
+				body, _ := io.ReadAll(r.Body)
+				assertEqual(t, `{"city":"Los Angeles","zip_code":"00000"}`, strings.TrimSpace(string(body)))
+			}
+
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{ "id": "success", "message": "login successful" }`))
 		} else {


### PR DESCRIPTION
For the #1009 issue, I’ve analyzed and added a post body content check to the existing test case to validate the reported issue. The functionality works as expected.

close #1009