### PR TITLE
Add SetLabel() to be discoverable to metrics

### DIFF
--- a/request.go
+++ b/request.go
@@ -73,6 +73,7 @@ type Request struct {
 	RetryDelayStrategy           RetryDelayStrategyFunc
 	IsRetryDefaultConditions     bool
 	IsRetryAllowNonIdempotent    bool
+	Label                        string
 
 	// Attempt provides insights into no. of attempts
 	// Resty made.
@@ -1291,6 +1292,18 @@ func (r *Request) SetMethodGetAllowPayload(allow bool) *Request {
 // It overrides the option set by the [Client.SetMethodDeleteAllowPayload]
 func (r *Request) SetMethodDeleteAllowPayload(allow bool) *Request {
 	r.IsMethodDeleteAllowPayload = allow
+	return r
+}
+
+// SetLabel method sets the label for the request, which can be used for logging and debugging purposes.
+// By default, the label is empty.
+//
+//  client.R().SetLabel("GetUserDetails").Get("/users/12345")
+//
+// In Response middlewares, you can access the label using [Response.Request.Label]
+// Then log the label along with time duration and method to get better insights into the request lifecycle.
+func (r *Request) SetLabel(label string) *Request {
+	r.Label = label
 	return r
 }
 

--- a/request.go
+++ b/request.go
@@ -1300,7 +1300,7 @@ func (r *Request) SetMethodDeleteAllowPayload(allow bool) *Request {
 // SetLabel method sets the label for the request, which can be used for logging and debugging purposes.
 // By default, the label is empty.
 //
-//  client.R().SetLabel("GetUserDetails").Get("/users/12345")
+//	client.R().SetLabel("GetUserDetails").Get("/users/12345")
 //
 // In Response middlewares, you can access the label using [Response.Request.Label]
 // Then log the label along with time duration and method to get better insights into the request lifecycle.

--- a/request_test.go
+++ b/request_test.go
@@ -2665,4 +2665,3 @@ func TestRequestSetLabel(t *testing.T) {
 
 	assertEqual(t, "AddUser", r.Label)
 }
-

--- a/request_test.go
+++ b/request_test.go
@@ -2657,3 +2657,12 @@ func TestRequestDataRace(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestRequestSetLabel(t *testing.T) {
+	c := New()
+	r := c.R().
+		SetLabel("AddUser")
+
+	assertEqual(t, "AddUser", r.Label)
+}
+


### PR DESCRIPTION
Adding `request.SetLabel()`. The idea is to read that label in `responseMiddleware` and emit Prometheus histogram metrics with the request duration and label.

Many of the URLs include dynamic path segments, so using the raw URL would introduce high-cardinality metrics which increase cost.

https://github.com/go-resty/resty/discussions/1122 for the discussion