### PR TITLE
refactor: streamline naming conventions to enable and ensure consistent and easy discovery

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -16,14 +16,14 @@ func Benchmark_parseRequestURL_PathParams(b *testing.B) {
 	c := New().SetPathParams(map[string]string{
 		"foo": "1",
 		"bar": "2",
-	}).SetRawPathParams(map[string]string{
+	}).SetPathRawParams(map[string]string{
 		"foo": "3",
 		"xyz": "4",
 	})
 	r := c.R().SetPathParams(map[string]string{
 		"foo": "5",
 		"qwe": "6",
-	}).SetRawPathParams(map[string]string{
+	}).SetPathRawParams(map[string]string{
 		"foo": "7",
 		"asd": "8",
 	})

--- a/client.go
+++ b/client.go
@@ -169,65 +169,65 @@ type TransportSettings struct {
 // Resty also provides an option to override most of the client settings
 // at [Request] level.
 type Client struct {
-	lock                     *sync.RWMutex
-	baseURL                  string
-	queryParams              url.Values
-	formData                 url.Values
-	pathParams               map[string]string
-	header                   http.Header
-	credentials              *credentials
-	authToken                string
-	authScheme               string
-	cookies                  []*http.Cookie
-	errorType                reflect.Type
-	debug                    bool
-	disableWarn              bool
-	allowMethodGetPayload    bool
-	allowMethodDeletePayload bool
-	timeout                  time.Duration
-	retryCount               int
-	retryWaitTime            time.Duration
-	retryMaxWaitTime         time.Duration
-	retryConditions          []RetryConditionFunc
-	retryHooks               []RetryHookFunc
-	retryDelayStrategy       RetryDelayStrategyFunc
-	isRetryDefaultConditions bool
-	allowNonIdempotentRetry  bool
-	headerAuthorizationKey   string
-	responseBodyLimit        int64
-	resBodyUnlimitedReads    bool
-	jsonEscapeHTML           bool
-	closeConnection          bool
-	notParseResponse         bool
-	isTrace                  bool
-	debugBodyLimit           int
-	outputDirectory          string
-	isSaveResponse           bool
-	scheme                   string
-	log                      Logger
-	ctx                      context.Context
-	httpClient               *http.Client
-	proxyURL                 *url.URL
-	debugLogFormatter        DebugLogFormatterFunc
-	debugLogCallback         DebugLogCallbackFunc
-	generateCurlCmd          bool
-	debugLogCurlCmd          bool
-	unescapeQueryParams      bool
-	loadBalancer             LoadBalancer
-	beforeRequest            []RequestMiddleware
-	afterResponse            []ResponseMiddleware
-	errorHooks               []ErrorHook
-	invalidHooks             []ErrorHook
-	panicHooks               []ErrorHook
-	successHooks             []SuccessHook
-	closeHooks               []CloseHook
-	contentTypeEncoders      map[string]ContentTypeEncoder
-	contentTypeDecoders      map[string]ContentTypeDecoder
-	contentDecompresserKeys  []string
-	contentDecompressers     map[string]ContentDecompresser
-	certWatcherStopChan      chan bool
-	circuitBreaker           *CircuitBreaker
-	hedging                  *hedgingConfig
+	lock                       *sync.RWMutex
+	baseURL                    string
+	queryParams                url.Values
+	formData                   url.Values
+	pathParams                 map[string]string
+	header                     http.Header
+	credentials                *credentials
+	authToken                  string
+	authScheme                 string
+	cookies                    []*http.Cookie
+	errorType                  reflect.Type
+	debug                      bool
+	disableWarn                bool
+	isMethodGetAllowPayload    bool
+	isMethodDeleteAllowPayload bool
+	timeout                    time.Duration
+	retryCount                 int
+	retryWaitTime              time.Duration
+	retryMaxWaitTime           time.Duration
+	retryConditions            []RetryConditionFunc
+	retryHooks                 []RetryHookFunc
+	retryDelayStrategy         RetryDelayStrategyFunc
+	isRetryDefaultConditions   bool
+	isRetryAllowNonIdempotent  bool
+	headerAuthorizationKey     string
+	responseBodyLimit          int64
+	resBodyUnlimitedReads      bool
+	jsonEscapeHTML             bool
+	closeConnection            bool
+	isResponseDoNotParse       bool
+	isTrace                    bool
+	debugBodyLimit             int
+	responseSaveDirectory      string
+	isResponseSaveToFile       bool
+	scheme                     string
+	log                        Logger
+	ctx                        context.Context
+	httpClient                 *http.Client
+	proxyURL                   *url.URL
+	debugLogFormatter          DebugLogFormatterFunc
+	debugLogCallback           DebugLogCallbackFunc
+	isCurlCmdGenerate          bool
+	isCurlCmdDebugLog          bool
+	unescapeQueryParams        bool
+	loadBalancer               LoadBalancer
+	beforeRequest              []RequestMiddleware
+	afterResponse              []ResponseMiddleware
+	errorHooks                 []ErrorHook
+	invalidHooks               []ErrorHook
+	panicHooks                 []ErrorHook
+	successHooks               []SuccessHook
+	closeHooks                 []CloseHook
+	contentTypeEncoders        map[string]ContentTypeEncoder
+	contentTypeDecoders        map[string]ContentTypeDecoder
+	contentDecompresserKeys    []string
+	contentDecompressers       map[string]ContentDecompresser
+	certWatcherStopChan        chan bool
+	circuitBreaker             *CircuitBreaker
+	hedging                    *hedgingConfig
 }
 
 // CertWatcherOptions allows configuring a watcher that reloads dynamically TLS certs.
@@ -685,31 +685,31 @@ func (c *Client) R() *Request {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	r := &Request{
-		QueryParams:                url.Values{},
-		FormData:                   url.Values{},
-		Header:                     http.Header{},
-		Cookies:                    make([]*http.Cookie, 0),
-		PathParams:                 make(map[string]string),
-		Timeout:                    c.timeout,
-		Debug:                      c.debug,
-		IsTrace:                    c.isTrace,
-		IsSaveResponse:             c.isSaveResponse,
-		AuthScheme:                 c.authScheme,
-		AuthToken:                  c.authToken,
-		RetryCount:                 c.retryCount,
-		RetryWaitTime:              c.retryWaitTime,
-		RetryMaxWaitTime:           c.retryMaxWaitTime,
-		RetryDelayStrategy:         c.retryDelayStrategy,
-		IsRetryDefaultConditions:   c.isRetryDefaultConditions,
-		CloseConnection:            c.closeConnection,
-		DoNotParseResponse:         c.notParseResponse,
-		DebugBodyLimit:             c.debugBodyLimit,
-		ResponseBodyLimit:          c.responseBodyLimit,
-		ResponseBodyUnlimitedReads: c.resBodyUnlimitedReads,
-		AllowMethodGetPayload:      c.allowMethodGetPayload,
-		AllowMethodDeletePayload:   c.allowMethodDeletePayload,
-		AllowNonIdempotentRetry:    c.allowNonIdempotentRetry,
-		HeaderAuthorizationKey:     c.headerAuthorizationKey,
+		QueryParams:                  url.Values{},
+		FormData:                     url.Values{},
+		Header:                       http.Header{},
+		Cookies:                      make([]*http.Cookie, 0),
+		PathParams:                   make(map[string]string),
+		Timeout:                      c.timeout,
+		IsDebug:                      c.debug,
+		IsTrace:                      c.isTrace,
+		IsResponseSaveToFile:         c.isResponseSaveToFile,
+		AuthScheme:                   c.authScheme,
+		AuthToken:                    c.authToken,
+		RetryCount:                   c.retryCount,
+		RetryWaitTime:                c.retryWaitTime,
+		RetryMaxWaitTime:             c.retryMaxWaitTime,
+		RetryDelayStrategy:           c.retryDelayStrategy,
+		IsRetryDefaultConditions:     c.isRetryDefaultConditions,
+		IsCloseConnection:            c.closeConnection,
+		IsResponseDoNotParse:         c.isResponseDoNotParse,
+		DebugBodyLimit:               c.debugBodyLimit,
+		ResponseBodyLimit:            c.responseBodyLimit,
+		IsResponseBodyUnlimitedReads: c.resBodyUnlimitedReads,
+		IsMethodGetAllowPayload:      c.isMethodGetAllowPayload,
+		IsMethodDeleteAllowPayload:   c.isMethodDeleteAllowPayload,
+		IsRetryAllowNonIdempotent:    c.isRetryAllowNonIdempotent,
+		HeaderAuthorizationKey:       c.headerAuthorizationKey,
 
 		mu:                  new(sync.Mutex),
 		client:              c,
@@ -717,8 +717,8 @@ func (c *Client) R() *Request {
 		multipartFields:     make([]*MultipartField, 0),
 		jsonEscapeHTML:      c.jsonEscapeHTML,
 		log:                 c.log,
-		generateCurlCmd:     c.generateCurlCmd,
-		debugLogCurlCmd:     c.debugLogCurlCmd,
+		isCurlCmdGenerate:   c.isCurlCmdGenerate,
+		isCurlCmdDebugLog:   c.isCurlCmdDebugLog,
 		unescapeQueryParams: c.unescapeQueryParams,
 		credentials:         c.credentials,
 	}
@@ -1041,24 +1041,10 @@ func (c *Client) IsDebug() bool {
 	return c.debug
 }
 
-// EnableDebug method is a helper method for [Client.SetDebug]
-func (c *Client) EnableDebug() *Client {
-	c.SetDebug(true)
-	return c
-}
-
-// DisableDebug method is a helper method for [Client.SetDebug]
-func (c *Client) DisableDebug() *Client {
-	c.SetDebug(false)
-	return c
-}
-
-// SetDebug method enables the debug mode on the Resty client. The client logs details
-// of every request and response.
+// SetDebug method is used to turn on/off the debug mode on the Resty client instance. It logs details
+// of every request and response when enabled.
 //
 //	client.SetDebug(true)
-//	// OR
-//	client.EnableDebug()
 //
 // Also, it can be enabled at the request level for a particular request; see [Request.SetDebug].
 //   - For [Request], it logs information such as HTTP verb, Relative URL path,
@@ -1130,61 +1116,61 @@ func (c *Client) IsDisableWarn() bool {
 	return c.disableWarn
 }
 
-// SetDisableWarn method disables the warning log message on the Resty client.
+// SetLoggerWarnLevel method disables the warning log message on the Resty client.
 //
 // For example, Resty warns users when BasicAuth is used in non-TLS mode.
 //
-//	client.SetDisableWarn(true)
-func (c *Client) SetDisableWarn(d bool) *Client {
+//	client.SetLoggerWarnLevel(true)
+func (c *Client) SetLoggerWarnLevel(d bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.disableWarn = d
 	return c
 }
 
-// AllowMethodGetPayload method returns `true` if the client is enabled to allow
+// IsMethodGetAllowPayload method returns `true` if the client is enabled to allow
 // payload with GET method; otherwise, it is `false`.
-func (c *Client) AllowMethodGetPayload() bool {
+func (c *Client) IsMethodGetAllowPayload() bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.allowMethodGetPayload
+	return c.isMethodGetAllowPayload
 }
 
-// SetAllowMethodGetPayload method allows the GET method with payload on the Resty client.
+// SetMethodGetAllowPayload method allows the GET method with payload on the Resty client.
 // By default, Resty does not allow.
 //
-//	client.SetAllowMethodGetPayload(true)
+//	client.SetMethodGetAllowPayload(true)
 //
-// It can be overridden at the request level. See [Request.SetAllowMethodGetPayload]
-func (c *Client) SetAllowMethodGetPayload(allow bool) *Client {
+// It can be overridden at the request level. See [Request.SetMethodGetAllowPayload]
+func (c *Client) SetMethodGetAllowPayload(allow bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.allowMethodGetPayload = allow
+	c.isMethodGetAllowPayload = allow
 	return c
 }
 
-// AllowMethodDeletePayload method returns `true` if the client is enabled to allow
+// IsMethodDeleteAllowPayload method returns `true` if the client is enabled to allow
 // payload with DELETE method; otherwise, it is `false`.
 //
 // More info, refer to GH#881
-func (c *Client) AllowMethodDeletePayload() bool {
+func (c *Client) IsMethodDeleteAllowPayload() bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.allowMethodDeletePayload
+	return c.isMethodDeleteAllowPayload
 }
 
-// SetAllowMethodDeletePayload method allows the DELETE method with payload on the Resty client.
+// SetMethodDeleteAllowPayload method allows the DELETE method with payload on the Resty client.
 // By default, Resty does not allow.
 //
-//	client.SetAllowMethodDeletePayload(true)
+//	client.SetMethodDeleteAllowPayload(true)
 //
 // More info, refer to GH#881
 //
-// It can be overridden at the request level. See [Request.SetAllowMethodDeletePayload]
-func (c *Client) SetAllowMethodDeletePayload(allow bool) *Client {
+// It can be overridden at the request level. See [Request.SetMethodDeleteAllowPayload]
+func (c *Client) SetMethodDeleteAllowPayload(allow bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.allowMethodDeletePayload = allow
+	c.isMethodDeleteAllowPayload = allow
 	return c
 }
 
@@ -1364,18 +1350,6 @@ func (c *Client) SetRetryDelayStrategy(rs RetryDelayStrategyFunc) *Client {
 	return c
 }
 
-// EnableRetryDefaultConditions method enables the Resty's default retry conditions
-func (c *Client) EnableRetryDefaultConditions() *Client {
-	c.SetRetryDefaultConditions(true)
-	return c
-}
-
-// DisableRetryDefaultConditions method disables the Resty's default retry conditions
-func (c *Client) DisableRetryDefaultConditions() *Client {
-	c.SetRetryDefaultConditions(false)
-	return c
-}
-
 // IsRetryDefaultConditions method returns true if Resty's default retry conditions
 // are enabled otherwise false
 //
@@ -1397,28 +1371,28 @@ func (c *Client) SetRetryDefaultConditions(b bool) *Client {
 	return c
 }
 
-// AllowNonIdempotentRetry method returns true if the client is enabled to allow
+// IsRetryAllowNonIdempotent method returns true if the client is enabled to allow
 // non-idempotent HTTP methods retry; otherwise, it is `false`
 //
 // Default value is `false`
-func (c *Client) AllowNonIdempotentRetry() bool {
+func (c *Client) IsRetryAllowNonIdempotent() bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.allowNonIdempotentRetry
+	return c.isRetryAllowNonIdempotent
 }
 
-// SetAllowNonIdempotentRetry method is used to enable/disable non-idempotent HTTP
+// SetRetryAllowNonIdempotent method is used to enable/disable non-idempotent HTTP
 // methods retry. By default, Resty only allows idempotent HTTP methods, see
 // [RFC 9110 Section 9.2.2], [RFC 9110 Section 18.2]
 //
-// It can be overridden at request level, see [Request.SetAllowNonIdempotentRetry]
+// It can be overridden at request level, see [Request.SetRetryAllowNonIdempotent]
 //
 // [RFC 9110 Section 9.2.2]: https://datatracker.ietf.org/doc/html/rfc9110.html#name-idempotent-methods
 // [RFC 9110 Section 18.2]: https://datatracker.ietf.org/doc/html/rfc9110.html#name-method-registration
-func (c *Client) SetAllowNonIdempotentRetry(b bool) *Client {
+func (c *Client) SetRetryAllowNonIdempotent(b bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.allowNonIdempotentRetry = b
+	c.isRetryAllowNonIdempotent = b
 	return c
 }
 
@@ -2015,48 +1989,48 @@ func (c *Client) initCertWatcher(pemFilePath, scope string, options *CertWatcher
 	}()
 }
 
-// OutputDirectory method returns the output directory value from the client.
-func (c *Client) OutputDirectory() string {
+// ResponseSaveDirectory method returns the output directory value from the client.
+func (c *Client) ResponseSaveDirectory() string {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.outputDirectory
+	return c.responseSaveDirectory
 }
 
-// SetOutputDirectory method sets the output directory for saving HTTP responses in a file.
+// SetResponseSaveDirectory method sets the output directory for saving HTTP responses in a file.
 // Resty creates one if the output directory does not exist. This setting is optional,
-// if you plan to use the absolute path in [Request.SetOutputFileName] and can used together.
+// if you plan to use the absolute path in [Request.SetResponseSaveFileName] and can used together.
 //
-//	client.SetOutputDirectory("/save/http/response/here")
-func (c *Client) SetOutputDirectory(dirPath string) *Client {
+//	client.SetResponseSaveDirectory("/save/http/response/here")
+func (c *Client) SetResponseSaveDirectory(dirPath string) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.outputDirectory = dirPath
+	c.responseSaveDirectory = dirPath
 	return c
 }
 
-// IsSaveResponse method returns true if the save response is set to true; otherwise, false
-func (c *Client) IsSaveResponse() bool {
+// IsResponseSaveToFile method returns true if the save response is set to true; otherwise, false
+func (c *Client) IsResponseSaveToFile() bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.isSaveResponse
+	return c.isResponseSaveToFile
 }
 
-// SetSaveResponse method used to enable the save response option at the client level for
+// SetResponseSaveToFile method used to enable the save response option at the client level for
 // all requests
 //
-//	client.SetSaveResponse(true)
+//	client.SetResponseSaveToFile(true)
 //
 // Resty determines the save filename in the following order -
-//   - [Request.SetOutputFileName]
+//   - [Request.SetResponseSaveFileName]
 //   - Content-Disposition header
 //   - Request URL using [path.Base]
 //   - Request URL hostname if path is empty or "/"
 //
-// It can be overridden at request level, see [Request.SetSaveResponse]
-func (c *Client) SetSaveResponse(save bool) *Client {
+// It can be overridden at request level, see [Request.SetResponseSaveToFile]
+func (c *Client) SetResponseSaveToFile(save bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.isSaveResponse = save
+	c.isResponseSaveToFile = save
 	return c
 }
 
@@ -2136,7 +2110,7 @@ func (c *Client) SetCloseConnection(close bool) *Client {
 	return c
 }
 
-// SetDoNotParseResponse method instructs Resty not to parse the response body automatically.
+// SetResponseDoNotParse method instructs Resty not to parse the response body automatically.
 //
 // Resty exposes the raw response body as [io.ReadCloser]. If you use it, do not
 // forget to close the body, otherwise, you might get into connection leaks, and connection
@@ -2144,10 +2118,10 @@ func (c *Client) SetCloseConnection(close bool) *Client {
 //
 // NOTE: The default [Response] middlewares are not executed when using this option. User
 // takes over the control of handling response body from Resty.
-func (c *Client) SetDoNotParseResponse(notParse bool) *Client {
+func (c *Client) SetResponseDoNotParse(notParse bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.notParseResponse = notParse
+	c.isResponseDoNotParse = notParse
 	return c
 }
 
@@ -2231,10 +2205,10 @@ func (c *Client) SetPathParams(params map[string]string) *Client {
 	return c
 }
 
-// SetRawPathParam method sets a single URL path key-value pair in the
+// SetPathRawParam method sets a single URL path key-value pair in the
 // Resty client instance without path escape.
 //
-//	client.SetRawPathParam("path", "groups/developers")
+//	client.SetPathRawParam("path", "groups/developers")
 //
 //	Result:
 //		URL - /v1/users/{path}/details
@@ -2244,21 +2218,21 @@ func (c *Client) SetPathParams(params map[string]string) *Client {
 // The value will be used as-is, no path escape applied.
 //
 // It can be overridden at the request level,
-// see [Request.SetRawPathParam] or [Request.SetRawPathParams]
-func (c *Client) SetRawPathParam(param, value string) *Client {
+// see [Request.SetPathRawParam] or [Request.SetPathRawParams]
+func (c *Client) SetPathRawParam(param, value string) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.pathParams[param] = value
 	return c
 }
 
-// SetRawPathParamAny method sets a single URL path key-value pair in the
+// SetPathRawParamAny method sets a single URL path key-value pair in the
 // Resty client instance without path escape.
 //
-// It is similar to [Client.SetRawPathParam] but accepts any type as the value and converts
+// It is similar to [Client.SetPathRawParam] but accepts any type as the value and converts
 // it to a string using predefined formatting rules (integers, bools, time.Time, etc.).
 //
-//	client.SetRawPathParamAny("userId", 12345)
+//	client.SetPathRawParamAny("userId", 12345)
 //
 //	Result:
 //	   URL - /v1/users/{userId}/details
@@ -2268,8 +2242,8 @@ func (c *Client) SetRawPathParam(param, value string) *Client {
 // The value will be used as-is, no path escape applied.
 //
 // It can be overridden at the request level,
-// see [Request.SetRawPathParamAny] or [Request.SetRawPathParams]
-func (c *Client) SetRawPathParamAny(param string, value any) *Client {
+// see [Request.SetPathRawParamAny] or [Request.SetPathRawParams]
+func (c *Client) SetPathRawParamAny(param string, value any) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	strVal := formatAnyToString(value)
@@ -2277,10 +2251,10 @@ func (c *Client) SetRawPathParamAny(param string, value any) *Client {
 	return c
 }
 
-// SetRawPathParams method sets multiple URL path key-value pairs at one go in the
+// SetPathRawParams method sets multiple URL path key-value pairs at one go in the
 // Resty client instance without path escape.
 //
-//	client.SetRawPathParams(map[string]string{
+//	client.SetPathRawParams(map[string]string{
 //		"userId":       "sample@sample.com",
 //		"subAccountId": "100002",
 //		"path":         "groups/developers",
@@ -2294,10 +2268,10 @@ func (c *Client) SetRawPathParamAny(param string, value any) *Client {
 // The value will be used as-is, no path escape applied.
 //
 // It can be overridden at the request level,
-// see [Request.SetRawPathParam] or [Request.SetRawPathParams]
-func (c *Client) SetRawPathParams(params map[string]string) *Client {
+// see [Request.SetPathRawParam] or [Request.SetPathRawParams]
+func (c *Client) SetPathRawParams(params map[string]string) *Client {
 	for p, v := range params {
-		c.SetRawPathParam(p, v)
+		c.SetPathRawParam(p, v)
 	}
 	return c
 }
@@ -2330,7 +2304,7 @@ func (c *Client) ResponseBodyLimit() int64 {
 // in the uncompressed response is larger than the limit.
 // Body size limit will not be enforced in the following cases:
 //   - ResponseBodyLimit <= 0, which is the default behavior.
-//   - [Request.SetOutputFileName] is called to save response data to the file.
+//   - [Request.SetResponseSaveFileName] is called to save response data to the file.
 //   - "DoNotParseResponse" is set for client or request.
 //
 // It can be overridden at the request level; see [Request.SetResponseBodyLimit]
@@ -2341,27 +2315,6 @@ func (c *Client) SetResponseBodyLimit(v int64) *Client {
 	return c
 }
 
-// EnableTrace method enables the Resty client trace for the requests fired from
-// the client using [httptrace.ClientTrace] and provides insights.
-//
-//	client := resty.New().EnableTrace()
-//
-//	resp, err := client.R().Get("https://httpbin.org/get")
-//	fmt.Println("error:", err)
-//	fmt.Println("Trace Info:", resp.Request.TraceInfo())
-//
-// The method [Request.EnableTrace] is also available to get trace info for a single request.
-func (c *Client) EnableTrace() *Client {
-	c.SetTrace(true)
-	return c
-}
-
-// DisableTrace method disables the Resty client trace. Refer to [Client.EnableTrace].
-func (c *Client) DisableTrace() *Client {
-	c.SetTrace(false)
-	return c
-}
-
 // IsTrace method returns true if the trace is enabled on the client instance; otherwise, it returns false.
 func (c *Client) IsTrace() bool {
 	c.lock.RLock()
@@ -2369,10 +2322,16 @@ func (c *Client) IsTrace() bool {
 	return c.isTrace
 }
 
-// SetTrace method is used to turn on/off the trace capability in the Resty client
-// Refer to [Client.EnableTrace] or [Client.DisableTrace].
+// SetTrace method is used to turn on/off the trace capability in the Resty client instance.
+// It provides an insight into the request lifecycle using [httptrace.ClientTrace].
 //
-// Also, see [Request.SetTrace]
+//	client := resty.New().SetTrace(true)
+//
+//	resp, err := client.R().Get("https://httpbin.org/get")
+//	fmt.Println("error:", err)
+//	fmt.Println("Trace Info:", resp.Request.TraceInfo())
+//
+// The method [Request.SetTrace] is also available to get trace info for a single request.
 func (c *Client) SetTrace(t bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -2380,36 +2339,12 @@ func (c *Client) SetTrace(t bool) *Client {
 	return c
 }
 
-// EnableGenerateCurlCmd method enables the generation of curl command at the
+// SetCurlCmdGenerate method is used to turn on/off the generate curl command at the
 // client instance level.
 //
 // By default, Resty does not log the curl command in the debug log since it has the potential
-// to leak sensitive data unless explicitly enabled via [Client.SetDebugLogCurlCmd] or
-// [Request.SetDebugLogCurlCmd].
-//
-// NOTE: Use with care.
-//   - Potential to leak sensitive data from [Request] and [Response] in the debug log
-//     when the debug log option is enabled.
-//   - Additional memory usage since the request body was reread.
-//   - curl body is not generated for [io.Reader] and multipart request flow.
-func (c *Client) EnableGenerateCurlCmd() *Client {
-	c.SetGenerateCurlCmd(true)
-	return c
-}
-
-// DisableGenerateCurlCmd method disables the option set by [Client.EnableGenerateCurlCmd] or
-// [Client.SetGenerateCurlCmd].
-func (c *Client) DisableGenerateCurlCmd() *Client {
-	c.SetGenerateCurlCmd(false)
-	return c
-}
-
-// SetGenerateCurlCmd method is used to turn on/off the generate curl command at the
-// client instance level.
-//
-// By default, Resty does not log the curl command in the debug log since it has the potential
-// to leak sensitive data unless explicitly enabled via [Client.SetDebugLogCurlCmd] or
-// [Request.SetDebugLogCurlCmd].
+// to leak sensitive data unless explicitly enabled via [Client.SetCurlCmdDebugLog] or
+// [Request.SetCurlCmdDebugLog].
 //
 // NOTE: Use with care.
 //   - Potential to leak sensitive data from [Request] and [Response] in the debug log
@@ -2417,31 +2352,31 @@ func (c *Client) DisableGenerateCurlCmd() *Client {
 //   - Additional memory usage since the request body was reread.
 //   - curl body is not generated for [io.Reader] and multipart request flow.
 //
-// It can be overridden at the request level; see [Request.SetGenerateCurlCmd]
-func (c *Client) SetGenerateCurlCmd(b bool) *Client {
+// It can be overridden at the request level; see [Request.SetCurlCmdGenerate]
+func (c *Client) SetCurlCmdGenerate(b bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.generateCurlCmd = b
+	c.isCurlCmdGenerate = b
 	return c
 }
 
-// SetDebugLogCurlCmd method enables the curl command to be logged in the debug log.
+// SetCurlCmdDebugLog method enables the curl command to be logged in the debug log.
 //
-// It can be overridden at the request level; see [Request.SetDebugLogCurlCmd]
-func (c *Client) SetDebugLogCurlCmd(b bool) *Client {
+// It can be overridden at the request level; see [Request.SetCurlCmdDebugLog]
+func (c *Client) SetCurlCmdDebugLog(b bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.debugLogCurlCmd = b
+	c.isCurlCmdDebugLog = b
 	return c
 }
 
-// SetUnescapeQueryParams method sets the choice of unescape query parameters for the request URL.
+// SetQueryParamsUnescape method sets the choice of unescape query parameters for the request URL.
 // To prevent broken URL, Resty replaces space (" ") with "+" in the query parameters.
 //
-// See [Request.SetUnescapeQueryParams]
+// See [Request.SetQueryParamsUnescape]
 //
 // NOTE: Request failure is possible due to non-standard usage of Unescaped Query Parameters.
-func (c *Client) SetUnescapeQueryParams(unescape bool) *Client {
+func (c *Client) SetQueryParamsUnescape(unescape bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.unescapeQueryParams = unescape
@@ -2571,7 +2506,7 @@ func (c *Client) execute(req *Request) (*Response, error) {
 
 	prepareRequestDebugInfo(c, req)
 
-	req.Time = time.Now()
+	req.StartTime = time.Now()
 	resp, err := c.Client().Do(req.withTimeout())
 	// Cancel multipart context for io.Copy to stop reading/writing further
 	if req.isMultiPart && req.multipartCancelFunc != nil {
@@ -2602,8 +2537,8 @@ func (c *Client) execute(req *Request) (*Response, error) {
 
 		response.wrapLimitReadCloser()
 
-		if !req.DoNotParseResponse {
-			if req.ResponseBodyUnlimitedReads || req.Debug {
+		if !req.IsResponseDoNotParse {
+			if req.IsResponseBodyUnlimitedReads || req.IsDebug {
 				response.wrapCopyReadCloser()
 
 				if err = response.readAll(); err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -96,7 +96,7 @@ func TestClientResponseMiddleware(t *testing.T) {
 
 	c := dcnl()
 	c.AddResponseMiddleware(func(c *Client, res *Response) error {
-		t.Logf("Request sent at: %v", res.Request.Time)
+		t.Logf("Request sent at: %v", res.Request.StartTime)
 		t.Logf("Response Received at: %v", res.ReceivedAt())
 
 		return nil
@@ -115,7 +115,7 @@ func TestClientRedirectPolicy(t *testing.T) {
 	ts := createRedirectServer(t)
 	defer ts.Close()
 
-	c := dcnl().SetRedirectPolicy(FlexibleRedirectPolicy(20), DomainCheckRedirectPolicy("127.0.0.1"))
+	c := dcnl().SetRedirectPolicy(RedirectFlexiblePolicy(20), RedirectDomainCheckPolicy("127.0.0.1"))
 	res, err := c.R().
 		SetHeader("Name1", "Value1").
 		SetHeader("Name2", "Value2").
@@ -131,7 +131,7 @@ func TestClientRedirectPolicy(t *testing.T) {
 	assertEqual(t, 307, finalReq.StatusCode)
 	assertEqual(t, ts.URL+"/redirect-20", finalReq.URL)
 
-	c.SetRedirectPolicy(NoRedirectPolicy())
+	c.SetRedirectPolicy(RedirectNoPolicy())
 	res, err = c.R().Get(ts.URL + "/redirect-1")
 	assertNil(t, err)
 	assertEqual(t, http.StatusTemporaryRedirect, res.StatusCode())
@@ -503,8 +503,8 @@ func TestClientSetPathParamAny(t *testing.T) {
 
 func TestClientSetRawPathParamAny(t *testing.T) {
 	c := dcnl().
-		SetRawPathParamAny("userId", 42).
-		SetRawPathParamAny("name", "john doe")
+		SetPathRawParamAny("userId", 42).
+		SetPathRawParamAny("name", "john doe")
 
 	assertEqual(t, "42", c.PathParams()["userId"])
 	assertEqual(t, "john doe", c.PathParams()["name"])
@@ -574,12 +574,12 @@ func TestClientSettingsCoverage(t *testing.T) {
 
 	c.SetCloseConnection(true)
 
-	c.DisableDebug()
+	c.SetDebug(false)
 
 	assertTrue(t, c.IsRetryDefaultConditions())
-	c.DisableRetryDefaultConditions()
+	c.SetRetryDefaultConditions(false)
 	assertFalse(t, c.IsRetryDefaultConditions())
-	c.EnableRetryDefaultConditions()
+	c.SetRetryDefaultConditions(true)
 	assertTrue(t, c.IsRetryDefaultConditions())
 
 	nr := nopReader{}
@@ -623,7 +623,7 @@ func TestContentLengthWhenBodyIsNil(t *testing.T) {
 		return nil
 	}
 	client.SetRequestMiddlewares(
-		PrepareRequestMiddleware,
+		MiddlewareRequestCreate,
 		fnPreRequestMiddleware1,
 	)
 
@@ -652,7 +652,7 @@ func TestClientPreRequestMiddlewares(t *testing.T) {
 	}
 
 	client.SetRequestMiddlewares(
-		PrepareRequestMiddleware,
+		MiddlewareRequestCreate,
 		fnPreRequestMiddleware1,
 		fnPreRequestMiddleware2,
 	)
@@ -685,7 +685,7 @@ func TestClientPreRequestMiddlewareError(t *testing.T) {
 		return errors.New("error from PreRequestMiddleware")
 	}
 	c.SetRequestMiddlewares(
-		PrepareRequestMiddleware,
+		MiddlewareRequestCreate,
 		fnPreRequestMiddleware1,
 	)
 
@@ -701,8 +701,8 @@ func TestClientAllowMethodGetPayload(t *testing.T) {
 
 	t.Run("method GET allow string payload at client level", func(t *testing.T) {
 		c := dcnl()
-		c.SetAllowMethodGetPayload(true)
-		assertTrue(t, c.AllowMethodGetPayload())
+		c.SetMethodGetAllowPayload(true)
+		assertTrue(t, c.IsMethodGetAllowPayload())
 
 		payload := "test-payload"
 		resp, err := c.R().SetBody(payload).Get(ts.URL + "/get-method-payload-test")
@@ -714,8 +714,8 @@ func TestClientAllowMethodGetPayload(t *testing.T) {
 
 	t.Run("method GET allow io.Reader payload at client level", func(t *testing.T) {
 		c := dcnl()
-		c.SetAllowMethodGetPayload(true)
-		assertTrue(t, c.AllowMethodGetPayload())
+		c.SetMethodGetAllowPayload(true)
+		assertTrue(t, c.IsMethodGetAllowPayload())
 
 		payload := "test-payload"
 		body := bytes.NewReader([]byte(payload))
@@ -728,8 +728,8 @@ func TestClientAllowMethodGetPayload(t *testing.T) {
 
 	t.Run("method GET disallow payload at client level", func(t *testing.T) {
 		c := dcnl()
-		c.SetAllowMethodGetPayload(false)
-		assertFalse(t, c.AllowMethodGetPayload())
+		c.SetMethodGetAllowPayload(false)
+		assertFalse(t, c.IsMethodGetAllowPayload())
 
 		payload := bytes.NewReader([]byte("test-payload"))
 		resp, err := c.R().SetBody(payload).Get(ts.URL + "/get-method-payload-test")
@@ -747,8 +747,8 @@ func TestClientAllowMethodDeletePayload(t *testing.T) {
 	t.Run("method DELETE allow string payload at client level", func(t *testing.T) {
 		c := dcnl().SetBaseURL(ts.URL)
 
-		c.SetAllowMethodDeletePayload(true)
-		assertTrue(t, c.AllowMethodDeletePayload())
+		c.SetMethodDeleteAllowPayload(true)
+		assertTrue(t, c.IsMethodDeleteAllowPayload())
 
 		payload := "test-payload"
 		resp, err := c.R().SetBody(payload).Delete("/delete")
@@ -761,8 +761,8 @@ func TestClientAllowMethodDeletePayload(t *testing.T) {
 	t.Run("method DELETE allow io.Reader payload at client level", func(t *testing.T) {
 		c := dcnl().SetBaseURL(ts.URL)
 
-		c.SetAllowMethodDeletePayload(true)
-		assertTrue(t, c.AllowMethodDeletePayload())
+		c.SetMethodDeleteAllowPayload(true)
+		assertTrue(t, c.IsMethodDeleteAllowPayload())
 
 		payload := "test-payload"
 		body := bytes.NewReader([]byte(payload))
@@ -776,8 +776,8 @@ func TestClientAllowMethodDeletePayload(t *testing.T) {
 	t.Run("method DELETE disallow payload at client level", func(t *testing.T) {
 		c := dcnl().SetBaseURL(ts.URL)
 
-		c.SetAllowMethodDeletePayload(false)
-		assertFalse(t, c.AllowMethodDeletePayload())
+		c.SetMethodDeleteAllowPayload(false)
+		assertFalse(t, c.IsMethodDeleteAllowPayload())
 
 		payload := bytes.NewReader([]byte("test-payload"))
 		resp, err := c.R().SetBody(payload).Delete("/delete")

--- a/client_test.go
+++ b/client_test.go
@@ -1413,21 +1413,24 @@ func TestResponseBodyLimit(t *testing.T) {
 	defer ts.Close()
 
 	t.Run("client body limit", func(t *testing.T) {
-		c := dcnl().SetResponseBodyLimit(1024)
-		assertEqual(t, int64(1024), c.ResponseBodyLimit())
+		resBodyLimit := int64(1024)
+		c := dcnl().SetResponseBodyLimit(resBodyLimit)
+		assertEqual(t, resBodyLimit, c.ResponseBodyLimit())
+
 		resp, err := c.R().Get(ts.URL + "/")
 		assertNotNil(t, err)
 		assertErrorIs(t, ErrReadExceedsThresholdLimit, err)
-		assertEqual(t, int64(1408), resp.Size())
+		assertTrue(t, resp.Size() > resBodyLimit)
 	})
 
 	t.Run("request body limit", func(t *testing.T) {
+		resBodyLimit := int64(1024)
 		c := dcnl()
 
-		resp, err := c.R().SetResponseBodyLimit(1024).Get(ts.URL + "/")
+		resp, err := c.R().SetResponseBodyLimit(resBodyLimit).Get(ts.URL + "/")
 		assertNotNil(t, err)
 		assertErrorIs(t, ErrReadExceedsThresholdLimit, err)
-		assertEqual(t, int64(1408), resp.Size())
+		assertTrue(t, resp.Size() > resBodyLimit)
 	})
 
 	t.Run("body less than limit", func(t *testing.T) {

--- a/digest_test.go
+++ b/digest_test.go
@@ -190,7 +190,7 @@ func TestClientDigestAuthWithBodyQopAuthIntGetBodyNil(t *testing.T) {
 
 	c := dcnl().SetDigestAuth(conf.username, conf.password)
 	c.SetRequestMiddlewares(
-		PrepareRequestMiddleware,
+		MiddlewareRequestCreate,
 		func(c *Client, r *Request) error {
 			r.RawRequest.GetBody = nil
 			return nil
@@ -215,7 +215,7 @@ func TestClientDigestAuthWithGetBodyError(t *testing.T) {
 
 	c := dcnl().SetDigestAuth(conf.username, conf.password)
 	c.SetRequestMiddlewares(
-		PrepareRequestMiddleware,
+		MiddlewareRequestCreate,
 		func(c *Client, r *Request) error {
 			r.RawRequest.GetBody = func() (_ io.ReadCloser, _ error) {
 				return nil, errors.New("get body test error")
@@ -244,7 +244,7 @@ func TestClientDigestAuthWithGetBodyNilReadError(t *testing.T) {
 
 	c := dcnl().SetDigestAuth(conf.username, conf.password)
 	c.SetRequestMiddlewares(
-		PrepareRequestMiddleware,
+		MiddlewareRequestCreate,
 		func(c *Client, r *Request) error {
 			r.RawRequest.GetBody = nil
 			return nil

--- a/middleware.go
+++ b/middleware.go
@@ -25,9 +25,16 @@ import (
 // Request Middleware(s)
 //_______________________________________________________________________
 
-// PrepareRequestMiddleware method is used to prepare HTTP requests from
-// user provides request values. Request preparation fails if any error occurs
-func PrepareRequestMiddleware(c *Client, r *Request) (err error) {
+// MiddlewareRequestCreate method is used to prepare HTTP requests using the
+// user-provided request values. It performs the following operations -
+//   - Parse the request URL with path params and query params
+//   - Parse the request headers from client and request level
+//   - Parse the request body based on the content type and body type
+//   - Create the underlying [http.Request] object
+//   - Add credentials such as Basic Auth and Token Auth into the request
+//
+// Returns an error if request preparation fails.
+func MiddlewareRequestCreate(c *Client, r *Request) (err error) {
 	if err = parseRequestURL(c, r); err != nil {
 		return err
 	}
@@ -242,7 +249,7 @@ func createRawRequest(c *Client, r *Request) (err error) {
 	r.SetContext(r.RawRequest.Context())
 
 	// Assign close connection option
-	r.RawRequest.Close = r.CloseConnection
+	r.RawRequest.Close = r.IsCloseConnection
 
 	// Add headers into http request
 	r.RawRequest.Header = r.Header
@@ -512,24 +519,25 @@ func handleRequestBody(c *Client, r *Request) error {
 // Response Middleware(s)
 //_______________________________________________________________________
 
-// AutoParseResponseMiddleware method is used to parse the response body automatically
-// based on registered HTTP response `Content-Type` decoder, see [Client.AddContentTypeDecoder];
-// if [Request.SetResult], [Request.SetResultError], or [Client.SetResultError] is used
-func AutoParseResponseMiddleware(c *Client, res *Response) (err error) {
+// MiddlewareResponseAutoParse method is used to parse the response body automatically
+// based on the registered HTTP response `Content-Type` decoder, see [Client.AddContentTypeDecoder];
+// if [Request.SetResult], [Request.SetResultError], or [Client.SetResultError] is used, it performs
+// the auto unmarshalling into the respective object.
+func MiddlewareResponseAutoParse(c *Client, res *Response) (err error) {
 	if (res.CascadeError != nil && (res.Request.isMultiPart && res.StatusCode() == 0)) ||
-		res.Request.DoNotParseResponse {
+		res.Request.IsResponseDoNotParse {
 		return // move on
 	}
 
 	if res.StatusCode() == http.StatusNoContent {
-		res.Request.Error = nil
+		res.Request.ResultError = nil
 		return
 	}
 
 	rct := firstNonEmpty(
-		res.Request.ForceResponseContentType,
+		res.Request.ResponseForceContentType,
 		res.Header().Get(hdrContentTypeKey),
-		res.Request.ExpectResponseContentType,
+		res.Request.ResponseExpectContentType,
 	)
 	decKey := inferContentTypeMapKey(rct)
 	decFunc, found := c.inferContentTypeDecoder(rct, decKey)
@@ -541,7 +549,7 @@ func AutoParseResponseMiddleware(c *Client, res *Response) (err error) {
 
 	// HTTP status code > 199 and < 300, considered as Result
 	if res.IsStatusSuccess() && res.Request.Result != nil {
-		res.Request.Error = nil
+		res.Request.ResultError = nil
 		defer closeq(res.Body)
 		err = decFunc(res.Body, res.Request.Result)
 		res.IsRead = true
@@ -551,13 +559,13 @@ func AutoParseResponseMiddleware(c *Client, res *Response) (err error) {
 	// HTTP status code > 399, considered as Error
 	if res.IsStatusFailure() {
 		// global error type registered at client-instance
-		if res.Request.Error == nil {
-			res.Request.Error = c.newErrorInterface()
+		if res.Request.ResultError == nil {
+			res.Request.ResultError = c.newErrorInterface()
 		}
 
-		if res.Request.Error != nil {
+		if res.Request.ResultError != nil {
 			defer closeq(res.Body)
-			err = decFunc(res.Body, res.Request.Error)
+			err = decFunc(res.Body, res.Request.ResultError)
 			res.IsRead = true
 			return
 		}
@@ -568,17 +576,17 @@ func AutoParseResponseMiddleware(c *Client, res *Response) (err error) {
 
 var hostnameReplacer = strings.NewReplacer(":", "_", ".", "_")
 
-// SaveToFileResponseMiddleware method used to write HTTP response body into
+// MiddlewareResponseSaveToFile method used to write HTTP response body into
 // file. The filename is determined in the following order -
-//   - [Request.SetOutputFileName]
+//   - [Request.SetResponseSaveFileName]
 //   - Content-Disposition header
 //   - Request URL using [path.Base]
-func SaveToFileResponseMiddleware(c *Client, res *Response) error {
-	if res.CascadeError != nil || !res.Request.IsSaveResponse {
+func MiddlewareResponseSaveToFile(c *Client, res *Response) error {
+	if res.CascadeError != nil || !res.Request.IsResponseSaveToFile {
 		return nil
 	}
 
-	file := res.Request.OutputFileName
+	file := res.Request.ResponseSaveFileName
 	if isStringEmpty(file) {
 		cntDispositionValue := res.Header().Get(hdrContentDisposition)
 		if len(cntDispositionValue) > 0 {
@@ -596,8 +604,8 @@ func SaveToFileResponseMiddleware(c *Client, res *Response) error {
 		}
 	}
 
-	if len(c.OutputDirectory()) > 0 && !filepath.IsAbs(file) {
-		file = filepath.Join(c.OutputDirectory(), string(filepath.Separator), file)
+	if len(c.ResponseSaveDirectory()) > 0 && !filepath.IsAbs(file) {
+		file = filepath.Join(c.ResponseSaveDirectory(), string(filepath.Separator), file)
 	}
 
 	file = filepath.Clean(file)

--- a/redirect.go
+++ b/redirect.go
@@ -40,19 +40,19 @@ func (f RedirectPolicyFunc) Apply(req *http.Request, via []*http.Request) error 
 	return f(req, via)
 }
 
-// NoRedirectPolicy is used to disable the redirects in the Resty client
+// RedirectNoPolicy is used to disable the redirects in the Resty client
 //
-//	resty.SetRedirectPolicy(resty.NoRedirectPolicy())
-func NoRedirectPolicy() RedirectPolicy {
+//	resty.SetRedirectPolicy(resty.RedirectNoPolicy())
+func RedirectNoPolicy() RedirectPolicy {
 	return RedirectPolicyFunc(func(req *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
 	})
 }
 
-// FlexibleRedirectPolicy method is convenient for creating several redirect policies for Resty clients.
+// RedirectFlexiblePolicy method is convenient for creating several redirect policies for Resty clients.
 //
-//	resty.SetRedirectPolicy(FlexibleRedirectPolicy(20))
-func FlexibleRedirectPolicy(noOfRedirect int) RedirectPolicy {
+//	resty.SetRedirectPolicy(RedirectFlexiblePolicy(20))
+func RedirectFlexiblePolicy(noOfRedirect int) RedirectPolicy {
 	return RedirectPolicyFunc(func(req *http.Request, via []*http.Request) error {
 		if len(via) >= noOfRedirect {
 			return fmt.Errorf("resty: stopped after %d redirects", noOfRedirect)
@@ -62,11 +62,11 @@ func FlexibleRedirectPolicy(noOfRedirect int) RedirectPolicy {
 	})
 }
 
-// DomainCheckRedirectPolicy method is convenient for defining domain name redirect rules in Resty clients.
+// RedirectDomainCheckPolicy method is convenient for defining domain name redirect rules in Resty clients.
 // Redirect is allowed only for the host mentioned in the policy.
 //
-//	resty.SetRedirectPolicy(resty.DomainCheckRedirectPolicy("host1.com", "host2.org", "host3.net"))
-func DomainCheckRedirectPolicy(hostnames ...string) RedirectPolicy {
+//	resty.SetRedirectPolicy(resty.RedirectDomainCheckPolicy("host1.com", "host2.org", "host3.net"))
+func RedirectDomainCheckPolicy(hostnames ...string) RedirectPolicy {
 	hosts := make(map[string]bool)
 	for _, h := range hostnames {
 		hosts[strings.ToLower(h)] = true

--- a/request_test.go
+++ b/request_test.go
@@ -396,7 +396,7 @@ func TestForceContentTypeForGH276andGH240(t *testing.T) {
 	resp, err := c.R().
 		SetBody(map[string]any{"username": "testuser", "password": "testpass"}).
 		SetResult(AuthSuccess{}).
-		SetForceResponseContentType("application/json").
+		SetResponseForceContentType("application/json").
 		Post(ts.URL + "/login-json-html")
 
 	assertNil(t, err) // JSON response comes with incorrect content-type, we correct it with ForceContentType
@@ -775,7 +775,7 @@ func TestFormDataDisableWarn(t *testing.T) {
 
 	c := dcnl()
 	c.SetFormData(map[string]string{"zip_code": "00000", "city": "Los Angeles"}).
-		SetDisableWarn(true)
+		SetLoggerWarnLevel(true)
 	c.outputLogTo(io.Discard)
 
 	resp, err := c.R().
@@ -973,7 +973,7 @@ func TestHostCheckRedirectPolicy(t *testing.T) {
 	defer ts.Close()
 
 	c := dcnl().
-		SetRedirectPolicy(DomainCheckRedirectPolicy("127.0.0.1"))
+		SetRedirectPolicy(RedirectDomainCheckPolicy("127.0.0.1"))
 
 	_, err := c.R().Get(ts.URL + "/redirect-host-check-1")
 
@@ -1376,8 +1376,8 @@ func TestRequestSetPathParamAny(t *testing.T) {
 
 func TestRequestSetRawPathParamAny(t *testing.T) {
 	r := dcnldr().
-		SetRawPathParamAny("userId", 42).
-		SetRawPathParamAny("name", "john doe")
+		SetPathRawParamAny("userId", 42).
+		SetPathRawParamAny("name", "john doe")
 
 	assertEqual(t, "42", r.PathParams["userId"])
 	assertEqual(t, "john doe", r.PathParams["name"])
@@ -1390,13 +1390,13 @@ func TestOutputFileWithBaseDirAndRelativePath(t *testing.T) {
 
 	baseOutputDir := filepath.Join(getTestDataPath(), "dir-sample")
 	client := dcnl().
-		SetRedirectPolicy(FlexibleRedirectPolicy(10)).
-		SetOutputDirectory(baseOutputDir).
+		SetRedirectPolicy(RedirectFlexiblePolicy(10)).
+		SetResponseSaveDirectory(baseOutputDir).
 		SetDebug(true)
 
 	outputFilePath := "go-resty/test-img-success.png"
 	resp, err := client.R().
-		SetOutputFileName(outputFilePath).
+		SetResponseSaveFileName(outputFilePath).
 		Get(ts.URL + "/my-image.png")
 
 	assertError(t, err)
@@ -1409,8 +1409,8 @@ func TestOutputFileWithBaseDirAndRelativePath(t *testing.T) {
 }
 
 func TestOutputFileWithBaseDirError(t *testing.T) {
-	c := dcnl().SetRedirectPolicy(FlexibleRedirectPolicy(10)).
-		SetOutputDirectory(filepath.Join(getTestDataPath(), `go-resty\0`))
+	c := dcnl().SetRedirectPolicy(RedirectFlexiblePolicy(10)).
+		SetResponseSaveDirectory(filepath.Join(getTestDataPath(), `go-resty\0`))
 
 	_ = c
 }
@@ -1421,11 +1421,11 @@ func TestOutputPathDirNotExists(t *testing.T) {
 	defer cleanupFiles(filepath.Join(".testdata", "not-exists-dir"))
 
 	client := dcnl().
-		SetRedirectPolicy(FlexibleRedirectPolicy(10)).
-		SetOutputDirectory(filepath.Join(getTestDataPath(), "not-exists-dir"))
+		SetRedirectPolicy(RedirectFlexiblePolicy(10)).
+		SetResponseSaveDirectory(filepath.Join(getTestDataPath(), "not-exists-dir"))
 
 	resp, err := client.R().
-		SetOutputFileName("test-img-success.png").
+		SetResponseSaveFileName("test-img-success.png").
 		Get(ts.URL + "/my-image.png")
 
 	assertError(t, err)
@@ -1441,7 +1441,7 @@ func TestOutputFileAbsPath(t *testing.T) {
 	outputFile := filepath.Join(getTestDataPath(), "go-resty", "test-img-success-2.png")
 
 	res, err := dcnlr().
-		SetOutputFileName(outputFile).
+		SetResponseSaveFileName(outputFile).
 		Get(ts.URL + "/my-image.png")
 
 	assertError(t, err)
@@ -1457,18 +1457,18 @@ func TestRequestSaveResponse(t *testing.T) {
 	defer cleanupFiles(filepath.Join(".testdata", "go-resty"))
 
 	c := dcnl().
-		SetSaveResponse(true).
-		SetOutputDirectory(filepath.Join(getTestDataPath(), "go-resty"))
+		SetResponseSaveToFile(true).
+		SetResponseSaveDirectory(filepath.Join(getTestDataPath(), "go-resty"))
 
-	assertTrue(t, c.IsSaveResponse())
+	assertTrue(t, c.IsResponseSaveToFile())
 
 	t.Run("content-disposition save response request", func(t *testing.T) {
 		outputFile := filepath.Join(getTestDataPath(), "go-resty", "test-img-success-2.png")
-		c.SetSaveResponse(false)
-		assertFalse(t, c.IsSaveResponse())
+		c.SetResponseSaveToFile(false)
+		assertFalse(t, c.IsResponseSaveToFile())
 
 		res, err := c.R().
-			SetSaveResponse(true).
+			SetResponseSaveToFile(true).
 			Get(ts.URL + "/my-image.png?content-disposition=true&filename=test-img-success-2.png")
 
 		assertError(t, err)
@@ -1480,11 +1480,11 @@ func TestRequestSaveResponse(t *testing.T) {
 
 	t.Run("use filename from path", func(t *testing.T) {
 		outputFile := filepath.Join(getTestDataPath(), "go-resty", "my-image.png")
-		c.SetSaveResponse(false)
-		assertFalse(t, c.IsSaveResponse())
+		c.SetResponseSaveToFile(false)
+		assertFalse(t, c.IsResponseSaveToFile())
 
 		res, err := c.R().
-			SetSaveResponse(true).
+			SetResponseSaveToFile(true).
 			Get(ts.URL + "/my-image.png")
 
 		assertError(t, err)
@@ -1496,7 +1496,7 @@ func TestRequestSaveResponse(t *testing.T) {
 
 	t.Run("empty path", func(t *testing.T) {
 		_, err := c.R().
-			SetSaveResponse(true).
+			SetResponseSaveToFile(true).
 			Get(ts.URL)
 		assertError(t, err)
 	})
@@ -1521,7 +1521,7 @@ func TestRequestDoNotParseResponse(t *testing.T) {
 	defer ts.Close()
 
 	t.Run("do not parse response 1", func(t *testing.T) {
-		client := dcnl().SetDoNotParseResponse(true)
+		client := dcnl().SetResponseDoNotParse(true)
 		resp, err := client.R().
 			SetQueryParam("request_no", strconv.FormatInt(time.Now().Unix(), 10)).
 			Get(ts.URL + "/")
@@ -1536,7 +1536,7 @@ func TestRequestDoNotParseResponse(t *testing.T) {
 
 	t.Run("manual reset raw response - do not parse response 2", func(t *testing.T) {
 		resp, err := dcnl().R().
-			SetDoNotParseResponse(true).
+			SetResponseDoNotParse(true).
 			Get(ts.URL + "/")
 
 		assertError(t, err)
@@ -1553,7 +1553,7 @@ func TestRequestDoNotParseResponseDebugLog(t *testing.T) {
 
 	t.Run("do not parse response debug log client level", func(t *testing.T) {
 		c := dcnl().
-			SetDoNotParseResponse(true).
+			SetResponseDoNotParse(true).
 			SetDebug(true)
 
 		var lgr bytes.Buffer
@@ -1575,7 +1575,7 @@ func TestRequestDoNotParseResponseDebugLog(t *testing.T) {
 
 		_, err := c.R().
 			SetDebug(true).
-			SetDoNotParseResponse(true).
+			SetResponseDoNotParse(true).
 			SetQueryParam("request_no", strconv.FormatInt(time.Now().Unix(), 10)).
 			Get(ts.URL + "/")
 
@@ -1595,7 +1595,7 @@ func TestRequestExpectContentTypeTest(t *testing.T) {
 	c := dcnl()
 	resp, err := c.R().
 		SetResult(noCtTest{}).
-		SetExpectResponseContentType("application/json").
+		SetResponseExpectContentType("application/json").
 		Get(ts.URL + "/json-no-set")
 
 	assertError(t, err)
@@ -1683,7 +1683,7 @@ func TestRequestFileUploadAsReader(t *testing.T) {
 
 	c := dcnl()
 	c.SetRequestMiddlewares(
-		PrepareRequestMiddleware,
+		MiddlewareRequestCreate,
 		func(c *Client, r *Request) error {
 			// validate content length values
 			assertTrue(t, r.isContentLengthSet)
@@ -1809,7 +1809,7 @@ func TestRawPathParamURLInput(t *testing.T) {
 
 	c := dcnl().
 		SetBaseURL(ts.URL).
-		SetRawPathParams(map[string]string{
+		SetPathRawParams(map[string]string{
 			"userId": "sample@sample.com",
 			"path":   "users/developers",
 		})
@@ -1817,8 +1817,8 @@ func TestRawPathParamURLInput(t *testing.T) {
 	assertEqual(t, "sample@sample.com", c.PathParams()["userId"])
 	assertEqual(t, "users/developers", c.PathParams()["path"])
 
-	resp, err := c.R().EnableDebug().
-		SetRawPathParams(map[string]string{
+	resp, err := c.R().SetDebug(true).
+		SetPathRawParams(map[string]string{
 			"subAccountId": "100002",
 			"website":      "https://example.com",
 		}).Get("/v1/users/{userId}/{subAccountId}/{path}/{website}")
@@ -1841,7 +1841,7 @@ func TestTraceInfo(t *testing.T) {
 	client := dcnl()
 
 	t.Run("enable trace on client", func(t *testing.T) {
-		client.SetBaseURL(ts.URL).EnableTrace()
+		client.SetBaseURL(ts.URL).SetTrace(true)
 		for _, u := range []string{"/", "/json", "/long-text", "/long-json"} {
 			resp, err := client.R().Get(u)
 			assertNil(t, err)
@@ -1861,12 +1861,12 @@ func TestTraceInfo(t *testing.T) {
 			assertNotNil(t, tr.Clone())
 		}
 
-		client.DisableTrace()
+		client.SetTrace(false)
 	})
 
 	t.Run("enable trace on request", func(t *testing.T) {
 		for _, u := range []string{"/", "/json", "/long-text", "/long-json"} {
-			resp, err := client.R().EnableTrace().Get(u)
+			resp, err := client.R().SetTrace(true).Get(u)
 			assertNil(t, err)
 			assertNotNil(t, resp)
 
@@ -1884,7 +1884,7 @@ func TestTraceInfo(t *testing.T) {
 	})
 
 	t.Run("enable trace on invalid request, issue #1016", func(t *testing.T) {
-		resp, err := client.R().EnableTrace().Get("unknown://url.com")
+		resp, err := client.R().SetTrace(true).Get("unknown://url.com")
 		assertNotNil(t, err)
 		tr := resp.Request.TraceInfo()
 		assertTrue(t, tr.DNSLookup == 0)
@@ -1901,7 +1901,7 @@ func TestTraceInfo(t *testing.T) {
 
 		requestURLs := []string{"/", "/json", "/long-text", "/long-json"}
 		for _, u := range requestURLs {
-			resp, err := c.R().EnableTrace().EnableDebug().Get(u)
+			resp, err := c.R().SetTrace(true).SetDebug(true).Get(u)
 			assertNil(t, err)
 			assertNotNil(t, resp)
 
@@ -1922,7 +1922,7 @@ func TestTraceInfo(t *testing.T) {
 
 		requestURLs := []string{"/", "/json", "/long-text", "/long-json"}
 		for _, u := range requestURLs {
-			resp, err := c.R().EnableTrace().EnableDebug().Get(u)
+			resp, err := c.R().SetTrace(true).SetDebug(true).Get(u)
 			assertNil(t, err)
 			assertNotNil(t, resp)
 		}
@@ -1963,7 +1963,7 @@ func TestTraceInfoOnTimeout(t *testing.T) {
 		DialerTimeout: 100 * time.Millisecond,
 	}).
 		SetBaseURL("http://resty-nowhere.local").
-		EnableTrace()
+		SetTrace(true)
 
 	resp, err := client.R().Get("/")
 	assertNotNil(t, err)
@@ -1985,7 +1985,7 @@ func TestTraceInfoOnTimeoutWithSetTimeout(t *testing.T) {
 		client := New().
 			SetTimeout(1 * time.Millisecond).
 			SetBaseURL("http://resty-nowhere.local").
-			EnableTrace()
+			SetTrace(true)
 
 		resp, err := client.R().Get("/")
 		assertNotNil(t, err)
@@ -2010,7 +2010,7 @@ func TestTraceInfoOnTimeoutWithSetTimeout(t *testing.T) {
 		client := New().
 			SetTimeout(5 * time.Second).
 			SetBaseURL(ts.URL).
-			EnableTrace()
+			SetTrace(true)
 
 		resp, err := client.R().Get("/")
 		assertNil(t, err)
@@ -2038,7 +2038,7 @@ func TestTraceInfoOnTimeoutWithSetTimeout(t *testing.T) {
 		client := New().
 			SetTimeout(5 * time.Second).
 			SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}).
-			EnableTrace()
+			SetTrace(true)
 
 		resp, err := client.R().Get(ts.URL)
 		assertNil(t, err)
@@ -2188,7 +2188,7 @@ func TestRequestClone(t *testing.T) {
 	// set an non-interface value
 	parent.URL = ts.URL
 	parent.SetPathParam("name", "parent")
-	parent.SetRawPathParam("name", "parent")
+	parent.SetPathRawParam("name", "parent")
 	// set http header
 	parent.SetHeader("X-Header", "parent")
 	// set an interface value
@@ -2273,7 +2273,7 @@ func TestRequestAllowPayload(t *testing.T) {
 		result1 := r.isPayloadSupported()
 		assertFalse(t, result1)
 
-		r.SetAllowMethodGetPayload(true)
+		r.SetMethodGetAllowPayload(true)
 		result2 := r.isPayloadSupported()
 		assertTrue(t, result2)
 	})
@@ -2285,7 +2285,7 @@ func TestRequestAllowPayload(t *testing.T) {
 		result1 := r.isPayloadSupported()
 		assertFalse(t, result1)
 
-		r.SetAllowMethodGetPayload(true)
+		r.SetMethodGetAllowPayload(true)
 		result2 := r.isPayloadSupported()
 		assertTrue(t, result2)
 	})
@@ -2318,7 +2318,7 @@ func TestRequestAllowPayload(t *testing.T) {
 		result1 := r.isPayloadSupported()
 		assertFalse(t, result1)
 
-		r.SetAllowMethodDeletePayload(true)
+		r.SetMethodDeleteAllowPayload(true)
 		result2 := r.isPayloadSupported()
 		assertTrue(t, result2)
 	})
@@ -2446,7 +2446,7 @@ func TestRequestSetResultAndSetOutputFile(t *testing.T) {
 		SetBody(&credentials{Username: "testuser", Password: "testpass"}).
 		SetResponseBodyUnlimitedReads(true).
 		SetResult(&AuthSuccess{}).
-		SetOutputFileName(outputFile).
+		SetResponseSaveFileName(outputFile).
 		Post("/login")
 
 	assertError(t, err)
@@ -2468,7 +2468,7 @@ func TestRequestBodyContentLengthValidation(t *testing.T) {
 	c := dcnl().SetBaseURL(ts.URL)
 
 	c.SetRequestMiddlewares(
-		PrepareRequestMiddleware,
+		MiddlewareRequestCreate,
 		func(c *Client, r *Request) error {
 			// validate content length
 			assertTrue(t, r.contentLength > 0)
@@ -2567,36 +2567,36 @@ func TestRequestSettingsCoverage(t *testing.T) {
 	c := dcnl()
 
 	r1 := c.R()
-	assertFalse(t, r1.CloseConnection)
+	assertFalse(t, r1.IsCloseConnection)
 	r1.SetCloseConnection(true)
-	assertTrue(t, r1.CloseConnection)
+	assertTrue(t, r1.IsCloseConnection)
 
 	r2 := c.R()
 	assertFalse(t, r2.IsTrace)
-	r2.EnableTrace()
+	r2.SetTrace(true)
 	assertTrue(t, r2.IsTrace)
-	r2.DisableTrace()
+	r2.SetTrace(false)
 	assertFalse(t, r2.IsTrace)
 
 	r3 := c.R()
-	assertFalse(t, r3.ResponseBodyUnlimitedReads)
+	assertFalse(t, r3.IsResponseBodyUnlimitedReads)
 	r3.SetResponseBodyUnlimitedReads(true)
-	assertTrue(t, r3.ResponseBodyUnlimitedReads)
+	assertTrue(t, r3.IsResponseBodyUnlimitedReads)
 	r3.SetResponseBodyUnlimitedReads(false)
-	assertFalse(t, r3.ResponseBodyUnlimitedReads)
+	assertFalse(t, r3.IsResponseBodyUnlimitedReads)
 
 	r4 := c.R()
-	assertFalse(t, r4.Debug)
-	r4.EnableDebug()
-	assertTrue(t, r4.Debug)
-	r4.DisableDebug()
-	assertFalse(t, r4.Debug)
+	assertFalse(t, r4.IsDebug)
+	r4.SetDebug(true)
+	assertTrue(t, r4.IsDebug)
+	r4.SetDebug(false)
+	assertFalse(t, r4.IsDebug)
 
 	r5 := c.R()
 	assertTrue(t, r5.IsRetryDefaultConditions)
-	r5.DisableRetryDefaultConditions()
+	r5.SetRetryDefaultConditions(false)
 	assertFalse(t, r5.IsRetryDefaultConditions)
-	r5.EnableRetryDefaultConditions()
+	r5.SetRetryDefaultConditions(true)
 	assertTrue(t, r5.IsRetryDefaultConditions)
 
 	r6 := c.R()

--- a/response.go
+++ b/response.go
@@ -108,7 +108,7 @@ func (r *Response) Result() any {
 //
 // See [Request.SetResultError], [Client.SetResultError]
 func (r *Response) ResultError() any {
-	return r.Request.Error
+	return r.Request.ResultError
 }
 
 // Header method returns the response headers
@@ -133,7 +133,7 @@ func (r *Response) Cookies() []*http.Cookie {
 // NOTE:
 //   - Returns an empty string on auto-unmarshal scenarios, unless
 //     [Client.SetResponseBodyUnlimitedReads] or [Request.SetResponseBodyUnlimitedReads] set.
-//   - Returns an empty string when [Client.SetDoNotParseResponse] or [Request.SetDoNotParseResponse] set.
+//   - Returns an empty string when [Client.SetResponseDoNotParse] or [Request.SetResponseDoNotParse] set.
 func (r *Response) String() string {
 	r.readIfRequired()
 	return strings.TrimSpace(string(r.bodyBytes))
@@ -145,7 +145,7 @@ func (r *Response) String() string {
 // NOTE:
 //   - Returns an empty byte slice on auto-unmarshal scenarios, unless
 //     [Client.SetResponseBodyUnlimitedReads] or [Request.SetResponseBodyUnlimitedReads] set.
-//   - Returns an empty byte slice when [Client.SetDoNotParseResponse] or [Request.SetDoNotParseResponse] set.
+//   - Returns an empty byte slice when [Client.SetResponseDoNotParse] or [Request.SetResponseDoNotParse] set.
 func (r *Response) Bytes() []byte {
 	r.readIfRequired()
 	return r.bodyBytes
@@ -160,7 +160,7 @@ func (r *Response) Duration() time.Duration {
 	if r.Request.trace != nil {
 		return r.Request.TraceInfo().TotalTime
 	}
-	return r.receivedAt.Sub(r.Request.Time)
+	return r.receivedAt.Sub(r.Request.StartTime)
 }
 
 // ReceivedAt method returns the time we received a response from the server for the request.
@@ -219,11 +219,11 @@ func (r *Response) setReceivedAt() {
 }
 
 func (r *Response) fmtBodyString(sl int) string {
-	if r.Request.DoNotParseResponse {
+	if r.Request.IsResponseDoNotParse {
 		return "***** DO NOT PARSE RESPONSE - Enabled *****"
 	}
 
-	if r.Request.IsSaveResponse {
+	if r.Request.IsResponseSaveToFile {
 		return "***** RESPONSE WRITTEN INTO FILE *****"
 	}
 
@@ -256,7 +256,7 @@ func (r *Response) fmtBodyString(sl int) string {
 }
 
 func (r *Response) readIfRequired() {
-	if len(r.bodyBytes) == 0 && !r.Request.DoNotParseResponse {
+	if len(r.bodyBytes) == 0 && !r.Request.IsResponseDoNotParse {
 		_ = r.readAll()
 	}
 }

--- a/resty.go
+++ b/resty.go
@@ -200,13 +200,13 @@ func createClient(hc *http.Client) *Client {
 
 	// request middlewares
 	c.SetRequestMiddlewares(
-		PrepareRequestMiddleware,
+		MiddlewareRequestCreate,
 	)
 
 	// response middlewares
 	c.SetResponseMiddlewares(
-		AutoParseResponseMiddleware,
-		SaveToFileResponseMiddleware,
+		MiddlewareResponseAutoParse,
+		MiddlewareResponseSaveToFile,
 	)
 
 	return c

--- a/resty_test.go
+++ b/resty_test.go
@@ -920,13 +920,13 @@ func dcnl() *Client {
 }
 
 func dcnld() *Client {
-	return dcnl().EnableDebug()
+	return dcnl().SetDebug(true)
 }
 
 func dcldb() (*Client, *bytes.Buffer) {
 	logBuf := acquireBuffer()
 	c := New().
-		EnableDebug().
+		SetDebug(true).
 		outputLogTo(logBuf)
 	return c, logBuf
 }

--- a/sse_test.go
+++ b/sse_test.go
@@ -25,7 +25,7 @@ func TestEventSourceSimpleFlow(t *testing.T) {
 
 	messageCounter := 0
 	messageFunc := func(e any) {
-		event := e.(*Event)
+		event := e.(*SSE)
 		assertEqual(t, strconv.Itoa(messageCounter), event.ID)
 		assertTrue(t, strings.HasPrefix(event.Data, "The time is"))
 		messageCounter++
@@ -138,7 +138,7 @@ func TestEventSourceOverwriteFuncs(t *testing.T) {
 
 	message2Counter := 0
 	messageFunc2 := func(e any) {
-		event := e.(*Event)
+		event := e.(*SSE)
 		assertEqual(t, strconv.Itoa(message2Counter), event.ID)
 		assertTrue(t, strings.HasPrefix(event.Data, "The time is"))
 		message2Counter++
@@ -189,7 +189,7 @@ func TestEventSourceRetry(t *testing.T) {
 
 	messageCounter := 2 // 0 & 1 connection failure
 	messageFunc := func(e any) {
-		event := e.(*Event)
+		event := e.(*SSE)
 		assertEqual(t, strconv.Itoa(messageCounter), event.ID)
 		assertTrue(t, strings.HasPrefix(event.Data, "The time is"))
 		messageCounter++
@@ -404,7 +404,7 @@ func TestEventSourceParseAndReadError(t *testing.T) {
 	assertNil(t, err)
 
 	// parse error
-	parseEvent = func(_ []byte) (*rawEvent, error) {
+	parseEvent = func(_ []byte) (*rawSSE, error) {
 		return nil, errors.New("test error")
 	}
 	counter = 0
@@ -475,7 +475,7 @@ func TestEventSourceWithDifferentMethods(t *testing.T) {
 
 			messageCounter := 0
 			messageFunc := func(e any) {
-				event := e.(*Event)
+				event := e.(*SSE)
 				assertEqual(t, strconv.Itoa(messageCounter), event.ID)
 				assertTrue(t, strings.HasPrefix(event.Data, fmt.Sprintf("%s method test:", tc.method)))
 				messageCounter++
@@ -590,7 +590,7 @@ func TestEventSource_readEventFunc(t *testing.T) {
 }
 
 func TestEventSourceCoverage(t *testing.T) {
-	es := NewEventSource()
+	es := NewSSESource()
 	err1 := es.Get()
 	assertEqual(t, "resty:sse: event source URL is required", err1.Error())
 
@@ -608,8 +608,8 @@ func TestEventSourceCoverage(t *testing.T) {
 	parseEvent([]byte{})
 }
 
-func createEventSource(t *testing.T, url string, fn EventMessageFunc, rt any) *EventSource {
-	es := NewEventSource().
+func createEventSource(t *testing.T, url string, fn SSEMessageFunc, rt any) *SSESource {
+	es := NewSSESource().
 		SetURL(url).
 		SetMethod(MethodGet).
 		AddHeader("X-Test-Header-1", "test header 1").
@@ -617,7 +617,7 @@ func createEventSource(t *testing.T, url string, fn EventMessageFunc, rt any) *E
 		SetRetryCount(2).
 		SetRetryWaitTime(200 * time.Millisecond).
 		SetRetryMaxWaitTime(1000 * time.Millisecond).
-		SetMaxBufSize(1 << 14). // 16kb
+		SetSizeMaxBuffer(1 << 14). // 16kb
 		SetLogger(createLogger()).
 		OnOpen(func(url string, respHdr http.Header) {
 			t.Log("I'm connected:", url, respHdr)

--- a/stream_test.go
+++ b/stream_test.go
@@ -29,13 +29,13 @@ func TestGetMethodWhenResponseIsNull(t *testing.T) {
 		w.Write([]byte("null"))
 	}))
 
-	client := New().SetRetryCount(3).EnableGenerateCurlCmd()
+	client := New().SetRetryCount(3).SetCurlCmdGenerate(true)
 
 	var x any
 	resp, err := client.R().SetBody("{}").
 		SetHeader("Content-Type", "application/json; charset=utf-8").
-		SetForceResponseContentType("application/json").
-		SetAllowMethodGetPayload(true).
+		SetResponseForceContentType("application/json").
+		SetMethodGetAllowPayload(true).
 		SetResponseBodyUnlimitedReads(true).
 		SetResult(&x).
 		Get(server.URL + "/test")
@@ -195,7 +195,7 @@ func TestGzipReaderPanicOnConcurrentCorruptedBody(t *testing.T) {
 
 				var out map[string]any
 				client.R().
-					SetAllowNonIdempotentRetry(true).
+					SetRetryAllowNonIdempotent(true).
 					SetResult(&out).
 					Post(server.URL)
 			}()


### PR DESCRIPTION
…of related functionality and feature methods by applying an appropriate method prefix.

This approach helps Resty v3 users with IntelliSense usage.

- Boolean methods should use the IsXXX naming convention.
- Setter methods should have a common prefix related to the functionality. It helps to organize methods together for IntelliSense usage.
  - Examples:
  - SetMethodXXX
  - SetResponseXXX
  - SetRetryXXX
  - etc.
- Each boolean method should have a corresponding setter method.
- Remove the non-frequently used EnableXXX and DisableXXX methods to align as much as possible with the setter-based builder pattern for Client and Request.

closes #1100 