### PR TITLE
feat: add ReaderFactory for non-seekable multipart reader retry

### DIFF
--- a/multipart.go
+++ b/multipart.go
@@ -7,6 +7,7 @@ package resty
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,6 +18,15 @@ import (
 )
 
 var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+
+// ErrReaderNotSeekable is returned when a multipart field reader
+// does not implement [io.ReadSeeker] and no [ReaderFactory] is provided.
+// This prevents silent data corruption during retry attempts where a
+// consumed [io.Reader] would produce an empty or truncated body.
+var ErrReaderNotSeekable = errors.New(
+	"resty: multipart reader is not seekable and no factory provided; " +
+		"use resty.NewMultipartFieldFromFactory for retry support with non-seekable readers",
+)
 
 // ReaderFactory is an interface for creating fresh [io.Reader] instances
 // per retry attempt. This is useful for non-seekable readers (cipher streams,
@@ -124,7 +134,7 @@ func (mf *MultipartField) resetReader() error {
 		return err
 	}
 
-	return nil
+	return ErrReaderNotSeekable
 }
 
 func (mf *MultipartField) isValues() bool {

--- a/multipart.go
+++ b/multipart.go
@@ -6,6 +6,7 @@
 package resty
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,21 @@ import (
 )
 
 var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+
+// ReaderFactory is an interface for creating fresh [io.Reader] instances
+// per retry attempt. This is useful for non-seekable readers (cipher streams,
+// network pipes, etc.) that cannot be reset via [io.ReadSeeker].
+//
+// See [NewMultipartFieldFromFactory], [BytesReaderFactory], [StringReaderFactory].
+type ReaderFactory interface {
+	NewReader() io.Reader
+}
+
+// LenReaderFactory is an optional interface that ReaderFactory implementations
+// can implement to provide content length.
+type LenReaderFactory interface {
+	Len() int64
+}
 
 func escapeQuotes(s string) string {
 	return quoteEscaper.Replace(s)
@@ -60,6 +76,12 @@ type MultipartField struct {
 	// It is primarily added for ordered multipart form-data field use cases
 	Values []string
 
+	// Factory is used to create a fresh io.Reader for each retry attempt.
+	// This is required for non-seekable readers (e.g., cipher streams, network pipes).
+	// When Factory is set, Reader is ignored and Factory.NewReader() is called
+	// for each retry attempt.
+	Factory ReaderFactory
+
 	// tempBuf is used to preserve the byte(s) read from the file to detect the content type.
 	// Or any possible read error early.
 	tempBuf []byte
@@ -72,11 +94,36 @@ func (mf *MultipartField) Clone() *MultipartField {
 	return mf2
 }
 
+// NewMultipartFieldFromFactory creates a [MultipartField] with a [ReaderFactory]
+// for retry support with non-seekable readers.
+//
+// When Factory is set, [ReaderFactory.NewReader] is called to obtain a fresh
+// [io.Reader] for each attempt (initial + retries).
+func NewMultipartFieldFromFactory(name, fileName, contentType string, factory ReaderFactory) *MultipartField {
+	return &MultipartField{
+		Name:        name,
+		FileName:    fileName,
+		ContentType: contentType,
+		Factory:     factory,
+	}
+}
+
 func (mf *MultipartField) resetReader() error {
+	if mf.Factory != nil {
+		mf.close()
+		mf.Reader = mf.Factory.NewReader()
+		return nil
+	}
+
+	if mf.Reader == nil {
+		return nil
+	}
+
 	if rs, ok := mf.Reader.(io.ReadSeeker); ok {
 		_, err := rs.Seek(0, io.SeekStart)
 		return err
 	}
+
 	return nil
 }
 
@@ -193,4 +240,38 @@ func (mpw *multipartProgressWriter) Write(p []byte) (n int, err error) {
 	mpw.pb += int64(n)
 	mpw.f(mpw.pb)
 	return
+}
+
+type BytesReaderFactory struct {
+	data []byte
+}
+
+// NewBytesReaderFactory creates a BytesReaderFactory from a byte slice.
+func NewBytesReaderFactory(data []byte) *BytesReaderFactory {
+	return &BytesReaderFactory{data: data}
+}
+
+func (f *BytesReaderFactory) NewReader() io.Reader {
+	return bytes.NewReader(f.data)
+}
+
+func (f *BytesReaderFactory) Len() int64 {
+	return int64(len(f.data))
+}
+
+type StringReaderFactory struct {
+	data string
+}
+
+// NewStringReaderFactory creates a StringReaderFactory from a string.
+func NewStringReaderFactory(data string) *StringReaderFactory {
+	return &StringReaderFactory{data: data}
+}
+
+func (f *StringReaderFactory) NewReader() io.Reader {
+	return strings.NewReader(f.data)
+}
+
+func (f *StringReaderFactory) Len() int64 {
+	return int64(len(f.data))
 }

--- a/multipart_test.go
+++ b/multipart_test.go
@@ -719,7 +719,7 @@ func TestMultipartCornerCoverage(t *testing.T) {
 		Reader: bytes.NewBufferString("I have no seek capability"),
 	}
 	err := mf.resetReader()
-	assertNil(t, err)
+	assertEqual(t, ErrReaderNotSeekable, err)
 
 	mf = &MultipartField{
 		Name:   "foo",
@@ -941,5 +941,31 @@ func TestStringReaderFactoryLen(t *testing.T) {
 	factory := NewStringReaderFactory(content)
 
 	assertEqual(t, int64(len(content)), factory.Len())
+}
+
+func TestRetryNonSeekableReaderWithoutFactoryReturnsError(t *testing.T) {
+	attemptCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attemptCount++
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	client := dcnl()
+	_, err := client.R().
+		SetRetryCount(2).
+		SetRetryWaitTime(10 * time.Millisecond).
+		SetRetryAllowNonIdempotent(true).
+		SetMultipartFields(&MultipartField{
+			Name:        "file",
+			FileName:    "test.txt",
+			ContentType: "text/plain",
+			Reader:      bytes.NewBufferString("non-seekable"),
+		}).
+		Post(srv.URL)
+
+	assertErrorIs(t, ErrReaderNotSeekable, err)
+	assertEqual(t, 1, attemptCount)
 }
 

--- a/multipart_test.go
+++ b/multipart_test.go
@@ -9,9 +9,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"io/fs"
 	"mime/multipart"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -719,9 +721,225 @@ func TestMultipartCornerCoverage(t *testing.T) {
 	err := mf.resetReader()
 	assertNil(t, err)
 
+	mf = &MultipartField{
+		Name:   "foo",
+		Reader: bytes.NewReader([]byte("I have seek capability")),
+	}
+	err = mf.resetReader()
+	assertNil(t, err)
+
+	mf = &MultipartField{
+		Name:    "foo",
+		Factory: NewBytesReaderFactory([]byte("factory content")),
+	}
+	err = mf.resetReader()
+	assertNil(t, err)
+	assertNotNil(t, mf.Reader)
+
 	// wrap test writer to return 0 written value
 	mpw := multipartProgressWriter{w: &returnValueTestWriter{}}
 	n, err := mpw.Write([]byte("test return value"))
 	assertNil(t, err)
 	assertEqual(t, 0, n)
 }
+
+func TestBytesReaderFactory(t *testing.T) {
+	content := []byte("test content for factory")
+	factory := NewBytesReaderFactory(content)
+
+	reader1 := factory.NewReader()
+	assertNotNil(t, reader1)
+
+	reader2 := factory.NewReader()
+	assertNotNil(t, reader2)
+
+	data1, _ := io.ReadAll(reader1)
+	data2, _ := io.ReadAll(reader2)
+
+	assertEqual(t, content, data1)
+	assertEqual(t, content, data2)
+}
+
+func TestBytesReaderFactoryLen(t *testing.T) {
+	content := []byte("test content")
+	factory := NewBytesReaderFactory(content)
+
+	assertEqual(t, int64(len(content)), factory.Len())
+}
+
+func TestStringReaderFactory(t *testing.T) {
+	content := "test string content"
+	factory := NewStringReaderFactory(content)
+
+	reader1 := factory.NewReader()
+	assertNotNil(t, reader1)
+
+	reader2 := factory.NewReader()
+	assertNotNil(t, reader2)
+
+	data1, _ := io.ReadAll(reader1)
+	data2, _ := io.ReadAll(reader2)
+
+	assertEqual(t, []byte(content), data1)
+	assertEqual(t, []byte(content), data2)
+}
+
+type trackingReader struct {
+	data      []byte
+	readCount int
+	closed    bool
+}
+
+func (r *trackingReader) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data)
+	r.readCount++
+	return n, nil
+}
+
+func (r *trackingReader) Close() error {
+	r.closed = true
+	return nil
+}
+
+func TestResetReaderWithFactoryClosesOld(t *testing.T) {
+	original := &trackingReader{data: []byte("original data")}
+	factory := NewBytesReaderFactory([]byte("new data"))
+
+	mf := &MultipartField{
+		Name:    "test",
+		Reader:  original,
+		Factory: factory,
+	}
+
+	err := mf.resetReader()
+	assertNil(t, err)
+	assertTrue(t, original.closed, "original reader should be closed")
+
+	data, _ := io.ReadAll(mf.Reader)
+	assertEqual(t, []byte("new data"), data)
+}
+
+func TestResetReaderNilReader(t *testing.T) {
+	mf := &MultipartField{
+		Name: "test",
+	}
+
+	err := mf.resetReader()
+	assertNil(t, err)
+}
+
+func TestNewMultipartFieldFromFactory(t *testing.T) {
+	factory := NewBytesReaderFactory([]byte("test"))
+	mf := NewMultipartFieldFromFactory("field", "filename.txt", "application/octet-stream", factory)
+
+	assertEqual(t, "field", mf.Name)
+	assertEqual(t, "filename.txt", mf.FileName)
+	assertEqual(t, "application/octet-stream", mf.ContentType)
+	assertEqual(t, factory, mf.Factory)
+	assertNil(t, mf.Reader)
+}
+
+func TestCustomReaderFactory(t *testing.T) {
+	factory := &customFactory{data: "factory data"}
+
+	mf := NewMultipartFieldFromFactory("test", "file.txt", "text/plain", factory)
+	err := mf.resetReader()
+	assertNil(t, err)
+	assertNotNil(t, mf.Reader)
+
+	data, _ := io.ReadAll(mf.Reader)
+	assertEqual(t, []byte("factory data"), data)
+
+	err = mf.resetReader()
+	assertNil(t, err)
+	data2, _ := io.ReadAll(mf.Reader)
+	assertEqual(t, []byte("factory data"), data2)
+}
+
+type customFactory struct {
+	data string
+}
+
+func (f *customFactory) NewReader() io.Reader {
+	return strings.NewReader(f.data)
+}
+
+func TestRetryWithBytesReaderFactory(t *testing.T) {
+	attemptCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attemptCount++
+		body, _ := io.ReadAll(r.Body)
+		assertTrue(t, len(body) > 0, "body should not be empty")
+		if attemptCount == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	factory := NewBytesReaderFactory([]byte("factory content"))
+
+	client := dcnl()
+	resp, err := client.R().
+		SetRetryCount(2).
+		SetRetryWaitTime(10 * time.Millisecond).
+		SetRetryAllowNonIdempotent(true).
+		SetMultipartFields(
+			NewMultipartFieldFromFactory("file", "test.txt", "application/octet-stream", factory),
+		).
+		Post(srv.URL)
+
+	assertNil(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
+	assertEqual(t, 2, attemptCount)
+}
+
+func TestRetryWithFactoryMiddlewareSeesFreshReader(t *testing.T) {
+	attemptCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attemptCount++
+		if attemptCount == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	middlewareCalled := 0
+	factory := NewBytesReaderFactory([]byte("test data"))
+
+	client := dcnl()
+	client.AddRequestMiddleware(func(c *Client, r *Request) error {
+		middlewareCalled++
+		return nil
+	})
+
+	resp, err := client.R().
+		SetRetryCount(1).
+		SetRetryWaitTime(10 * time.Millisecond).
+		SetRetryAllowNonIdempotent(true).
+		SetMultipartFields(
+			NewMultipartFieldFromFactory("file", "test.txt", "application/octet-stream", factory),
+		).
+		Post(srv.URL)
+
+	assertNil(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
+	assertEqual(t, 2, middlewareCalled, "middleware should be called for each attempt")
+	assertEqual(t, 2, attemptCount)
+}
+
+func TestStringReaderFactoryLen(t *testing.T) {
+	content := "test content"
+	factory := NewStringReaderFactory(content)
+
+	assertEqual(t, int64(len(content)), factory.Len())
+}
+

--- a/request.go
+++ b/request.go
@@ -1474,6 +1474,12 @@ func (r *Request) Execute(method, url string) (res *Response, err error) {
 	}
 
 	isInvalidRequestErr := false
+
+	// Initialize readers from factory before first attempt.
+	// This only creates the initial reader from factory; it does NOT
+	// try to seek existing readers (which would break bytes.Buffer usage).
+	r.initFileReadersFromFactory()
+
 	// first attempt + retry count = total attempts
 	for i := 0; i <= r.RetryCount; i++ {
 		r.Attempt++
@@ -1829,6 +1835,14 @@ func (r *Request) resetFileReaders() error {
 		}
 	}
 	return nil
+}
+
+func (r *Request) initFileReadersFromFactory() {
+	for _, f := range r.multipartFields {
+		if f.Factory != nil && f.Reader == nil {
+			f.Reader = f.Factory.NewReader()
+		}
+	}
 }
 
 // https://datatracker.ietf.org/doc/html/rfc9110.html#name-idempotent-methods


### PR DESCRIPTION
## Summary

- Add `ReaderFactory` interface for multipart fields that creates a fresh `io.Reader` per retry attempt, solving the non-seekable reader retry gap (#770, #334)
- Add `ErrReaderNotSeekable` sentinel error so non-seekable readers without a factory fail loudly instead of silently sending corrupt bodies on retry

## Motivation

PR #549 added `io.ReadSeeker` support for resetting multipart readers on retry. However, non-seekable readers (cipher streams, network pipes, compression wrappers) had no solution — `resetReader()` silently returned `nil`, causing retried requests to send empty or truncated bodies.

## New APIs

- `ReaderFactory` interface: single `NewReader() io.Reader` method
- `LenReaderFactory` interface: optional `Len() int64` for content length
- `BytesReaderFactory`, `StringReaderFactory`: built-in implementations (both implement `LenReaderFactory`)
- `NewMultipartFieldFromFactory(name, fileName, contentType, factory)`: constructor
- `MultipartField.Factory` field: set directly or via constructor
- `ErrReaderNotSeekable`: returned when a non-seekable reader has no factory (**breaking change** — previously returned `nil`)

## Breaking change

`resetReader()` now returns `ErrReaderNotSeekable` instead of `nil` for readers that don't implement `io.ReadSeeker` and have no `Factory` set. Code that passes `bytes.Buffer` or similar non-seekable readers with retries will now get an explicit error. The fix is to either:
1. Use `io.ReadSeeker` (e.g. `bytes.Reader` instead of `bytes.Buffer`), or
2. Use `NewMultipartFieldFromFactory` with a `ReaderFactory`

This is intentionally split into two commits for reviewability.

## Test plan

- [x] Unit tests for `BytesReaderFactory`, `StringReaderFactory`, `LenReaderFactory`
- [x] Unit test for `resetReader()` with factory (closes old reader, creates fresh one)
- [x] Unit test for custom `ReaderFactory` implementation
- [x] Integration test: retry with factory produces non-empty body on each attempt
- [x] Integration test: middleware called for each attempt with factory
- [x] Integration test: `ErrReaderNotSeekable` propagates through retry loop to caller
- [x] Full existing test suite passes

Fixes #770
Related: #334, #549