### PR TITLE
refactor(enhancement): streamline error function names and fields #1062

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1038,7 +1038,7 @@ func TestNewWithLocalAddr(t *testing.T) {
 	assertEqual(t, "TestGet: text response", resp.String())
 }
 
-func TestClientOnResponseError(t *testing.T) {
+func TestClientOnResponseFailure(t *testing.T) {
 	tests := []struct {
 		name        string
 		setup       func(*Client)
@@ -1050,13 +1050,13 @@ func TestClientOnResponseError(t *testing.T) {
 			name: "successful_request",
 		},
 		{
-			name: "http_status_error",
+			name: "http_status_failure",
 			setup: func(client *Client) {
 				client.SetAuthToken("BAD")
 			},
 		},
 		{
-			name: "before_request_error",
+			name: "before_request_failure",
 			setup: func(client *Client) {
 				client.AddRequestMiddleware(func(client *Client, request *Request) error {
 					return fmt.Errorf("before request")
@@ -1065,7 +1065,7 @@ func TestClientOnResponseError(t *testing.T) {
 			isError: true,
 		},
 		{
-			name: "before_request_error_retry",
+			name: "before_request_failure_retry",
 			setup: func(client *Client) {
 				client.SetRetryCount(3).AddRequestMiddleware(func(client *Client, request *Request) error {
 					return fmt.Errorf("before request")
@@ -1074,7 +1074,7 @@ func TestClientOnResponseError(t *testing.T) {
 			isError: true,
 		},
 		{
-			name: "after_response_error",
+			name: "after_response_failure",
 			setup: func(client *Client) {
 				client.AddResponseMiddleware(func(client *Client, response *Response) error {
 					return fmt.Errorf("after response")
@@ -1084,7 +1084,7 @@ func TestClientOnResponseError(t *testing.T) {
 			hasResponse: true,
 		},
 		{
-			name: "after_response_error_retry",
+			name: "after_response_failure_retry",
 			setup: func(client *Client) {
 				client.SetRetryCount(3).AddResponseMiddleware(func(client *Client, response *Response) error {
 					return fmt.Errorf("after response")
@@ -1152,7 +1152,7 @@ func TestClientOnResponseError(t *testing.T) {
 					if err != nil {
 						return true
 					}
-					return response.IsError()
+					return response.IsStatusFailure()
 				}).
 				OnError(func(r *Request, err error) {
 					assertErrorHook(r, err)

--- a/request.go
+++ b/request.go
@@ -398,9 +398,9 @@ func (r *Request) SetBody(body any) *Request {
 	return r
 }
 
-// SetResult method is to register the response `Result` object for automatic
+// SetResult method registers the response `Result` object type for automatic
 // unmarshalling of the HTTP response if the response status code is
-// between 200 and 299, and the content type is JSON or XML.
+// between 200 and 299, and the content type is either JSON or XML.
 //
 // Note: [Request.SetResult] input can be a pointer or non-pointer.
 //
@@ -427,21 +427,23 @@ func (r *Request) SetResult(v any) *Request {
 	return r
 }
 
-// SetError method is to register the request `Error` object for automatic unmarshalling for the request,
-// if the response status code is greater than 399 and the content type is either JSON or XML.
+// SetResultError method registers the response `ResultError` object type for automatic
+// unmarshalling for the request, if the response status code is greater than 399 and
+// the content type is either JSON or XML.
 //
-// NOTE: [Request.SetError] input can be a pointer or non-pointer.
+// NOTE: [Request.SetResultError] input can be a pointer or non-pointer.
 //
-//	client.R().SetError(&AuthError{})
+//	client.R().SetResultError(&AuthError{})
 //	// OR
-//	client.R().SetError(AuthError{})
+//	client.R().SetResultError(AuthError{})
 //
-// Accessing an error value from response instance.
+// Accessing an unmarshalled error object from response instance.
 //
-//	response.Error().(*AuthError)
+//	response.ResultError().(*AuthError)
 //
-// If this request Error object is nil, Resty will use the client-level error object Type if it is set.
-func (r *Request) SetError(err any) *Request {
+// If this request ResultError object is nil, it will use the client-level error object
+// type if it is set.
+func (r *Request) SetResultError(err any) *Request {
 	r.Error = getPointer(err)
 	return r
 }

--- a/request_test.go
+++ b/request_test.go
@@ -281,17 +281,17 @@ func TestPostJSONStructInvalidLogin(t *testing.T) {
 	resp, err := c.R().
 		SetHeader(hdrContentTypeKey, "application/json; charset=utf-8").
 		SetBody(credentials{Username: "testuser", Password: "testpass1"}).
-		SetError(AuthError{}).
+		SetResultError(AuthError{}).
 		SetJSONEscapeHTML(false).
 		Post(ts.URL + "/login")
 
 	assertError(t, err)
 	assertEqual(t, http.StatusUnauthorized, resp.StatusCode())
 
-	authError := resp.Error().(*AuthError)
+	authError := resp.ResultError().(*AuthError)
 	assertEqual(t, "unauthorized", authError.ID)
 	assertEqual(t, "Invalid credentials", authError.Message)
-	t.Logf("Result Error: %q", resp.Error().(*AuthError))
+	t.Logf("Result Error: %q", resp.ResultError().(*AuthError))
 
 	logResponse(t, resp)
 }
@@ -304,16 +304,16 @@ func TestPostJSONErrorRFC7807(t *testing.T) {
 	resp, err := c.R().
 		SetHeader(hdrContentTypeKey, "application/json; charset=utf-8").
 		SetBody(credentials{Username: "testuser", Password: "testpass1"}).
-		SetError(AuthError{}).
+		SetResultError(AuthError{}).
 		Post(ts.URL + "/login?ct=problem")
 
 	assertError(t, err)
 	assertEqual(t, http.StatusUnauthorized, resp.StatusCode())
 
-	authError := resp.Error().(*AuthError)
+	authError := resp.ResultError().(*AuthError)
 	assertEqual(t, "unauthorized", authError.ID)
 	assertEqual(t, "Invalid credentials", authError.Message)
-	t.Logf("Result Error: %q", resp.Error().(*AuthError))
+	t.Logf("Result Error: %q", resp.ResultError().(*AuthError))
 
 	logResponse(t, resp)
 }
@@ -513,7 +513,7 @@ func TestPostXMLStructInvalidLogin(t *testing.T) {
 	defer ts.Close()
 
 	c := dcnl()
-	c.SetError(&AuthError{})
+	c.SetResultError(&AuthError{})
 
 	resp, err := c.R().
 		SetHeader(hdrContentTypeKey, "application/xml").
@@ -524,7 +524,7 @@ func TestPostXMLStructInvalidLogin(t *testing.T) {
 	assertEqual(t, http.StatusUnauthorized, resp.StatusCode())
 	assertEqual(t, resp.Header().Get("Www-Authenticate"), "Protected Realm")
 
-	t.Logf("Result Error: %q", resp.Error().(*AuthError))
+	t.Logf("Result Error: %q", resp.ResultError().(*AuthError))
 
 	logResponse(t, resp)
 }
@@ -633,7 +633,7 @@ func TestRequestBasicAuthFail(t *testing.T) {
 
 	c := dcnl()
 	c.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}).
-		SetError(AuthError{})
+		SetResultError(AuthError{})
 
 	resp, err := c.R().
 		SetBasicAuth("myuser", "basicauth1").
@@ -642,7 +642,7 @@ func TestRequestBasicAuthFail(t *testing.T) {
 	assertError(t, err)
 	assertEqual(t, http.StatusUnauthorized, resp.StatusCode())
 
-	t.Logf("Result Error: %q", resp.Error().(*AuthError))
+	t.Logf("Result Error: %q", resp.ResultError().(*AuthError))
 	logResponse(t, resp)
 }
 
@@ -1700,7 +1700,7 @@ func TestNotFoundWithError(t *testing.T) {
 
 	resp, err := dcnl().R().
 		SetHeader(hdrContentTypeKey, "application/json").
-		SetError(&httpError).
+		SetResultError(&httpError).
 		Get(ts.URL + "/not-found-with-error")
 
 	assertError(t, err)
@@ -1720,7 +1720,7 @@ func TestNotFoundWithoutError(t *testing.T) {
 
 	c := dcnl().outputLogTo(os.Stdout)
 	resp, err := c.R().
-		SetError(&httpError).
+		SetResultError(&httpError).
 		SetHeader(hdrContentTypeKey, "application/json").
 		Get(ts.URL + "/not-found-no-error")
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -509,10 +509,10 @@ func TestClientRetryErrorRecover(t *testing.T) {
 
 	c := dcnl().
 		SetRetryCount(2).
-		SetError(AuthError{}).
+		SetResultError(AuthError{}).
 		AddRetryConditions(
 			func(r *Response, _ error) bool {
-				err, ok := r.Error().(*AuthError)
+				err, ok := r.ResultError().(*AuthError)
 				retry := ok && r.StatusCode() == 429 && err.Message == "too many"
 				return retry
 			},
@@ -531,7 +531,7 @@ func TestClientRetryErrorRecover(t *testing.T) {
 	assertEqual(t, http.StatusOK, resp.StatusCode())
 	assertEqual(t, "hello", authSuccess.Message)
 
-	assertNil(t, resp.Error())
+	assertNil(t, resp.ResultError())
 }
 
 func TestClientRetryCountWithTimeout(t *testing.T) {
@@ -582,7 +582,7 @@ func TestClientRetryTooManyRequestsAndRecover(t *testing.T) {
 	assertEqual(t, http.StatusOK, resp.StatusCode())
 	assertEqual(t, "hello", authSuccess.Message)
 
-	assertNil(t, resp.Error())
+	assertNil(t, resp.ResultError())
 }
 
 func TestClientRetryHookWithTimeout(t *testing.T) {
@@ -771,7 +771,7 @@ func TestRequestRetryTooManyRequestsHeaderRetryAfter(t *testing.T) {
 	assertEqual(t, http.StatusOK, resp.StatusCode())
 	assertEqual(t, "hello", authSuccess.Message)
 
-	assertNil(t, resp.Error())
+	assertNil(t, resp.ResultError())
 }
 
 func TestRetryDefaultConditions(t *testing.T) {


### PR DESCRIPTION
The following method names are streamlined; next is documentation work:

```go
Client.SetError 	-> Client.SetResultError
Request.SetError 	-> Request.SetResultError
Response.IsSuccess 	-> Response.IsStatusSuccess
Response.IsError 	-> Response.IsStatusFailure
Response.Err 		-> Response.CascadeError
```

close #1062 