### PR TITLE
chore: update Go version to 1.25.0 and upgrade golang.org/x/net to v0…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,17 @@ on:
     branches:
       - v2
     paths-ignore:
-      - '**.md'
-      - '**.bazel'
-      - 'WORKSPACE'
+      - "**.md"
+      - "**.bazel"
+      - "WORKSPACE"
   pull_request:
     branches:
       - main
       - v2
     paths-ignore:
-      - '**.md'
-      - '**.bazel'
-      - 'WORKSPACE'
+      - "**.md"
+      - "**.bazel"
+      - "WORKSPACE"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -25,8 +25,8 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go: [ 'stable', '1.23.x' ]
-        os: [ ubuntu-latest ]
+        go: ["stable", "1.25.x"]
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -1,19 +1,19 @@
-name: 'Label'
+name: "Label"
 
 on:
   pull_request:
     types: [labeled]
     paths-ignore:
-      - '**.md'
-      - '**.bazel'
-      - 'WORKSPACE'
+      - "**.md"
+      - "**.bazel"
+      - "WORKSPACE"
 
 jobs:
   build:
     strategy:
       matrix:
-        go: [ 'stable', '1.23.x' ]
-        os: [ ubuntu-latest ]
+        go: ["stable", "1.25.x"]
+        os: [ubuntu-latest]
 
     name: Run Build
     if: ${{ github.event.label.name == 'run-build' }}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/go-resty/resty/v2
 
-go 1.23.0
+go 1.25.0
 
 require (
-	golang.org/x/net v0.43.0
+	golang.org/x/net v0.51.0
 	golang.org/x/time v0.12.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
-golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
+golang.org/x/net v0.51.0 h1:94R/GTO7mt3/4wIKpcR5gkGmRLOuE/2hNGeWq/GBIFo=
+golang.org/x/net v0.51.0/go.mod h1:aamm+2QF5ogm02fjy5Bb7CQ0WMt1/WVM7FtyaTLlA9Y=
 golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
 golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=


### PR DESCRIPTION
fixed: vulnerabilities: 	
[GO-2026-4441]Infinite parsing loop in golang.org/x/net
golang.org/x/net/html Fixed in v0.45.0.
[GO-2026-4559] Sending certain HTTP/2 frames can cause a server to panic in golang.org/x/net
golang.org/x/net/http2 Fixed in v0.51.0.