### PR TITLE
Add support for `SetXXXAny` methods for  headers, query parameters, and path parameters.

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 )
 
 func Benchmark_parseRequestURL_PathParams(b *testing.B) {
@@ -200,5 +201,152 @@ func Benchmark_parseRequestBody_MultiPart(b *testing.B) {
 		if err := parseRequestBody(c, r); err != nil {
 			b.Errorf("parseRequestBody() error = %v", err)
 		}
+	}
+}
+
+// benchmarkStringer implements fmt.Stringer for benchmarking
+type benchmarkStringer struct {
+	value string
+}
+
+func (s benchmarkStringer) String() string {
+	return s.value
+}
+
+// Tier 1: most common URL types
+func Benchmark_formatAnyToString_string(b *testing.B) {
+	v := "hello world"
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+func Benchmark_formatAnyToString_int(b *testing.B) {
+	v := 12345
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+func Benchmark_formatAnyToString_bool(b *testing.B) {
+	v := true
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+func Benchmark_formatAnyToString_int64(b *testing.B) {
+	v := int64(9223372036854775807)
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+func Benchmark_formatAnyToString_stringSlice(b *testing.B) {
+	v := []string{"a", "b", "c"}
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+// Tier 2: common stdlib types
+func Benchmark_formatAnyToString_time(b *testing.B) {
+	v := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+func Benchmark_formatAnyToString_byteSlice(b *testing.B) {
+	v := []byte("binary data")
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+func Benchmark_formatAnyToString_float64(b *testing.B) {
+	v := 3.14159265359
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+// Tier 3: less common integers (signed)
+func Benchmark_formatAnyToString_int32(b *testing.B) {
+	v := int32(2147483647)
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+func Benchmark_formatAnyToString_int16(b *testing.B) {
+	v := int16(32767)
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+func Benchmark_formatAnyToString_int8(b *testing.B) {
+	v := int8(127)
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+// Tier 4: less common integers (unsigned)
+func Benchmark_formatAnyToString_uint64(b *testing.B) {
+	v := uint64(18446744073709551615)
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+func Benchmark_formatAnyToString_uint32(b *testing.B) {
+	v := uint32(4294967295)
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+func Benchmark_formatAnyToString_uint16(b *testing.B) {
+	v := uint16(65535)
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+func Benchmark_formatAnyToString_uint8(b *testing.B) {
+	v := uint8(255)
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+func Benchmark_formatAnyToString_uint(b *testing.B) {
+	v := uint(12345)
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+// Tier 5: rare types and fallbacks
+func Benchmark_formatAnyToString_float32(b *testing.B) {
+	v := float32(3.14)
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+func Benchmark_formatAnyToString_stringer(b *testing.B) {
+	v := benchmarkStringer{value: "custom value"}
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
+	}
+}
+
+func Benchmark_formatAnyToString_default(b *testing.B) {
+	v := struct{ Name string }{Name: "test"}
+	for i := 0; i < b.N; i++ {
+		_ = formatAnyToString(v)
 	}
 }

--- a/client.go
+++ b/client.go
@@ -303,6 +303,25 @@ func (c *Client) SetHeader(header, value string) *Client {
 	return c
 }
 
+// SetHeaderAny method sets a single header field and its value in the client instance
+// for all requests raised from the client.
+//
+// It is similar to [Client.SetHeader] but accepts any type as the value and converts
+// it to a string using predefined formatting rules (integers, bools, time.Time, etc.).
+//
+// For Example: To set `X-Request-Id` with an integer value
+//
+//	client.SetHeaderAny("X-Request-Id", 12345)
+//
+// See [Request.SetHeaderAny] or [Client.SetHeader].
+func (c *Client) SetHeaderAny(header string, value any) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	strVal := formatAnyToString(value)
+	c.header.Set(header, strVal)
+	return c
+}
+
 // SetHeaders method sets multiple headers and their values at one go, and
 // these headers will be applied to all requests raised from the client instance.
 // Also, it can be overridden at request-level headers options.
@@ -339,6 +358,25 @@ func (c *Client) SetHeaderVerbatim(header, value string) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.header[header] = []string{value}
+	return c
+}
+
+// SetHeaderVerbatimAny method sets the HTTP header key and value verbatim in the client instance
+// for all requests raised from the client.
+//
+// It is similar to [Client.SetHeaderVerbatim] but accepts any type as the value and converts
+// it to a string using predefined formatting rules (integers, bools, time.Time, etc.).
+//
+// For Example: To set header key as `x-trace-id` with an integer value
+//
+//	client.SetHeaderVerbatimAny("x-trace-id", 798940)
+//
+// See [Request.SetHeaderVerbatimAny] or [Client.SetHeaderVerbatim].
+func (c *Client) SetHeaderVerbatimAny(header string, value any) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	strVal := formatAnyToString(value)
+	c.header[header] = []string{strVal}
 	return c
 }
 
@@ -444,6 +482,27 @@ func (c *Client) SetQueryParam(param, value string) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.queryParams.Set(param, value)
+	return c
+}
+
+// SetQueryParamAny method sets a single query parameter and its value in the client instance.
+// It will be formed as a query string for the request.
+//
+// It is similar to [Client.SetQueryParam] but accepts any type as the value and converts
+// it to a string using predefined formatting rules (integers, bools, time.Time, etc.).
+//
+// For Example: To set `page` and `active` query parameters
+//
+//	client.
+//		SetQueryParamAny("page", 5).
+//		SetQueryParamAny("active", true)
+//
+// See [Request.SetQueryParamAny] or [Client.SetQueryParam].
+func (c *Client) SetQueryParamAny(param string, value any) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	strVal := formatAnyToString(value)
+	c.queryParams.Set(param, strVal)
 	return c
 }
 
@@ -1919,6 +1978,31 @@ func (c *Client) SetPathParam(param, value string) *Client {
 	return c
 }
 
+// SetPathParamAny method sets a single URL path key-value pair in the
+// Resty client instance.
+//
+// It is similar to [Client.SetPathParam] but accepts any type as the value and converts
+// it to a string using predefined formatting rules (integers, bools, time.Time, etc.).
+//
+//	client.SetPathParamAny("userId", 12345)
+//
+//	Result:
+//	   URL - /v1/users/{userId}/details
+//	   Composed URL - /v1/users/12345/details
+//
+// It replaces the value of the key while composing the request URL.
+// The value will be escaped using [url.PathEscape] function.
+//
+// It can be overridden at the request level,
+// see [Request.SetPathParamAny] or [Request.SetPathParams]
+func (c *Client) SetPathParamAny(param string, value any) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	strVal := formatAnyToString(value)
+	c.pathParams[param] = url.PathEscape(strVal)
+	return c
+}
+
 // SetPathParams method sets multiple URL path key-value pairs at one go in the
 // Resty client instance.
 //
@@ -1962,6 +2046,31 @@ func (c *Client) SetRawPathParam(param, value string) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.pathParams[param] = value
+	return c
+}
+
+// SetRawPathParamAny method sets a single URL path key-value pair in the
+// Resty client instance without path escape.
+//
+// It is similar to [Client.SetRawPathParam] but accepts any type as the value and converts
+// it to a string using predefined formatting rules (integers, bools, time.Time, etc.).
+//
+//	client.SetRawPathParamAny("userId", 12345)
+//
+//	Result:
+//	   URL - /v1/users/{userId}/details
+//	   Composed URL - /v1/users/12345/details
+//
+// It replaces the value of the key while composing the request URL.
+// The value will be used as-is, no path escape applied.
+//
+// It can be overridden at the request level,
+// see [Request.SetRawPathParamAny] or [Request.SetRawPathParams]
+func (c *Client) SetRawPathParamAny(param string, value any) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	strVal := formatAnyToString(value)
+	c.pathParams[param] = strVal
 	return c
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -465,6 +465,51 @@ func TestClientSetHeaderVerbatim(t *testing.T) {
 	assertEqual(t, "value_standard", c.Header().Get("Header-Lowercase"))
 }
 
+func TestClientSetHeaderAny(t *testing.T) {
+	c := dcnl().
+		SetHeaderAny("X-Int-Value", 42).
+		SetHeaderAny("X-String-Value", "hello")
+
+	assertEqual(t, "42", c.Header().Get("X-Int-Value"))
+	assertEqual(t, "hello", c.Header().Get("X-String-Value"))
+}
+
+func TestClientSetHeaderVerbatimAny(t *testing.T) {
+	c := dcnl().
+		SetHeaderVerbatimAny("header-lowercase", 123)
+
+	//lint:ignore SA1008 valid one, so ignore this!
+	unConventionHdrValue := strings.Join(c.Header()["header-lowercase"], "")
+	assertEqual(t, "123", unConventionHdrValue)
+}
+
+func TestClientSetQueryParamAny(t *testing.T) {
+	c := dcnl().
+		SetQueryParamAny("page", 5).
+		SetQueryParamAny("active", true)
+
+	assertEqual(t, "5", c.QueryParams().Get("page"))
+	assertEqual(t, "true", c.QueryParams().Get("active"))
+}
+
+func TestClientSetPathParamAny(t *testing.T) {
+	c := dcnl().
+		SetPathParamAny("userId", 42).
+		SetPathParamAny("name", "john doe")
+
+	assertEqual(t, "42", c.PathParams()["userId"])
+	assertEqual(t, "john%20doe", c.PathParams()["name"])
+}
+
+func TestClientSetRawPathParamAny(t *testing.T) {
+	c := dcnl().
+		SetRawPathParamAny("userId", 42).
+		SetRawPathParamAny("name", "john doe")
+
+	assertEqual(t, "42", c.PathParams()["userId"])
+	assertEqual(t, "john doe", c.PathParams()["name"])
+}
+
 func TestClientSetTransport(t *testing.T) {
 	ts := createGetServer(t)
 	defer ts.Close()

--- a/request.go
+++ b/request.go
@@ -183,6 +183,24 @@ func (r *Request) SetHeader(header, value string) *Request {
 	return r
 }
 
+// SetHeaderAny method sets a single header field and its value in the current request.
+//
+// It is similar to [Request.SetHeader] but accepts any type as the value and converts
+// it to a string using predefined formatting rules (integers, bools, time.Time, etc.).
+//
+// For Example: To set `X-Request-Id` with an integer value
+//
+//	client.R().SetHeaderAny("X-Request-Id", 12345)
+//
+// It overrides the header value set at the client instance level.
+//
+// See [Client.SetHeaderAny].
+func (r *Request) SetHeaderAny(header string, value any) *Request {
+	strVal := formatAnyToString(value)
+	r.Header.Set(header, strVal)
+	return r
+}
+
 // SetHeaders method sets multiple header fields and their values at one go in the current request.
 //
 // For Example: To set `Content-Type` and `Accept` as `application/json`
@@ -234,6 +252,24 @@ func (r *Request) SetHeaderVerbatim(header, value string) *Request {
 	return r
 }
 
+// SetHeaderVerbatimAny method sets the HTTP header key and value verbatim in the current request.
+//
+// It is similar to [Request.SetHeaderVerbatim] but accepts any type as the value and converts
+// it to a string using predefined formatting rules (integers, bools, time.Time, etc.).
+//
+// For Example: To set header key as `x-trace-id` with an integer value
+//
+//	client.R().SetHeaderVerbatimAny("x-trace-id", 798940)
+//
+// It overrides the header value set at the client instance level.
+//
+// See [Client.SetHeaderVerbatimAny].
+func (r *Request) SetHeaderVerbatimAny(header string, value any) *Request {
+	strVal := formatAnyToString(value)
+	r.Header[header] = []string{strVal}
+	return r
+}
+
 // SetQueryParam method sets a single parameter and its value in the current request.
 // It will be formed as a query string for the request.
 //
@@ -246,6 +282,27 @@ func (r *Request) SetHeaderVerbatim(header, value string) *Request {
 // It overrides the query parameter value set at the client instance level.
 func (r *Request) SetQueryParam(param, value string) *Request {
 	r.QueryParams.Set(param, value)
+	return r
+}
+
+// SetQueryParamAny method sets a single query parameter and its value in the current request.
+// It will be formed as a query string for the request.
+//
+// It is similar to [Request.SetQueryParam] but accepts any type as the value and converts
+// it to a string using predefined formatting rules (integers, bools, time.Time, etc.).
+//
+// For Example: To set `page` and `active` query parameters
+//
+//	client.R().
+//		SetQueryParamAny("page", 5).
+//		SetQueryParamAny("active", true)
+//
+// It overrides the query parameter value set at the client instance level.
+//
+// See [Client.SetQueryParamAny].
+func (r *Request) SetQueryParamAny(param string, value any) *Request {
+	strVal := formatAnyToString(value)
+	r.QueryParams.Set(param, strVal)
 	return r
 }
 
@@ -778,6 +835,30 @@ func (r *Request) SetPathParam(param, value string) *Request {
 	return r
 }
 
+// SetPathParamAny method sets a single URL path key-value pair in the
+// current request instance.
+//
+// It is similar to [Request.SetPathParam] but accepts any type as the value and converts
+// it to a string using predefined formatting rules (integers, bools, time.Time, etc.).
+//
+//	client.R().SetPathParamAny("userId", 12345)
+//
+//	Result:
+//	   URL - /v1/users/{userId}/details
+//	   Composed URL - /v1/users/12345/details
+//
+// It replaces the value of the key while composing the request URL.
+// The value will be escaped using [url.PathEscape] function.
+//
+// It overrides the path parameter set at the client instance level.
+//
+// See [Client.SetPathParamAny].
+func (r *Request) SetPathParamAny(param string, value any) *Request {
+	strVal := formatAnyToString(value)
+	r.PathParams[param] = url.PathEscape(strVal)
+	return r
+}
+
 // SetPathParams method sets multiple URL path key-value pairs at one go in the
 // Resty current request instance.
 //
@@ -823,6 +904,30 @@ func (r *Request) SetPathParams(params map[string]string) *Request {
 // It overrides the raw path parameter set at the client instance level.
 func (r *Request) SetRawPathParam(param, value string) *Request {
 	r.PathParams[param] = value
+	return r
+}
+
+// SetRawPathParamAny method sets a single URL path key-value pair in the
+// current request instance without path escape.
+//
+// It is similar to [Request.SetRawPathParam] but accepts any type as the value and converts
+// it to a string using predefined formatting rules (integers, bools, time.Time, etc.).
+//
+//	client.R().SetRawPathParamAny("userId", 12345)
+//
+//	Result:
+//	   URL - /v1/users/{userId}/details
+//	   Composed URL - /v1/users/12345/details
+//
+// It replaces the value of the key while composing the request URL.
+// The value will be used as-is, no path escape applied.
+//
+// It overrides the raw path parameter set at the client instance level.
+//
+// See [Client.SetRawPathParamAny].
+func (r *Request) SetRawPathParamAny(param string, value any) *Request {
+	strVal := formatAnyToString(value)
+	r.PathParams[param] = strVal
 	return r
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -1339,6 +1339,50 @@ func TestSetHeaderMultipleValue(t *testing.T) {
 	assertEqual(t, "Bearer xyz", r.Header.Get("authorization"))
 }
 
+func TestRequestSetHeaderAny(t *testing.T) {
+	r := dcnldr().
+		SetHeaderAny("X-Int-Value", 42).
+		SetHeaderAny("X-String-Value", "hello")
+
+	assertEqual(t, "42", r.Header.Get("X-Int-Value"))
+	assertEqual(t, "hello", r.Header.Get("X-String-Value"))
+}
+
+func TestRequestSetHeaderVerbatimAny(t *testing.T) {
+	r := dcnldr().
+		SetHeaderVerbatimAny("header-lowercase", 123)
+
+	//lint:ignore SA1008 valid one ignore this!
+	assertEqual(t, "123", strings.Join(r.Header["header-lowercase"], ""))
+}
+
+func TestRequestSetQueryParamAny(t *testing.T) {
+	r := dcnldr().
+		SetQueryParamAny("page", 5).
+		SetQueryParamAny("active", true)
+
+	assertEqual(t, "5", r.QueryParams.Get("page"))
+	assertEqual(t, "true", r.QueryParams.Get("active"))
+}
+
+func TestRequestSetPathParamAny(t *testing.T) {
+	r := dcnldr().
+		SetPathParamAny("userId", 42).
+		SetPathParamAny("name", "john doe")
+
+	assertEqual(t, "42", r.PathParams["userId"])
+	assertEqual(t, "john%20doe", r.PathParams["name"])
+}
+
+func TestRequestSetRawPathParamAny(t *testing.T) {
+	r := dcnldr().
+		SetRawPathParamAny("userId", 42).
+		SetRawPathParamAny("name", "john doe")
+
+	assertEqual(t, "42", r.PathParams["userId"])
+	assertEqual(t, "john doe", r.PathParams["name"])
+}
+
 func TestOutputFileWithBaseDirAndRelativePath(t *testing.T) {
 	ts := createGetServer(t)
 	defer ts.Close()

--- a/util.go
+++ b/util.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -402,6 +403,61 @@ func toJSON(v any) string {
 	defer releaseBuffer(buf)
 	_ = encodeJSON(buf, v)
 	return buf.String()
+}
+
+// formatAnyToString converts various types of values to their string representation
+// based on predefined formatting rules.
+func formatAnyToString(value any) string {
+	switch v := value.(type) {
+
+	// Tier 1: most common URL types
+	case string:
+		return v
+	case int:
+		return strconv.Itoa(v)
+	case bool:
+		return strconv.FormatBool(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case []string:
+		return strings.Join(v, ",")
+
+	// Tier 2: common stdlib types
+	case time.Time:
+		return v.Format(time.RFC3339)
+	case []byte:
+		return string(v)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+
+	// Tier 3: less common integers (signed)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case int16:
+		return strconv.FormatInt(int64(v), 10)
+	case int8:
+		return strconv.FormatInt(int64(v), 10)
+
+	// Tier 4: less common integers (unsigned)
+	case uint64:
+		return strconv.FormatUint(v, 10)
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint:
+		return strconv.FormatUint(uint64(v), 10)
+
+	// Tier 5: rare types and fallbacks
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case fmt.Stringer:
+		return v.String()
+	default:
+		return fmt.Sprint(v)
+	}
 }
 
 //‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾


### PR DESCRIPTION
Add support for SetXXXAny methods to simplify handling various data types in headers, query parameters, and path parameters.

Closes #1027 