### PR TITLE
fix: return error for non-seekable readers without factory on retry

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -16,14 +16,14 @@ func Benchmark_parseRequestURL_PathParams(b *testing.B) {
 	c := New().SetPathParams(map[string]string{
 		"foo": "1",
 		"bar": "2",
-	}).SetRawPathParams(map[string]string{
+	}).SetPathRawParams(map[string]string{
 		"foo": "3",
 		"xyz": "4",
 	})
 	r := c.R().SetPathParams(map[string]string{
 		"foo": "5",
 		"qwe": "6",
-	}).SetRawPathParams(map[string]string{
+	}).SetPathRawParams(map[string]string{
 		"foo": "7",
 		"asd": "8",
 	})

--- a/client.go
+++ b/client.go
@@ -169,65 +169,65 @@ type TransportSettings struct {
 // Resty also provides an option to override most of the client settings
 // at [Request] level.
 type Client struct {
-	lock                     *sync.RWMutex
-	baseURL                  string
-	queryParams              url.Values
-	formData                 url.Values
-	pathParams               map[string]string
-	header                   http.Header
-	credentials              *credentials
-	authToken                string
-	authScheme               string
-	cookies                  []*http.Cookie
-	errorType                reflect.Type
-	debug                    bool
-	disableWarn              bool
-	allowMethodGetPayload    bool
-	allowMethodDeletePayload bool
-	timeout                  time.Duration
-	retryCount               int
-	retryWaitTime            time.Duration
-	retryMaxWaitTime         time.Duration
-	retryConditions          []RetryConditionFunc
-	retryHooks               []RetryHookFunc
-	retryDelayStrategy       RetryDelayStrategyFunc
-	isRetryDefaultConditions bool
-	allowNonIdempotentRetry  bool
-	headerAuthorizationKey   string
-	responseBodyLimit        int64
-	resBodyUnlimitedReads    bool
-	jsonEscapeHTML           bool
-	closeConnection          bool
-	notParseResponse         bool
-	isTrace                  bool
-	debugBodyLimit           int
-	outputDirectory          string
-	isSaveResponse           bool
-	scheme                   string
-	log                      Logger
-	ctx                      context.Context
-	httpClient               *http.Client
-	proxyURL                 *url.URL
-	debugLogFormatter        DebugLogFormatterFunc
-	debugLogCallback         DebugLogCallbackFunc
-	generateCurlCmd          bool
-	debugLogCurlCmd          bool
-	unescapeQueryParams      bool
-	loadBalancer             LoadBalancer
-	beforeRequest            []RequestMiddleware
-	afterResponse            []ResponseMiddleware
-	errorHooks               []ErrorHook
-	invalidHooks             []ErrorHook
-	panicHooks               []ErrorHook
-	successHooks             []SuccessHook
-	closeHooks               []CloseHook
-	contentTypeEncoders      map[string]ContentTypeEncoder
-	contentTypeDecoders      map[string]ContentTypeDecoder
-	contentDecompresserKeys  []string
-	contentDecompressers     map[string]ContentDecompresser
-	certWatcherStopChan      chan bool
-	circuitBreaker           *CircuitBreaker
-	hedging                  *hedgingConfig
+	lock                       *sync.RWMutex
+	baseURL                    string
+	queryParams                url.Values
+	formData                   url.Values
+	pathParams                 map[string]string
+	header                     http.Header
+	credentials                *credentials
+	authToken                  string
+	authScheme                 string
+	cookies                    []*http.Cookie
+	errorType                  reflect.Type
+	debug                      bool
+	disableWarn                bool
+	isMethodGetAllowPayload    bool
+	isMethodDeleteAllowPayload bool
+	timeout                    time.Duration
+	retryCount                 int
+	retryWaitTime              time.Duration
+	retryMaxWaitTime           time.Duration
+	retryConditions            []RetryConditionFunc
+	retryHooks                 []RetryHookFunc
+	retryDelayStrategy         RetryDelayStrategyFunc
+	isRetryDefaultConditions   bool
+	isRetryAllowNonIdempotent  bool
+	headerAuthorizationKey     string
+	responseBodyLimit          int64
+	resBodyUnlimitedReads      bool
+	jsonEscapeHTML             bool
+	closeConnection            bool
+	isResponseDoNotParse       bool
+	isTrace                    bool
+	debugBodyLimit             int
+	responseSaveDirectory      string
+	isResponseSaveToFile       bool
+	scheme                     string
+	log                        Logger
+	ctx                        context.Context
+	httpClient                 *http.Client
+	proxyURL                   *url.URL
+	debugLogFormatter          DebugLogFormatterFunc
+	debugLogCallback           DebugLogCallbackFunc
+	isCurlCmdGenerate          bool
+	isCurlCmdDebugLog          bool
+	unescapeQueryParams        bool
+	loadBalancer               LoadBalancer
+	beforeRequest              []RequestMiddleware
+	afterResponse              []ResponseMiddleware
+	errorHooks                 []ErrorHook
+	invalidHooks               []ErrorHook
+	panicHooks                 []ErrorHook
+	successHooks               []SuccessHook
+	closeHooks                 []CloseHook
+	contentTypeEncoders        map[string]ContentTypeEncoder
+	contentTypeDecoders        map[string]ContentTypeDecoder
+	contentDecompresserKeys    []string
+	contentDecompressers       map[string]ContentDecompresser
+	certWatcherStopChan        chan bool
+	circuitBreaker             *CircuitBreaker
+	hedging                    *hedgingConfig
 }
 
 // CertWatcherOptions allows configuring a watcher that reloads dynamically TLS certs.
@@ -685,31 +685,31 @@ func (c *Client) R() *Request {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	r := &Request{
-		QueryParams:                url.Values{},
-		FormData:                   url.Values{},
-		Header:                     http.Header{},
-		Cookies:                    make([]*http.Cookie, 0),
-		PathParams:                 make(map[string]string),
-		Timeout:                    c.timeout,
-		Debug:                      c.debug,
-		IsTrace:                    c.isTrace,
-		IsSaveResponse:             c.isSaveResponse,
-		AuthScheme:                 c.authScheme,
-		AuthToken:                  c.authToken,
-		RetryCount:                 c.retryCount,
-		RetryWaitTime:              c.retryWaitTime,
-		RetryMaxWaitTime:           c.retryMaxWaitTime,
-		RetryDelayStrategy:         c.retryDelayStrategy,
-		IsRetryDefaultConditions:   c.isRetryDefaultConditions,
-		CloseConnection:            c.closeConnection,
-		DoNotParseResponse:         c.notParseResponse,
-		DebugBodyLimit:             c.debugBodyLimit,
-		ResponseBodyLimit:          c.responseBodyLimit,
-		ResponseBodyUnlimitedReads: c.resBodyUnlimitedReads,
-		AllowMethodGetPayload:      c.allowMethodGetPayload,
-		AllowMethodDeletePayload:   c.allowMethodDeletePayload,
-		AllowNonIdempotentRetry:    c.allowNonIdempotentRetry,
-		HeaderAuthorizationKey:     c.headerAuthorizationKey,
+		QueryParams:                  url.Values{},
+		FormData:                     url.Values{},
+		Header:                       http.Header{},
+		Cookies:                      make([]*http.Cookie, 0),
+		PathParams:                   make(map[string]string),
+		Timeout:                      c.timeout,
+		IsDebug:                      c.debug,
+		IsTrace:                      c.isTrace,
+		IsResponseSaveToFile:         c.isResponseSaveToFile,
+		AuthScheme:                   c.authScheme,
+		AuthToken:                    c.authToken,
+		RetryCount:                   c.retryCount,
+		RetryWaitTime:                c.retryWaitTime,
+		RetryMaxWaitTime:             c.retryMaxWaitTime,
+		RetryDelayStrategy:           c.retryDelayStrategy,
+		IsRetryDefaultConditions:     c.isRetryDefaultConditions,
+		IsCloseConnection:            c.closeConnection,
+		IsResponseDoNotParse:         c.isResponseDoNotParse,
+		DebugBodyLimit:               c.debugBodyLimit,
+		ResponseBodyLimit:            c.responseBodyLimit,
+		IsResponseBodyUnlimitedReads: c.resBodyUnlimitedReads,
+		IsMethodGetAllowPayload:      c.isMethodGetAllowPayload,
+		IsMethodDeleteAllowPayload:   c.isMethodDeleteAllowPayload,
+		IsRetryAllowNonIdempotent:    c.isRetryAllowNonIdempotent,
+		HeaderAuthorizationKey:       c.headerAuthorizationKey,
 
 		mu:                  new(sync.Mutex),
 		client:              c,
@@ -717,8 +717,8 @@ func (c *Client) R() *Request {
 		multipartFields:     make([]*MultipartField, 0),
 		jsonEscapeHTML:      c.jsonEscapeHTML,
 		log:                 c.log,
-		generateCurlCmd:     c.generateCurlCmd,
-		debugLogCurlCmd:     c.debugLogCurlCmd,
+		isCurlCmdGenerate:   c.isCurlCmdGenerate,
+		isCurlCmdDebugLog:   c.isCurlCmdDebugLog,
 		unescapeQueryParams: c.unescapeQueryParams,
 		credentials:         c.credentials,
 	}
@@ -1041,24 +1041,10 @@ func (c *Client) IsDebug() bool {
 	return c.debug
 }
 
-// EnableDebug method is a helper method for [Client.SetDebug]
-func (c *Client) EnableDebug() *Client {
-	c.SetDebug(true)
-	return c
-}
-
-// DisableDebug method is a helper method for [Client.SetDebug]
-func (c *Client) DisableDebug() *Client {
-	c.SetDebug(false)
-	return c
-}
-
-// SetDebug method enables the debug mode on the Resty client. The client logs details
-// of every request and response.
+// SetDebug method is used to turn on/off the debug mode on the Resty client instance. It logs details
+// of every request and response when enabled.
 //
 //	client.SetDebug(true)
-//	// OR
-//	client.EnableDebug()
 //
 // Also, it can be enabled at the request level for a particular request; see [Request.SetDebug].
 //   - For [Request], it logs information such as HTTP verb, Relative URL path,
@@ -1130,61 +1116,61 @@ func (c *Client) IsDisableWarn() bool {
 	return c.disableWarn
 }
 
-// SetDisableWarn method disables the warning log message on the Resty client.
+// SetLoggerWarnLevel method disables the warning log message on the Resty client.
 //
 // For example, Resty warns users when BasicAuth is used in non-TLS mode.
 //
-//	client.SetDisableWarn(true)
-func (c *Client) SetDisableWarn(d bool) *Client {
+//	client.SetLoggerWarnLevel(true)
+func (c *Client) SetLoggerWarnLevel(d bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.disableWarn = d
 	return c
 }
 
-// AllowMethodGetPayload method returns `true` if the client is enabled to allow
+// IsMethodGetAllowPayload method returns `true` if the client is enabled to allow
 // payload with GET method; otherwise, it is `false`.
-func (c *Client) AllowMethodGetPayload() bool {
+func (c *Client) IsMethodGetAllowPayload() bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.allowMethodGetPayload
+	return c.isMethodGetAllowPayload
 }
 
-// SetAllowMethodGetPayload method allows the GET method with payload on the Resty client.
+// SetMethodGetAllowPayload method allows the GET method with payload on the Resty client.
 // By default, Resty does not allow.
 //
-//	client.SetAllowMethodGetPayload(true)
+//	client.SetMethodGetAllowPayload(true)
 //
-// It can be overridden at the request level. See [Request.SetAllowMethodGetPayload]
-func (c *Client) SetAllowMethodGetPayload(allow bool) *Client {
+// It can be overridden at the request level. See [Request.SetMethodGetAllowPayload]
+func (c *Client) SetMethodGetAllowPayload(allow bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.allowMethodGetPayload = allow
+	c.isMethodGetAllowPayload = allow
 	return c
 }
 
-// AllowMethodDeletePayload method returns `true` if the client is enabled to allow
+// IsMethodDeleteAllowPayload method returns `true` if the client is enabled to allow
 // payload with DELETE method; otherwise, it is `false`.
 //
 // More info, refer to GH#881
-func (c *Client) AllowMethodDeletePayload() bool {
+func (c *Client) IsMethodDeleteAllowPayload() bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.allowMethodDeletePayload
+	return c.isMethodDeleteAllowPayload
 }
 
-// SetAllowMethodDeletePayload method allows the DELETE method with payload on the Resty client.
+// SetMethodDeleteAllowPayload method allows the DELETE method with payload on the Resty client.
 // By default, Resty does not allow.
 //
-//	client.SetAllowMethodDeletePayload(true)
+//	client.SetMethodDeleteAllowPayload(true)
 //
 // More info, refer to GH#881
 //
-// It can be overridden at the request level. See [Request.SetAllowMethodDeletePayload]
-func (c *Client) SetAllowMethodDeletePayload(allow bool) *Client {
+// It can be overridden at the request level. See [Request.SetMethodDeleteAllowPayload]
+func (c *Client) SetMethodDeleteAllowPayload(allow bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.allowMethodDeletePayload = allow
+	c.isMethodDeleteAllowPayload = allow
 	return c
 }
 
@@ -1364,18 +1350,6 @@ func (c *Client) SetRetryDelayStrategy(rs RetryDelayStrategyFunc) *Client {
 	return c
 }
 
-// EnableRetryDefaultConditions method enables the Resty's default retry conditions
-func (c *Client) EnableRetryDefaultConditions() *Client {
-	c.SetRetryDefaultConditions(true)
-	return c
-}
-
-// DisableRetryDefaultConditions method disables the Resty's default retry conditions
-func (c *Client) DisableRetryDefaultConditions() *Client {
-	c.SetRetryDefaultConditions(false)
-	return c
-}
-
 // IsRetryDefaultConditions method returns true if Resty's default retry conditions
 // are enabled otherwise false
 //
@@ -1397,28 +1371,28 @@ func (c *Client) SetRetryDefaultConditions(b bool) *Client {
 	return c
 }
 
-// AllowNonIdempotentRetry method returns true if the client is enabled to allow
+// IsRetryAllowNonIdempotent method returns true if the client is enabled to allow
 // non-idempotent HTTP methods retry; otherwise, it is `false`
 //
 // Default value is `false`
-func (c *Client) AllowNonIdempotentRetry() bool {
+func (c *Client) IsRetryAllowNonIdempotent() bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.allowNonIdempotentRetry
+	return c.isRetryAllowNonIdempotent
 }
 
-// SetAllowNonIdempotentRetry method is used to enable/disable non-idempotent HTTP
+// SetRetryAllowNonIdempotent method is used to enable/disable non-idempotent HTTP
 // methods retry. By default, Resty only allows idempotent HTTP methods, see
 // [RFC 9110 Section 9.2.2], [RFC 9110 Section 18.2]
 //
-// It can be overridden at request level, see [Request.SetAllowNonIdempotentRetry]
+// It can be overridden at request level, see [Request.SetRetryAllowNonIdempotent]
 //
 // [RFC 9110 Section 9.2.2]: https://datatracker.ietf.org/doc/html/rfc9110.html#name-idempotent-methods
 // [RFC 9110 Section 18.2]: https://datatracker.ietf.org/doc/html/rfc9110.html#name-method-registration
-func (c *Client) SetAllowNonIdempotentRetry(b bool) *Client {
+func (c *Client) SetRetryAllowNonIdempotent(b bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.allowNonIdempotentRetry = b
+	c.isRetryAllowNonIdempotent = b
 	return c
 }
 
@@ -2015,48 +1989,48 @@ func (c *Client) initCertWatcher(pemFilePath, scope string, options *CertWatcher
 	}()
 }
 
-// OutputDirectory method returns the output directory value from the client.
-func (c *Client) OutputDirectory() string {
+// ResponseSaveDirectory method returns the output directory value from the client.
+func (c *Client) ResponseSaveDirectory() string {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.outputDirectory
+	return c.responseSaveDirectory
 }
 
-// SetOutputDirectory method sets the output directory for saving HTTP responses in a file.
+// SetResponseSaveDirectory method sets the output directory for saving HTTP responses in a file.
 // Resty creates one if the output directory does not exist. This setting is optional,
-// if you plan to use the absolute path in [Request.SetOutputFileName] and can used together.
+// if you plan to use the absolute path in [Request.SetResponseSaveFileName] and can used together.
 //
-//	client.SetOutputDirectory("/save/http/response/here")
-func (c *Client) SetOutputDirectory(dirPath string) *Client {
+//	client.SetResponseSaveDirectory("/save/http/response/here")
+func (c *Client) SetResponseSaveDirectory(dirPath string) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.outputDirectory = dirPath
+	c.responseSaveDirectory = dirPath
 	return c
 }
 
-// IsSaveResponse method returns true if the save response is set to true; otherwise, false
-func (c *Client) IsSaveResponse() bool {
+// IsResponseSaveToFile method returns true if the save response is set to true; otherwise, false
+func (c *Client) IsResponseSaveToFile() bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.isSaveResponse
+	return c.isResponseSaveToFile
 }
 
-// SetSaveResponse method used to enable the save response option at the client level for
+// SetResponseSaveToFile method used to enable the save response option at the client level for
 // all requests
 //
-//	client.SetSaveResponse(true)
+//	client.SetResponseSaveToFile(true)
 //
 // Resty determines the save filename in the following order -
-//   - [Request.SetOutputFileName]
+//   - [Request.SetResponseSaveFileName]
 //   - Content-Disposition header
 //   - Request URL using [path.Base]
 //   - Request URL hostname if path is empty or "/"
 //
-// It can be overridden at request level, see [Request.SetSaveResponse]
-func (c *Client) SetSaveResponse(save bool) *Client {
+// It can be overridden at request level, see [Request.SetResponseSaveToFile]
+func (c *Client) SetResponseSaveToFile(save bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.isSaveResponse = save
+	c.isResponseSaveToFile = save
 	return c
 }
 
@@ -2136,7 +2110,7 @@ func (c *Client) SetCloseConnection(close bool) *Client {
 	return c
 }
 
-// SetDoNotParseResponse method instructs Resty not to parse the response body automatically.
+// SetResponseDoNotParse method instructs Resty not to parse the response body automatically.
 //
 // Resty exposes the raw response body as [io.ReadCloser]. If you use it, do not
 // forget to close the body, otherwise, you might get into connection leaks, and connection
@@ -2144,10 +2118,10 @@ func (c *Client) SetCloseConnection(close bool) *Client {
 //
 // NOTE: The default [Response] middlewares are not executed when using this option. User
 // takes over the control of handling response body from Resty.
-func (c *Client) SetDoNotParseResponse(notParse bool) *Client {
+func (c *Client) SetResponseDoNotParse(notParse bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.notParseResponse = notParse
+	c.isResponseDoNotParse = notParse
 	return c
 }
 
@@ -2231,10 +2205,10 @@ func (c *Client) SetPathParams(params map[string]string) *Client {
 	return c
 }
 
-// SetRawPathParam method sets a single URL path key-value pair in the
+// SetPathRawParam method sets a single URL path key-value pair in the
 // Resty client instance without path escape.
 //
-//	client.SetRawPathParam("path", "groups/developers")
+//	client.SetPathRawParam("path", "groups/developers")
 //
 //	Result:
 //		URL - /v1/users/{path}/details
@@ -2244,21 +2218,21 @@ func (c *Client) SetPathParams(params map[string]string) *Client {
 // The value will be used as-is, no path escape applied.
 //
 // It can be overridden at the request level,
-// see [Request.SetRawPathParam] or [Request.SetRawPathParams]
-func (c *Client) SetRawPathParam(param, value string) *Client {
+// see [Request.SetPathRawParam] or [Request.SetPathRawParams]
+func (c *Client) SetPathRawParam(param, value string) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.pathParams[param] = value
 	return c
 }
 
-// SetRawPathParamAny method sets a single URL path key-value pair in the
+// SetPathRawParamAny method sets a single URL path key-value pair in the
 // Resty client instance without path escape.
 //
-// It is similar to [Client.SetRawPathParam] but accepts any type as the value and converts
+// It is similar to [Client.SetPathRawParam] but accepts any type as the value and converts
 // it to a string using predefined formatting rules (integers, bools, time.Time, etc.).
 //
-//	client.SetRawPathParamAny("userId", 12345)
+//	client.SetPathRawParamAny("userId", 12345)
 //
 //	Result:
 //	   URL - /v1/users/{userId}/details
@@ -2268,8 +2242,8 @@ func (c *Client) SetRawPathParam(param, value string) *Client {
 // The value will be used as-is, no path escape applied.
 //
 // It can be overridden at the request level,
-// see [Request.SetRawPathParamAny] or [Request.SetRawPathParams]
-func (c *Client) SetRawPathParamAny(param string, value any) *Client {
+// see [Request.SetPathRawParamAny] or [Request.SetPathRawParams]
+func (c *Client) SetPathRawParamAny(param string, value any) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	strVal := formatAnyToString(value)
@@ -2277,10 +2251,10 @@ func (c *Client) SetRawPathParamAny(param string, value any) *Client {
 	return c
 }
 
-// SetRawPathParams method sets multiple URL path key-value pairs at one go in the
+// SetPathRawParams method sets multiple URL path key-value pairs at one go in the
 // Resty client instance without path escape.
 //
-//	client.SetRawPathParams(map[string]string{
+//	client.SetPathRawParams(map[string]string{
 //		"userId":       "sample@sample.com",
 //		"subAccountId": "100002",
 //		"path":         "groups/developers",
@@ -2294,10 +2268,10 @@ func (c *Client) SetRawPathParamAny(param string, value any) *Client {
 // The value will be used as-is, no path escape applied.
 //
 // It can be overridden at the request level,
-// see [Request.SetRawPathParam] or [Request.SetRawPathParams]
-func (c *Client) SetRawPathParams(params map[string]string) *Client {
+// see [Request.SetPathRawParam] or [Request.SetPathRawParams]
+func (c *Client) SetPathRawParams(params map[string]string) *Client {
 	for p, v := range params {
-		c.SetRawPathParam(p, v)
+		c.SetPathRawParam(p, v)
 	}
 	return c
 }
@@ -2330,7 +2304,7 @@ func (c *Client) ResponseBodyLimit() int64 {
 // in the uncompressed response is larger than the limit.
 // Body size limit will not be enforced in the following cases:
 //   - ResponseBodyLimit <= 0, which is the default behavior.
-//   - [Request.SetOutputFileName] is called to save response data to the file.
+//   - [Request.SetResponseSaveFileName] is called to save response data to the file.
 //   - "DoNotParseResponse" is set for client or request.
 //
 // It can be overridden at the request level; see [Request.SetResponseBodyLimit]
@@ -2341,27 +2315,6 @@ func (c *Client) SetResponseBodyLimit(v int64) *Client {
 	return c
 }
 
-// EnableTrace method enables the Resty client trace for the requests fired from
-// the client using [httptrace.ClientTrace] and provides insights.
-//
-//	client := resty.New().EnableTrace()
-//
-//	resp, err := client.R().Get("https://httpbin.org/get")
-//	fmt.Println("error:", err)
-//	fmt.Println("Trace Info:", resp.Request.TraceInfo())
-//
-// The method [Request.EnableTrace] is also available to get trace info for a single request.
-func (c *Client) EnableTrace() *Client {
-	c.SetTrace(true)
-	return c
-}
-
-// DisableTrace method disables the Resty client trace. Refer to [Client.EnableTrace].
-func (c *Client) DisableTrace() *Client {
-	c.SetTrace(false)
-	return c
-}
-
 // IsTrace method returns true if the trace is enabled on the client instance; otherwise, it returns false.
 func (c *Client) IsTrace() bool {
 	c.lock.RLock()
@@ -2369,10 +2322,16 @@ func (c *Client) IsTrace() bool {
 	return c.isTrace
 }
 
-// SetTrace method is used to turn on/off the trace capability in the Resty client
-// Refer to [Client.EnableTrace] or [Client.DisableTrace].
+// SetTrace method is used to turn on/off the trace capability in the Resty client instance.
+// It provides an insight into the request lifecycle using [httptrace.ClientTrace].
 //
-// Also, see [Request.SetTrace]
+//	client := resty.New().SetTrace(true)
+//
+//	resp, err := client.R().Get("https://httpbin.org/get")
+//	fmt.Println("error:", err)
+//	fmt.Println("Trace Info:", resp.Request.TraceInfo())
+//
+// The method [Request.SetTrace] is also available to get trace info for a single request.
 func (c *Client) SetTrace(t bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -2380,36 +2339,12 @@ func (c *Client) SetTrace(t bool) *Client {
 	return c
 }
 
-// EnableGenerateCurlCmd method enables the generation of curl command at the
+// SetCurlCmdGenerate method is used to turn on/off the generate curl command at the
 // client instance level.
 //
 // By default, Resty does not log the curl command in the debug log since it has the potential
-// to leak sensitive data unless explicitly enabled via [Client.SetDebugLogCurlCmd] or
-// [Request.SetDebugLogCurlCmd].
-//
-// NOTE: Use with care.
-//   - Potential to leak sensitive data from [Request] and [Response] in the debug log
-//     when the debug log option is enabled.
-//   - Additional memory usage since the request body was reread.
-//   - curl body is not generated for [io.Reader] and multipart request flow.
-func (c *Client) EnableGenerateCurlCmd() *Client {
-	c.SetGenerateCurlCmd(true)
-	return c
-}
-
-// DisableGenerateCurlCmd method disables the option set by [Client.EnableGenerateCurlCmd] or
-// [Client.SetGenerateCurlCmd].
-func (c *Client) DisableGenerateCurlCmd() *Client {
-	c.SetGenerateCurlCmd(false)
-	return c
-}
-
-// SetGenerateCurlCmd method is used to turn on/off the generate curl command at the
-// client instance level.
-//
-// By default, Resty does not log the curl command in the debug log since it has the potential
-// to leak sensitive data unless explicitly enabled via [Client.SetDebugLogCurlCmd] or
-// [Request.SetDebugLogCurlCmd].
+// to leak sensitive data unless explicitly enabled via [Client.SetCurlCmdDebugLog] or
+// [Request.SetCurlCmdDebugLog].
 //
 // NOTE: Use with care.
 //   - Potential to leak sensitive data from [Request] and [Response] in the debug log
@@ -2417,31 +2352,31 @@ func (c *Client) DisableGenerateCurlCmd() *Client {
 //   - Additional memory usage since the request body was reread.
 //   - curl body is not generated for [io.Reader] and multipart request flow.
 //
-// It can be overridden at the request level; see [Request.SetGenerateCurlCmd]
-func (c *Client) SetGenerateCurlCmd(b bool) *Client {
+// It can be overridden at the request level; see [Request.SetCurlCmdGenerate]
+func (c *Client) SetCurlCmdGenerate(b bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.generateCurlCmd = b
+	c.isCurlCmdGenerate = b
 	return c
 }
 
-// SetDebugLogCurlCmd method enables the curl command to be logged in the debug log.
+// SetCurlCmdDebugLog method enables the curl command to be logged in the debug log.
 //
-// It can be overridden at the request level; see [Request.SetDebugLogCurlCmd]
-func (c *Client) SetDebugLogCurlCmd(b bool) *Client {
+// It can be overridden at the request level; see [Request.SetCurlCmdDebugLog]
+func (c *Client) SetCurlCmdDebugLog(b bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.debugLogCurlCmd = b
+	c.isCurlCmdDebugLog = b
 	return c
 }
 
-// SetUnescapeQueryParams method sets the choice of unescape query parameters for the request URL.
+// SetQueryParamsUnescape method sets the choice of unescape query parameters for the request URL.
 // To prevent broken URL, Resty replaces space (" ") with "+" in the query parameters.
 //
-// See [Request.SetUnescapeQueryParams]
+// See [Request.SetQueryParamsUnescape]
 //
 // NOTE: Request failure is possible due to non-standard usage of Unescaped Query Parameters.
-func (c *Client) SetUnescapeQueryParams(unescape bool) *Client {
+func (c *Client) SetQueryParamsUnescape(unescape bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.unescapeQueryParams = unescape
@@ -2571,7 +2506,7 @@ func (c *Client) execute(req *Request) (*Response, error) {
 
 	prepareRequestDebugInfo(c, req)
 
-	req.Time = time.Now()
+	req.StartTime = time.Now()
 	resp, err := c.Client().Do(req.withTimeout())
 	// Cancel multipart context for io.Copy to stop reading/writing further
 	if req.isMultiPart && req.multipartCancelFunc != nil {
@@ -2602,8 +2537,8 @@ func (c *Client) execute(req *Request) (*Response, error) {
 
 		response.wrapLimitReadCloser()
 
-		if !req.DoNotParseResponse {
-			if req.ResponseBodyUnlimitedReads || req.Debug {
+		if !req.IsResponseDoNotParse {
+			if req.IsResponseBodyUnlimitedReads || req.IsDebug {
 				response.wrapCopyReadCloser()
 
 				if err = response.readAll(); err != nil {

--- a/client.go
+++ b/client.go
@@ -924,7 +924,7 @@ func (c *Client) ContentTypeEncoders() map[string]ContentTypeEncoder {
 func (c *Client) AddContentTypeEncoder(ct string, e ContentTypeEncoder) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.contentTypeEncoders[ct] = e
+	c.contentTypeEncoders[strings.ToLower(ct)] = e
 	return c
 }
 
@@ -952,7 +952,7 @@ func (c *Client) ContentTypeDecoders() map[string]ContentTypeDecoder {
 func (c *Client) AddContentTypeDecoder(ct string, d ContentTypeDecoder) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.contentTypeDecoders[ct] = d
+	c.contentTypeDecoders[strings.ToLower(ct)] = d
 	return c
 }
 
@@ -983,10 +983,11 @@ func (c *Client) ContentDecompressers() map[string]ContentDecompresser {
 func (c *Client) AddContentDecompresser(k string, d ContentDecompresser) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	if !slices.Contains(c.contentDecompresserKeys, k) {
-		c.contentDecompresserKeys = slices.Insert(c.contentDecompresserKeys, 0, k)
+	lk := strings.ToLower(k)
+	if !slices.Contains(c.contentDecompresserKeys, lk) {
+		c.contentDecompresserKeys = slices.Insert(c.contentDecompresserKeys, 0, lk)
 	}
-	c.contentDecompressers[k] = d
+	c.contentDecompressers[lk] = d
 	return c
 }
 
@@ -1011,6 +1012,7 @@ func (c *Client) SetContentDecompresserKeys(keys []string) *Client {
 	result := make([]string, 0)
 	decoders := c.ContentDecompressers()
 	for _, k := range keys {
+		k = strings.ToLower(k)
 		if _, f := decoders[k]; f {
 			result = append(result, k)
 		}

--- a/client.go
+++ b/client.go
@@ -227,7 +227,7 @@ type Client struct {
 	contentDecompressers       map[string]ContentDecompresser
 	certWatcherStopChan        chan bool
 	circuitBreaker             *CircuitBreaker
-	hedging                    *hedgingConfig
+	hedging                    *Hedging
 }
 
 // CertWatcherOptions allows configuring a watcher that reloads dynamically TLS certs.
@@ -1446,203 +1446,59 @@ func (c *Client) AddRetryHooks(hooks ...RetryHookFunc) *Client {
 	return c
 }
 
-// isHedgingEnabled method returns true if hedging is enabled and get client clock.
-func (c *Client) IsHedgingEnabled() bool {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-	return c.isHedgingEnabled()
-}
-
 // isHedgingEnabled method returns true if hedging is enabled.
 func (c *Client) isHedgingEnabled() bool {
-	return c.hedging != nil && c.hedging.enabled
-}
-
-// SetHedgingDelay method sets the delay between hedged requests.
-func (c *Client) SetHedgingDelay(delay time.Duration) *Client {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	if c.isHedgingEnabled() {
-		c.hedging.delay = delay
-		return c
-	}
-	c.log.Errorf("SetHedgingDelay: %v", ErrHedgingDisabled)
-	return c
-}
-
-// HedgingDelay method returns the configured hedging delay.
-func (c *Client) HedgingDelay() time.Duration {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	if c.isHedgingEnabled() {
-		return c.hedging.delay
-	}
-	return hedgingDefaultDelay
+	return c.hedging != nil
 }
 
-// SetHedgingUpTo method sets maximum concurrent hedged requests.
-func (c *Client) SetHedgingUpTo(upTo int) *Client {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	if c.isHedgingEnabled() {
-		c.hedging.upTo = upTo
-		return c
-	}
-	c.log.Errorf("SetHedgingUpTo: %v", ErrHedgingDisabled)
-	return c
-}
-
-// HedgingUpTo method returns the maximum concurrent requests.
-func (c *Client) HedgingUpTo() int {
+// Hedging method returns the hedging configuration of the client.
+// If nil is returned, it means hedging is disabled.
+func (c *Client) Hedging() *Hedging {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	if c.isHedgingEnabled() {
-		return c.hedging.upTo
-	}
-	return hedgingDefaultUpTo
+	return c.hedging
 }
 
-// SetHedgingMaxPerSecond method sets rate limit for hedged requests.
-func (c *Client) SetHedgingMaxPerSecond(maxPerSecond float64) *Client {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	if c.isHedgingEnabled() {
-		c.hedging.maxPerSecond = maxPerSecond
-		return c
-	}
-	c.log.Errorf("SetHedgingMaxPerSecond: %v", ErrHedgingDisabled)
-	return c
-}
-
-// HedgingMaxPerSecond method returns the hedging rate limit.
-func (c *Client) HedgingMaxPerSecond() float64 {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-	if c.isHedgingEnabled() {
-		return c.hedging.maxPerSecond
-	}
-	return hedgingDefaultMaxPerSecond
-}
-
-// SetHedgingAllowNonReadOnly method allows hedging for non-read-only HTTP methods.
-// By default, only read-only methods (GET, HEAD, OPTIONS, TRACE) are hedged.
-// NOTE:
-//   - Use this with caution as hedging write operations can lead to duplicates.
-func (c *Client) SetHedgingAllowNonReadOnly(allow bool) *Client {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	if c.isHedgingEnabled() {
-		c.hedging.allowNonReadOnly = allow
-		// Re-wrap to apply new settings
-		c.unwrapHedgingTransport()
-		c.wrapTransportWithHedging()
-		return c
-	}
-	c.log.Errorf("SetHedgingAllowNonReadOnly: %v", ErrHedgingDisabled)
-	return c
-}
-
-// IsHedgingAllowNonReadOnly method returns true if hedging is enabled for non-read-only methods.
-func (c *Client) IsHedgingAllowNonReadOnly() bool {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-	if c.isHedgingEnabled() {
-		return c.hedging.allowNonReadOnly
-	}
-	return hedgingDefaultAllowNonReadOnly
-}
-
-// EnableHedging method enables hedging with the given configuration.
+// SetHedging method sets the hedging instance into client. If nil is passed, it disables hedging.
 //
-// Hedging sends multiple concurrent requests with staggered delays and returns
-// the first response to complete to reduce tail latency. Only read-only HTTP methods
-// (GET, HEAD, OPTIONS, TRACE) are hedged by default unless SetHedgingAllowNonReadOnly is used.
-//
-//		client.EnableHedging(
-//		    50*time.Millisecond,   // delay between requests
-//		    3,                     // max 3 concurrent requests
-//		    10.0,                  // max 10 hedged requests per second
-//		)
-//	 Last one come from rate package, to use fractional rates, e.g.
-//	 - 0.1 = 1 request every 10 seconds
-//	 - 0.5 = 1 request every 2 seconds
-//	 - 1.0 = 1 request per second
-//	 - 2.5 = 2.5 requests per second (5 requests every 2 seconds)
-//	 - 10.0 = 10 requests per second
-func (c *Client) EnableHedging(delay time.Duration, upTo int, maxPerSecond float64) *Client {
+// See [NewHedging] for more details about the Hedging configuration.
+func (c *Client) SetHedging(h *Hedging) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if c.hedging == nil {
-		c.hedging = &hedgingConfig{}
+	// if nil is passed, we disable hedging
+	// by reverting the transport instance
+	if h == nil {
+		if ht, ok := c.httpClient.Transport.(*Hedging); ok {
+			c.httpClient.Transport = ht.transport
+			c.hedging = h
+		}
+		return c
 	}
 
-	c.hedging.delay = delay
-	c.hedging.upTo = upTo
-	c.hedging.maxPerSecond = maxPerSecond
-	c.hedging.enabled = true
-
-	// Disable retry by default when hedging is enabled.
-	// Users can re-enable retry if they want it as a fallback mechanism.
-	if c.retryCount > 0 {
-		c.log.Warnf("Disabling retry (count: %d) as hedging is now enabled. You can re-enable retry with SetRetryCount() if you want it as a fallback.", c.retryCount)
-		c.retryCount = 0
-	}
-
-	c.wrapTransportWithHedging()
-
-	return c
-}
-
-// DisableHedging method disables hedging.
-func (c *Client) DisableHedging() *Client {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	if c.isHedgingEnabled() {
-		c.hedging.enabled = false
-	}
-
-	c.unwrapHedgingTransport()
-
-	return c
-}
-
-func (c *Client) wrapTransportWithHedging() {
-	if c.hedging == nil || !c.hedging.enabled {
-		return
-	}
+	// enable hedging if its not already enabled
 
 	currentTransport := c.httpClient.Transport
 	if currentTransport == nil {
 		currentTransport = createTransport(nil, nil)
 	}
 
-	// Already set
-	if _, ok := currentTransport.(*hedgingTransport); ok {
-		return
+	// Disable retry by default when hedging is enabled.
+	// Users can re-enable retry if they want it as a fallback mechanism.
+	if c.retryCount > 0 {
+		c.log.Warnf("Disabling retry (count: %d) as hedging is now enabled."+
+			" You can re-enable retry with SetRetryCount() if you really want it as a fallback."+
+			" otherwise, hedging and retry requests can overwhelm the server.", c.retryCount)
+		c.retryCount = 0
 	}
 
-	// Calculate rate delay: if maxPerSecond is 10, delay is 100ms (1s / 10)
-	var rateDelay time.Duration
-	if c.hedging.maxPerSecond > 0 {
-		rateDelay = time.Duration(float64(time.Second) / c.hedging.maxPerSecond)
-	}
+	h.transport = currentTransport
+	c.httpClient.Transport = h
+	c.hedging = h
 
-	c.httpClient.Transport = &hedgingTransport{
-		transport:        currentTransport,
-		delay:            c.hedging.delay,
-		upTo:             c.hedging.upTo,
-		rateDelay:        rateDelay,
-		allowNonReadOnly: c.hedging.allowNonReadOnly,
-	}
-}
-
-func (c *Client) unwrapHedgingTransport() {
-	if ht, ok := c.httpClient.Transport.(*hedgingTransport); ok {
-		c.httpClient.Transport = ht.transport
-	}
+	return c
 }
 
 // TLSClientConfig method returns the [tls.Config] from underlying client transport

--- a/client.go
+++ b/client.go
@@ -1485,6 +1485,12 @@ func (c *Client) SetHedging(h *Hedging) *Client {
 		currentTransport = createTransport(nil, nil)
 	}
 
+	// If current transport is already a Hedging instance, unwrap it
+	// to avoid double-wrapping (e.g., when SetHedging is called multiple times)
+	if hedging, ok := currentTransport.(*Hedging); ok {
+		currentTransport = hedging.transport
+	}
+
 	// Disable retry by default when hedging is enabled.
 	// Users can re-enable retry if they want it as a fallback mechanism.
 	if c.retryCount > 0 {

--- a/client_test.go
+++ b/client_test.go
@@ -912,7 +912,7 @@ func TestLzwCompress(t *testing.T) {
 	assertEqual(t, ErrContentDecompresserNotFound, err)
 
 	// Register LZW content decoder
-	c.AddContentDecompresser("compress", func(r io.ReadCloser) (io.ReadCloser, error) {
+	c.AddContentDecompresser("ComPreSs", func(r io.ReadCloser) (io.ReadCloser, error) {
 		l := &lzwReader{
 			s: r,
 			r: lzw.NewReader(r, lzw.LSB, 8),

--- a/client_test.go
+++ b/client_test.go
@@ -1542,8 +1542,13 @@ func TestClientHedgingBasic(t *testing.T) {
 	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
 	defer ts.Close()
 
+	h := NewHedging().
+		SetDelay(20 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
+
 	c := dcnl()
-	c.EnableHedging(20*time.Millisecond, 3, 0)
+	c.SetHedging(h)
 
 	resp, err := c.R().Get(ts.URL + "/hedging-slow-first")
 	assertError(t, err)
@@ -1556,12 +1561,17 @@ func TestClientHedgingDisable(t *testing.T) {
 	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
 	defer ts.Close()
 
-	c := dcnl()
-	c.EnableHedging(20*time.Millisecond, 3, 0)
-	assertEqual(t, true, c.IsHedgingEnabled())
+	h := NewHedging().
+		SetDelay(20 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
 
-	c.DisableHedging()
-	assertEqual(t, false, c.IsHedgingEnabled())
+	c := dcnl()
+	c.SetHedging(h)
+	assertEqual(t, true, c.isHedgingEnabled())
+
+	c.SetHedging(nil)
+	assertEqual(t, false, c.isHedgingEnabled())
 
 	resp, err := c.R().Get(ts.URL + "/hedging-slow-first")
 	assertError(t, err)
@@ -1570,14 +1580,16 @@ func TestClientHedgingDisable(t *testing.T) {
 
 func TestClientHedgingNil(t *testing.T) {
 	c := dcnl()
-	c.hedging = nil
-	c.wrapTransportWithHedging()
 
-	assertEqual(t, false, c.IsHedgingEnabled())
-
-	_, ok := c.httpClient.Transport.(*hedgingTransport)
-	if ok {
+	assertEqual(t, false, c.isHedgingEnabled())
+	if _, ok := c.httpClient.Transport.(*Hedging); ok {
 		t.Error("Transport shouldn't be hedgingTransport when hedging is nil")
+	}
+
+	c.SetHedging(NewHedging())
+	assertEqual(t, true, c.isHedgingEnabled())
+	if _, ok := c.httpClient.Transport.(*Hedging); !ok {
+		t.Error("Transport should be hedgingTransport when hedging is set")
 	}
 }
 
@@ -1589,42 +1601,22 @@ func TestClientHedgingMutualExclusionWithRetry(t *testing.T) {
 	assertEqual(t, 2, c.RetryCount())
 
 	// Enable hedging should disable retry by default
-	c.EnableHedging(50*time.Millisecond, 3, 0)
+	h := NewHedging().
+		SetDelay(50 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
+	c.SetHedging(h)
 	assertEqual(t, 0, c.RetryCount())
 
 	// But user can re-enable retry as fallback
 	c.SetRetryCount(1)
 	assertEqual(t, 1, c.RetryCount())
-	assertEqual(t, true, c.IsHedgingEnabled())
+	assertEqual(t, true, c.isHedgingEnabled())
 
 	// Disable hedging
-	c.DisableHedging()
-	assertEqual(t, false, c.IsHedgingEnabled())
+	c.SetHedging(nil)
+	assertEqual(t, false, c.isHedgingEnabled())
 	assertEqual(t, 1, c.RetryCount()) // Retry count should remain
-}
-
-func TestClientHedgingConfiguration(t *testing.T) {
-	c := dcnl()
-
-	// Setters require hedging to be enabled first
-	assertEqual(t, false, c.IsHedgingEnabled())
-
-	c.EnableHedging(50*time.Millisecond, 3, 10.0)
-
-	assertEqual(t, true, c.IsHedgingEnabled())
-	assertEqual(t, 50*time.Millisecond, c.HedgingDelay())
-	assertEqual(t, 3, c.HedgingUpTo())
-	assertEqual(t, 10.0, c.HedgingMaxPerSecond())
-
-	// Now we can update individual settings
-	c.SetHedgingDelay(100 * time.Millisecond)
-	assertEqual(t, 100*time.Millisecond, c.HedgingDelay())
-
-	c.SetHedgingUpTo(5)
-	assertEqual(t, 5, c.HedgingUpTo())
-
-	c.SetHedgingMaxPerSecond(20.0)
-	assertEqual(t, 20.0, c.HedgingMaxPerSecond())
 }
 
 func TestClientHedgingWithRateLimit(t *testing.T) {
@@ -1632,8 +1624,12 @@ func TestClientHedgingWithRateLimit(t *testing.T) {
 	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
 	defer ts.Close()
 
-	c := dcnl()
-	c.EnableHedging(10*time.Millisecond, 10, 5.0)
+	h := NewHedging().
+		SetDelay(10 * time.Millisecond).
+		SetMaxRequest(10).
+		SetMaxRequestPerSecond(5.0)
+
+	c := dcnl().SetHedging(h)
 
 	resp, err := c.R().Get(ts.URL + "/hedging-slow-all")
 	assertError(t, err)
@@ -1644,8 +1640,12 @@ func TestClientHedgingSafeMethodsOnly(t *testing.T) {
 	ts := createGetServer(t)
 	defer ts.Close()
 
-	c := dcnl()
-	c.EnableHedging(20*time.Millisecond, 3, 0)
+	h := NewHedging().
+		SetDelay(20 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
+
+	c := dcnl().SetHedging(h)
 
 	resp, err := c.R().Get(ts.URL + "/")
 	assertError(t, err)

--- a/client_test.go
+++ b/client_test.go
@@ -1537,62 +1537,6 @@ func TestClientOnCloseMultipleHooks(t *testing.T) {
 	assertEqual(t, []string{"first", "second", "third"}, executionOrder)
 }
 
-func TestClientHedgingBasic(t *testing.T) {
-	var attemptCount int32
-	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
-	defer ts.Close()
-
-	h := NewHedging().
-		SetDelay(20 * time.Millisecond).
-		SetMaxRequest(3).
-		SetMaxRequestPerSecond(0)
-
-	c := dcnl()
-	c.SetHedging(h)
-
-	resp, err := c.R().Get(ts.URL + "/hedging-slow-first")
-	assertError(t, err)
-	assertEqual(t, http.StatusOK, resp.StatusCode())
-	assertNotEqual(t, "", resp.String())
-}
-
-func TestClientHedgingDisable(t *testing.T) {
-	var attemptCount int32
-	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
-	defer ts.Close()
-
-	h := NewHedging().
-		SetDelay(20 * time.Millisecond).
-		SetMaxRequest(3).
-		SetMaxRequestPerSecond(0)
-
-	c := dcnl()
-	c.SetHedging(h)
-	assertEqual(t, true, c.isHedgingEnabled())
-
-	c.SetHedging(nil)
-	assertEqual(t, false, c.isHedgingEnabled())
-
-	resp, err := c.R().Get(ts.URL + "/hedging-slow-first")
-	assertError(t, err)
-	assertEqual(t, http.StatusOK, resp.StatusCode())
-}
-
-func TestClientHedgingNil(t *testing.T) {
-	c := dcnl()
-
-	assertEqual(t, false, c.isHedgingEnabled())
-	if _, ok := c.httpClient.Transport.(*Hedging); ok {
-		t.Error("Transport shouldn't be hedgingTransport when hedging is nil")
-	}
-
-	c.SetHedging(NewHedging())
-	assertEqual(t, true, c.isHedgingEnabled())
-	if _, ok := c.httpClient.Transport.(*Hedging); !ok {
-		t.Error("Transport should be hedgingTransport when hedging is set")
-	}
-}
-
 func TestClientHedgingMutualExclusionWithRetry(t *testing.T) {
 	c := dcnl()
 
@@ -1617,45 +1561,4 @@ func TestClientHedgingMutualExclusionWithRetry(t *testing.T) {
 	c.SetHedging(nil)
 	assertEqual(t, false, c.isHedgingEnabled())
 	assertEqual(t, 1, c.RetryCount()) // Retry count should remain
-}
-
-func TestClientHedgingWithRateLimit(t *testing.T) {
-	var attemptCount int32
-	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
-	defer ts.Close()
-
-	h := NewHedging().
-		SetDelay(10 * time.Millisecond).
-		SetMaxRequest(10).
-		SetMaxRequestPerSecond(5.0)
-
-	c := dcnl().SetHedging(h)
-
-	resp, err := c.R().Get(ts.URL + "/hedging-slow-all")
-	assertError(t, err)
-	assertEqual(t, http.StatusOK, resp.StatusCode())
-}
-
-func TestClientHedgingSafeMethodsOnly(t *testing.T) {
-	ts := createGetServer(t)
-	defer ts.Close()
-
-	h := NewHedging().
-		SetDelay(20 * time.Millisecond).
-		SetMaxRequest(3).
-		SetMaxRequestPerSecond(0)
-
-	c := dcnl().SetHedging(h)
-
-	resp, err := c.R().Get(ts.URL + "/")
-	assertError(t, err)
-	assertEqual(t, http.StatusOK, resp.StatusCode())
-
-	resp2, err2 := c.R().Head(ts.URL + "/")
-	assertError(t, err2)
-	assertEqual(t, http.StatusOK, resp2.StatusCode())
-
-	resp3, err3 := c.R().Options(ts.URL + "/")
-	assertError(t, err3)
-	assertEqual(t, http.StatusOK, resp3.StatusCode())
 }

--- a/digest_test.go
+++ b/digest_test.go
@@ -190,7 +190,7 @@ func TestClientDigestAuthWithBodyQopAuthIntGetBodyNil(t *testing.T) {
 
 	c := dcnl().SetDigestAuth(conf.username, conf.password)
 	c.SetRequestMiddlewares(
-		PrepareRequestMiddleware,
+		MiddlewareRequestCreate,
 		func(c *Client, r *Request) error {
 			r.RawRequest.GetBody = nil
 			return nil
@@ -215,7 +215,7 @@ func TestClientDigestAuthWithGetBodyError(t *testing.T) {
 
 	c := dcnl().SetDigestAuth(conf.username, conf.password)
 	c.SetRequestMiddlewares(
-		PrepareRequestMiddleware,
+		MiddlewareRequestCreate,
 		func(c *Client, r *Request) error {
 			r.RawRequest.GetBody = func() (_ io.ReadCloser, _ error) {
 				return nil, errors.New("get body test error")
@@ -244,7 +244,7 @@ func TestClientDigestAuthWithGetBodyNilReadError(t *testing.T) {
 
 	c := dcnl().SetDigestAuth(conf.username, conf.password)
 	c.SetRequestMiddlewares(
-		PrepareRequestMiddleware,
+		MiddlewareRequestCreate,
 		func(c *Client, r *Request) error {
 			r.RawRequest.GetBody = nil
 			return nil

--- a/hedging.go
+++ b/hedging.go
@@ -10,47 +10,158 @@ package resty
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"sync"
 	"time"
 )
 
-var (
-	ErrHedgingDisabled = errors.New("resty: hedging not enabled, ignoring this option, please enable with EnableHedging() first")
-)
-
-const (
-	hedgingDefaultEnabled          = true
-	hedgingDefaultDelay            = 0
-	hedgingDefaultUpTo             = 0
-	hedgingDefaultMaxPerSecond     = 0
-	hedgingDefaultAllowNonReadOnly = false
-)
-
-// hedgingConfig holds configuration for hedging requests
-type hedgingConfig struct {
-	enabled          bool
-	delay            time.Duration
-	upTo             int
-	maxPerSecond     float64
-	allowNonReadOnly bool
+// NewHedging creates a new Hedging instance with default configuration.
+// By default values are:
+//   - 50ms delay between requests
+//   - Maximum 3 requests
+//   - Maximum 3 requests per second
+//   - Only read-only methods are hedged
+//
+// You can customize these settings using the corresponding setter methods.
+// For example:
+//
+//	hedging := NewHedging().
+//		SetDelay(100 * time.Millisecond).
+//		SetMaxRequest(5).
+//		SetMaxRequestPerSecond(10)
+//
+//	// Assign the hedging instance to the Resty client
+//	client := resty.New().
+//		SetHedging(hedging)
+//
+//	defer c.Close()
+func NewHedging() *Hedging {
+	h := &Hedging{
+		lock:                 new(sync.RWMutex),
+		delay:                50 * time.Millisecond, // delay between requests
+		maxRequest:           3,                     // max requests
+		maxRequestPerSecond:  3,                     // max requests per second
+		isNonReadOnlyAllowed: false,                 // only hedge read-only methods by default
+	}
+	h.calculateRateDelay()
+	return h
 }
 
-type hedgingTransport struct {
-	transport        http.RoundTripper
-	delay            time.Duration
-	upTo             int
-	rateDelay        time.Duration // delay between requests based on maxPerSecond
-	allowNonReadOnly bool
+// Hedging struct implements the http.RoundTripper interface to perform hedged HTTP requests.
+// It sends multiple requests in parallel with a specified delay and returns the first successful
+// response. Hedging is particularly useful for improving latency and reliability in scenarios
+// where requests may occasionally fail or experience high latency.
+//
+// By default only read-only HTTP methods (GET, HEAD, OPTIONS, TRACE) are hedged to avoid unintended
+// side effects on the server. Unless SetHedgingAllowNonReadOnly is used to allow non-read-only methods,
+// in which case all HTTP methods will be hedged.
+//
+// NOTE:
+//   - Hedging should be used with caution, especially for non-read-only methods, as it can lead to
+//     unintended consequences if multiple requests are processed by the server.
+//   - Ensure that the server can safely handle multiple concurrent requests when using hedging,
+//     as otherwise, hedging requests can overwhelm the server.
+//
+// For more information on hedging and its use cases, refer to the following resources:
+//   - [The Tail at Scale]
+//
+// [The Tail at Scale]: https://research.google/pubs/the-tail-at-scale/
+type Hedging struct {
+	lock                 *sync.RWMutex
+	transport            http.RoundTripper
+	delay                time.Duration
+	maxRequest           int
+	maxRequestPerSecond  float64
+	rateDelay            time.Duration // delay between requests based on maxPerSecond
+	isNonReadOnlyAllowed bool
 }
 
-func (ht *hedgingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if !ht.allowNonReadOnly && !isReadOnlyMethod(req.Method) {
+// Delay method returns the configured hedging delay.
+func (h *Hedging) Delay() time.Duration {
+	h.lock.RLock()
+	defer h.lock.RUnlock()
+	return h.delay
+}
+
+// SetDelay method sets the delay between hedged requests.
+func (h *Hedging) SetDelay(delay time.Duration) *Hedging {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.delay = delay
+	return h
+}
+
+// MaxRequest method returns the maximum concurrent requests.
+func (h *Hedging) MaxRequest() int {
+	h.lock.RLock()
+	defer h.lock.RUnlock()
+	return h.maxRequest
+}
+
+// SetMaxRequest method sets maximum concurrent hedged requests.
+func (h *Hedging) SetMaxRequest(count int) *Hedging {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.maxRequest = count
+	return h
+}
+
+// MaxRequestPerSecond method returns the hedging rate limit.
+func (h *Hedging) MaxRequestPerSecond() float64 {
+	h.lock.RLock()
+	defer h.lock.RUnlock()
+	return h.maxRequestPerSecond
+}
+
+// SetMaxRequestPerSecond method sets rate limit for hedged requests.
+func (h *Hedging) SetMaxRequestPerSecond(count float64) *Hedging {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.maxRequestPerSecond = count
+	h.calculateRateDelay()
+	return h
+}
+
+// IsNonReadOnlyAllowed method returns true if hedging is enabled for non-read-only
+// HTTP methods.
+func (h *Hedging) IsNonReadOnlyAllowed() bool {
+	h.lock.RLock()
+	defer h.lock.RUnlock()
+	return h.isNonReadOnlyAllowed
+}
+
+// SetNonReadOnlyAllowed method allows hedging for non-read-only HTTP methods.
+// By default, only read-only methods (GET, HEAD, OPTIONS, TRACE) are hedged.
+//
+// NOTE:
+//   - Use this with caution as hedging write operations can lead to duplicates.
+func (h *Hedging) SetNonReadOnlyAllowed(allow bool) *Hedging {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	h.isNonReadOnlyAllowed = allow
+	return h
+}
+
+// calculateRateDelay method calculates the delay between requests based on the maxPerSecond setting.
+// If maxPerSecond is greater than 0, it sets rateDelay to 1 second divided by maxPerSecond.
+// Otherwise, it sets rateDelay to 0 (no delay).
+//
+// NOTE: It should be called within lock region.
+func (h *Hedging) calculateRateDelay() {
+	if h.maxRequestPerSecond > 0 {
+		// Calculate rate delay: if maxPerSecond is 10, delay is 100ms (1s / 10)
+		h.rateDelay = time.Duration(float64(time.Second) / h.maxRequestPerSecond)
+	} else {
+		h.rateDelay = 0 // no delay if maxPerSecond is 0 or negative
+	}
+}
+
+func (ht *Hedging) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !ht.isNonReadOnlyAllowed && !isReadOnlyMethod(req.Method) {
 		return ht.transport.RoundTrip(req)
 	}
 
-	if ht.upTo <= 1 {
+	if ht.MaxRequest() <= 1 {
 		return ht.transport.RoundTrip(req)
 	}
 
@@ -63,14 +174,14 @@ func (ht *hedgingTransport) RoundTrip(req *http.Request) (*http.Response, error)
 		err  error
 	}
 
-	resultCh := make(chan result, ht.upTo)
+	resultCh := make(chan result, ht.MaxRequest())
 	var once sync.Once
 
-	for i := 0; i < ht.upTo; i++ {
+	for i := 0; i < ht.MaxRequest(); i++ {
 		if i > 0 {
-			if ht.delay > 0 {
+			if ht.Delay() > 0 {
 				select {
-				case <-time.After(ht.delay):
+				case <-time.After(ht.Delay()):
 				case <-hedgeCtx.Done():
 					break
 				}
@@ -78,9 +189,12 @@ func (ht *hedgingTransport) RoundTrip(req *http.Request) (*http.Response, error)
 
 			// Rate limiting: add delay between requests based on maxPerSecond
 			// to prevent overwhelming the server.
-			if ht.rateDelay > 0 {
+			ht.lock.RLock()
+			rateDelay := ht.rateDelay
+			ht.lock.RUnlock()
+			if rateDelay > 0 {
 				select {
-				case <-time.After(ht.rateDelay):
+				case <-time.After(rateDelay):
 				case <-hedgeCtx.Done():
 					break
 				}

--- a/hedging.go
+++ b/hedging.go
@@ -166,7 +166,30 @@ func (ht *Hedging) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	ctx := req.Context()
-	hedgeCtx, cancel := context.WithCancel(ctx)
+	deadline, hasDeadline := ctx.Deadline()
+
+	// Derive hedgeCtx from the original request context to respect cancellations
+	var (
+		hedgeCtx context.Context
+		cancel   context.CancelFunc
+	)
+	if hasDeadline {
+		// Use original deadline for the race (first to complete wins)
+		remaining := time.Until(deadline)
+		if remaining > 0 {
+			hedgeCtx, cancel = context.WithTimeout(ctx, remaining)
+		} else {
+			// Deadline already expired, use context with cancel
+			hedgeCtx, cancel = context.WithCancel(ctx)
+		}
+	} else {
+		// No deadline in original context, create cancellable context from it
+		hedgeCtx, cancel = context.WithCancel(ctx)
+	}
+
+	// defer cancel() ensures cleanup on all paths (timeout, cancellation, or normal return)
+	// cancel() may also be called inside once.Do() when a request wins, but calling it
+	// multiple times is safe and ensures the context is canceled as soon as any goroutine completes
 	defer cancel()
 
 	type result struct {
@@ -174,14 +197,20 @@ func (ht *Hedging) RoundTrip(req *http.Request) (*http.Response, error) {
 		err  error
 	}
 
-	resultCh := make(chan result, ht.MaxRequest())
+	ht.lock.RLock()
+	maxReq := ht.maxRequest
+	delay := ht.delay
+	rateDelay := ht.rateDelay
+	ht.lock.RUnlock()
+
+	resultCh := make(chan result, maxReq)
 	var once sync.Once
 
-	for i := 0; i < ht.MaxRequest(); i++ {
+	for i := range maxReq {
 		if i > 0 {
-			if ht.Delay() > 0 {
+			if delay > 0 {
 				select {
-				case <-time.After(ht.Delay()):
+				case <-time.After(delay):
 				case <-hedgeCtx.Done():
 					break
 				}
@@ -189,9 +218,6 @@ func (ht *Hedging) RoundTrip(req *http.Request) (*http.Response, error) {
 
 			// Rate limiting: add delay between requests based on maxPerSecond
 			// to prevent overwhelming the server.
-			ht.lock.RLock()
-			rateDelay := ht.rateDelay
-			ht.lock.RUnlock()
 			if rateDelay > 0 {
 				select {
 				case <-time.After(rateDelay):
@@ -202,13 +228,16 @@ func (ht *Hedging) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 
 		go func() {
-			hedgedReq := req.Clone(ctx)
+			hedgedReq := req.Clone(hedgeCtx)
 			resp, err := ht.transport.RoundTrip(hedgedReq)
 
 			won := false
 			once.Do(func() {
 				won = true
 				resultCh <- result{resp: resp, err: err}
+
+				// Cancel inside once.Do() to stop other goroutines immediately when a request wins
+				// defer cancel() ensures cleanup even if no request completes successfully
 				cancel()
 			})
 

--- a/hedging_test.go
+++ b/hedging_test.go
@@ -672,3 +672,35 @@ func TestHedgingRateDelayBetweenRequests(t *testing.T) {
 		}
 	}
 }
+
+func TestHedgingNoDoubleWrap(t *testing.T) {
+	h1 := NewHedging().SetDelay(50 * time.Millisecond)
+	h2 := NewHedging().SetDelay(100 * time.Millisecond)
+
+	c := dcnl()
+
+	// Enable hedging first time
+	c.SetHedging(h1)
+	_, ok := c.httpClient.Transport.(*Hedging)
+	assertTrue(t, ok, "Hedging transport")
+
+	// Enable different hedging without disabling first
+	c.SetHedging(h2)
+
+	// Both should be Hedging
+	hedging2, ok := c.httpClient.Transport.(*Hedging)
+	assertTrue(t, ok, "Hedging transport")
+
+	// The wrapped transport should NOT be another Hedging
+	_, isHedging := hedging2.transport.(*Hedging)
+	assertFalse(t, isHedging, "Double-wrapped hedging detected - transport should be unwrapped")
+
+	// Verify transport chain depth, should only have one Hedging layer
+	if hedging, ok := c.httpClient.Transport.(*Hedging); ok {
+		_, isHedging := hedging.transport.(*Hedging)
+		assertFalse(t, isHedging, "Double-wrapped hedging detected")
+	}
+
+	// Verify the configuration is the new one
+	assertEqual(t, hedging2.Delay(), 100*time.Millisecond, "Expected 100ms delay")
+}

--- a/hedging_test.go
+++ b/hedging_test.go
@@ -8,7 +8,6 @@ package resty
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -17,44 +16,22 @@ import (
 	"time"
 )
 
-func createHedgingTestServer(t *testing.T, attemptCount *int32, r1, r2 int32) *httptest.Server {
+func createHedgingTestServer(t *testing.T, attemptCount *int32) *httptest.Server {
+	timeouts := [5]time.Duration{800 * time.Millisecond, 400 * time.Millisecond, 10 * time.Millisecond, 5 * time.Millisecond, 1 * time.Millisecond}
 	return createTestServer(func(w http.ResponseWriter, r *http.Request) {
 		attempt := atomic.AddInt32(attemptCount, 1)
-		t.Logf("Method: %v", r.Method)
-		t.Logf("Path: %v", r.URL.Path)
-
-		delay1 := r1
-		if delay1 == 0 {
-			delay1 = 200
-		}
-
-		delay2 := r2
-		if delay2 == 0 {
-			delay2 = 50
-		}
-
-		switch r.URL.Path {
-		case "/", "/hedging-slow-first":
-			w.Header().Set("X-Attempt", fmt.Sprintf("%d", attempt))
-			if attempt == 1 {
-				time.Sleep(time.Duration(rand.Int31n(delay1)) * time.Millisecond)
-			} else {
-				time.Sleep(time.Duration(rand.Int31n(delay2)) * time.Millisecond)
-			}
-			_, _ = fmt.Fprintf(w, "Attempt %d", attempt)
-		case "/hedging-slow-all":
-			w.Header().Set("X-Attempt", fmt.Sprintf("%d", attempt))
-			time.Sleep(time.Duration(rand.Int31n(delay1)) * time.Millisecond)
-			_, _ = fmt.Fprintf(w, "Attempt %d", attempt)
-		}
+		time.Sleep(timeouts[attempt-1])
+		w.Header().Set("X-Attempt", fmt.Sprintf("%d", attempt))
+		_, _ = fmt.Fprintf(w, "Attempt %d", attempt)
 	})
 }
 
 func TestHedgingBasic(t *testing.T) {
 	var attemptCount int32
-	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
+	ts := createHedgingTestServer(t, &attemptCount)
 	defer ts.Close()
 
+	const maxRequests = 3
 	h := NewHedging().
 		SetDelay(10 * time.Millisecond).
 		SetMaxRequest(3).
@@ -62,28 +39,20 @@ func TestHedgingBasic(t *testing.T) {
 
 	c := dcnl().SetHedging(h)
 
-	resp, err := c.R().Get(ts.URL + "/")
+	resp, err := c.R().Get(ts.URL)
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
-
-	count := atomic.LoadInt32(&attemptCount)
-	if count < 1 {
-		t.Errorf("Expected at least 1 requests, got %d", count)
-	}
+	assertEqual(t, int32(maxRequests), atomic.LoadInt32(&attemptCount), "total attempts should match max requests")
 }
 
 func TestHedgingSecondWins(t *testing.T) {
 	var attemptCount int32
-	firstAttempt := atomic.Int32{}
-
+	winnerAttempt := atomic.Int32{}
+	timeouts := [2]time.Duration{400 * time.Millisecond, 20 * time.Millisecond}
 	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
 		attempt := atomic.AddInt32(&attemptCount, 1)
-		if attempt == 1 {
-			time.Sleep(100 * time.Millisecond)
-		} else {
-			time.Sleep(20 * time.Millisecond)
-		}
-		firstAttempt.CompareAndSwap(0, attempt)
+		time.Sleep(timeouts[attempt-1])
+		winnerAttempt.CompareAndSwap(0, attempt)
 
 		w.Header().Set("X-Attempt", fmt.Sprintf("%d", attempt))
 		w.WriteHeader(http.StatusOK)
@@ -92,27 +61,20 @@ func TestHedgingSecondWins(t *testing.T) {
 	defer ts.Close()
 
 	h := NewHedging().
-		SetDelay(30 * time.Millisecond).
+		SetDelay(10 * time.Millisecond).
 		SetMaxRequest(2).
 		SetMaxRequestPerSecond(0)
 
 	c := dcnl().SetHedging(h)
 
-	resp, err := c.R().Get(ts.URL + "/")
+	resp, err := c.R().Get(ts.URL)
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
 
-	time.Sleep(100 * time.Millisecond)
-
-	winner := firstAttempt.Load()
-	if winner != 2 {
-		t.Errorf("Expected second request to win, got attempt %d", winner)
-	}
-
-	totalAttempts := atomic.LoadInt32(&attemptCount)
-	if totalAttempts < 2 {
-		t.Errorf("Expected at least 2 hedged requests, got %d", totalAttempts)
-	}
+	winnerRequest := winnerAttempt.Load()
+	assertEqual(t, fmt.Sprintf("Attempt %d", winnerRequest), resp.String(), "expected second attempt to win")
+	assertEqual(t, int32(2), winnerRequest, "expected second request to win")
+	assertEqual(t, int32(2), atomic.LoadInt32(&attemptCount), "total attempts should be 2")
 }
 
 func TestHedgingTimeout(t *testing.T) {
@@ -146,7 +108,7 @@ func TestHedgingTimeout(t *testing.T) {
 
 	c := dcnl().SetHedging(h)
 
-	resp, err := c.R().Get(ts.URL + "/")
+	resp, err := c.R().Get(ts.URL)
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
 
@@ -163,12 +125,11 @@ func TestHedgingTimeout(t *testing.T) {
 
 func TestHedgingReadOnlyMethodsOnly(t *testing.T) {
 	var attemptCount int32
-
-	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
+	ts := createHedgingTestServer(t, &attemptCount)
 	defer ts.Close()
 
 	h := NewHedging().
-		SetDelay(20 * time.Millisecond).
+		SetDelay(10 * time.Millisecond).
 		SetMaxRequest(3).
 		SetMaxRequestPerSecond(0)
 
@@ -192,21 +153,17 @@ func TestHedgingReadOnlyMethodsOnly(t *testing.T) {
 		t.Run(tc.method, func(t *testing.T) {
 			atomic.StoreInt32(&attemptCount, 0)
 
-			resp, err := tc.requestFunc(c, ts.URL+"/")
+			resp, err := tc.requestFunc(c, ts.URL)
 			assertError(t, err)
 			assertEqual(t, http.StatusOK, resp.StatusCode())
 
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(20 * time.Millisecond)
 
 			count := atomic.LoadInt32(&attemptCount)
 			if tc.expectHedging {
-				if count < 2 {
-					t.Logf("%s: Expected hedging (multiple requests), got %d request(s)", tc.method, count)
-				}
+				assertNotEqual(t, 1, count, fmt.Sprintf("%s: expected hedging with multiple requests, got %d request(s)", tc.method, count))
 			} else {
-				if count != 1 {
-					t.Errorf("%s: Expected no hedging (1 request), got %d request(s)", tc.method, count)
-				}
+				assertEqual(t, int32(1), count, fmt.Sprintf("%s: no hedging 1 request only", tc.method))
 			}
 		})
 	}
@@ -214,8 +171,7 @@ func TestHedgingReadOnlyMethodsOnly(t *testing.T) {
 
 func TestHedgingRateLimit(t *testing.T) {
 	var attemptCount int32
-
-	ts := createHedgingTestServer(t, &attemptCount, 500, 0)
+	ts := createHedgingTestServer(t, &attemptCount)
 	defer ts.Close()
 
 	h := NewHedging().
@@ -226,7 +182,7 @@ func TestHedgingRateLimit(t *testing.T) {
 	c := dcnl().SetHedging(h)
 
 	start := time.Now()
-	resp, err := c.R().Get(ts.URL + "/")
+	resp, err := c.R().Get(ts.URL)
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
 
@@ -266,12 +222,11 @@ func TestHedgingWithRetryFallback(t *testing.T) {
 
 func TestHedgingDisable(t *testing.T) {
 	var attemptCount int32
-
-	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
+	ts := createHedgingTestServer(t, &attemptCount)
 	defer ts.Close()
 
 	h := NewHedging().
-		SetDelay(20 * time.Millisecond).
+		SetDelay(10 * time.Millisecond).
 		SetMaxRequest(3).
 		SetMaxRequestPerSecond(0)
 
@@ -283,11 +238,11 @@ func TestHedgingDisable(t *testing.T) {
 	assertEqual(t, false, c.isHedgingEnabled())
 
 	atomic.StoreInt32(&attemptCount, 0)
-	resp, err := c.R().Get(ts.URL + "/")
+	resp, err := c.R().Get(ts.URL)
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 
 	assertEqual(t, int32(1), atomic.LoadInt32(&attemptCount))
 }
@@ -296,41 +251,33 @@ func TestHedgingContextCancellation(t *testing.T) {
 	attemptCount := atomic.Int32{}
 	startedCount := atomic.Int32{}
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
 		startedCount.Add(1)
 		time.Sleep(200 * time.Millisecond)
 		attemptCount.Add(1)
 		w.WriteHeader(http.StatusOK)
-	}))
+	})
 	defer ts.Close()
 
 	h := NewHedging().
-		SetDelay(20 * time.Millisecond).
+		SetDelay(10 * time.Millisecond).
 		SetMaxRequest(3).
 		SetMaxRequestPerSecond(0)
 
 	c := dcnl().SetHedging(h)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
 
-	_, err := c.R().SetContext(ctx).Get(ts.URL + "/")
-	if err == nil {
-		t.Error("Expected context cancellation error")
-	}
+	_, err := c.R().SetContext(ctx).Get(ts.URL)
+	assertErrorIs(t, context.DeadlineExceeded, err)
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 
 	started := startedCount.Load()
 	completed := attemptCount.Load()
-
-	if started < 2 {
-		t.Logf("Expected multiple hedged requests to start, got %d", started)
-	}
-
-	if completed > 0 {
-		t.Logf("Context cancellation should have prevented completion, but %d completed", completed)
-	}
+	assertTrue(t, started > 1, "expected multiple hedged request to start")
+	assertEqual(t, int32(0), completed, "context cancellation should have prevented completion")
 }
 
 func TestHedgingConfiguration(t *testing.T) {
@@ -383,90 +330,68 @@ func TestHedgingConfigurationViaClient(t *testing.T) {
 
 func TestHedgingWithCustomTransport(t *testing.T) {
 	var attemptCount int32
-
-	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
+	ts := createHedgingTestServer(t, &attemptCount)
 	defer ts.Close()
 
 	customTransport := &http.Transport{}
 	c := NewWithClient(&http.Client{Transport: customTransport})
 
 	h := NewHedging().
-		SetDelay(20 * time.Millisecond).
+		SetDelay(10 * time.Millisecond).
 		SetMaxRequest(3).
 		SetMaxRequestPerSecond(0)
 	c.SetHedging(h)
 
-	resp, err := c.R().Get(ts.URL + "/")
+	resp, err := c.R().Get(ts.URL)
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
+	assertEqual(t, int32(3), atomic.LoadInt32(&attemptCount), "Expected 3 attempts with hedging enabled")
 
-	time.Sleep(100 * time.Millisecond)
-
-	count := atomic.LoadInt32(&attemptCount)
-	if count < 2 {
-		t.Errorf("Expected hedging with custom transport, got %d request(s)", count)
-	}
-
+	// disable hedging and verify transport is unwrapped
 	c.SetHedging(nil)
-
-	ht, ok := c.httpClient.Transport.(*Hedging)
-	if ok {
-		t.Error("Transport should be unwrapped after Disabling Hedging")
-	}
-	_ = ht
+	_, ok := c.httpClient.Transport.(*Hedging)
+	assertFalse(t, ok, "transport should be unwrapped after disabling hedging")
 }
 
 func TestHedgingSingleRequest(t *testing.T) {
 	var attemptCount int32
-
-	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
+	ts := createHedgingTestServer(t, &attemptCount)
 	defer ts.Close()
 
 	h := NewHedging().
-		SetDelay(20 * time.Millisecond).
+		SetDelay(10 * time.Millisecond).
 		SetMaxRequest(1).
 		SetMaxRequestPerSecond(0)
 
 	c := dcnl().SetHedging(h)
 
-	resp, err := c.R().Get(ts.URL + "/")
+	resp, err := c.R().Get(ts.URL)
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
-
-	time.Sleep(100 * time.Millisecond)
-
 	assertEqual(t, int32(1), atomic.LoadInt32(&attemptCount))
 }
 
 func TestHedgingAllowNonReadOnly(t *testing.T) {
 	var attemptCount int32
-
-	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
+	ts := createHedgingTestServer(t, &attemptCount)
 	defer ts.Close()
 
 	h := NewHedging().
-		SetDelay(20 * time.Millisecond).
+		SetDelay(10 * time.Millisecond).
 		SetMaxRequest(3).
 		SetMaxRequestPerSecond(0)
 
 	c := dcnl().SetHedging(h)
 
-	hh := c.Hedging()
-	_ = hh
 	// By default, non-read-only methods should not be hedged
 	assertEqual(t, false, c.Hedging().IsNonReadOnlyAllowed())
 
 	// Test POST without allowing non-read-only
 	atomic.StoreInt32(&attemptCount, 0)
-	resp, err := c.R().Post(ts.URL + "/")
+	resp, err := c.R().Post(ts.URL)
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
-
-	time.Sleep(100 * time.Millisecond)
-	count := atomic.LoadInt32(&attemptCount)
-	if count != 1 {
-		t.Errorf("Expected no hedging for POST without allow flag, got %d request(s)", count)
-	}
+	assertEqual(t, int32(1), atomic.LoadInt32(&attemptCount), "no hedging for POST without allow flag")
 
 	// Enable non-read-only methods
 	c.Hedging().SetNonReadOnlyAllowed(true)
@@ -474,52 +399,39 @@ func TestHedgingAllowNonReadOnly(t *testing.T) {
 
 	// Test POST with allowing non-read-only
 	atomic.StoreInt32(&attemptCount, 0)
-	resp, err = c.R().Post(ts.URL + "/")
+	resp, err = c.R().Post(ts.URL)
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
-
-	time.Sleep(100 * time.Millisecond)
-	count = atomic.LoadInt32(&attemptCount)
-	if count < 2 {
-		t.Errorf("Expected hedging for POST with allow flag, got %d request(s)", count)
-	}
+	assertEqual(t, int32(3), atomic.LoadInt32(&attemptCount), "hedging for POST with allow flag")
 }
 
 func TestHedgingWithNilTransport(t *testing.T) {
 	var attemptCount int32
-
-	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
+	ts := createHedgingTestServer(t, &attemptCount)
 	defer ts.Close()
 
 	// Create client with nil transport
 	c := NewWithClient(&http.Client{Transport: nil})
 
 	h := NewHedging().
-		SetDelay(20 * time.Millisecond).
+		SetDelay(10 * time.Millisecond).
 		SetMaxRequest(3).
 		SetMaxRequestPerSecond(0)
 	c.SetHedging(h)
 
-	resp, err := c.R().Get(ts.URL + "/")
+	resp, err := c.R().Get(ts.URL)
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
-
-	time.Sleep(100 * time.Millisecond)
-
-	count := atomic.LoadInt32(&attemptCount)
-	if count < 2 {
-		t.Errorf("Expected hedging with nil transport, got %d request(s)", count)
-	}
+	assertEqual(t, int32(3), atomic.LoadInt32(&attemptCount), "hedging with nil transport should still work")
 }
 
 func TestHedgingEnableMultipleTimes(t *testing.T) {
 	var attemptCount int32
-
-	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
+	ts := createHedgingTestServer(t, &attemptCount)
 	defer ts.Close()
 
 	h := NewHedging().
-		SetDelay(20 * time.Millisecond).
+		SetDelay(10 * time.Millisecond).
 		SetMaxRequest(3).
 		SetMaxRequestPerSecond(0)
 
@@ -541,16 +453,10 @@ func TestHedgingEnableMultipleTimes(t *testing.T) {
 	assertEqual(t, 10.0, c.Hedging().MaxRequestPerSecond())
 
 	// Verify hedging still works
-	resp, err := c.R().Get(ts.URL + "/")
+	resp, err := c.R().Get(ts.URL)
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
-
-	time.Sleep(100 * time.Millisecond)
-
-	count := atomic.LoadInt32(&attemptCount)
-	if count < 2 {
-		t.Errorf("Expected hedging after re-enabling, got %d request(s)", count)
-	}
+	assertEqual(t, int32(3), atomic.LoadInt32(&attemptCount), "expected hedging after re-enabling")
 }
 
 func TestHedgingWrapWithDisabledHedging(t *testing.T) {
@@ -569,52 +475,7 @@ func TestHedgingWrapWithDisabledHedging(t *testing.T) {
 
 	// Verify transport is not a hedgingTransport
 	_, ok := c.httpClient.Transport.(*Hedging)
-	if ok {
-		t.Error("Transport should not be hedging Transport after Disabling Hedging")
-	}
-}
-
-func TestHedgingWrapAlreadyWrapped(t *testing.T) {
-	var attemptCount int32
-
-	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
-	defer ts.Close()
-
-	h := NewHedging().
-		SetDelay(20 * time.Millisecond).
-		SetMaxRequest(3).
-		SetMaxRequestPerSecond(0)
-
-	c := dcnl()
-
-	// Enable hedging first time - wraps transport
-	c.SetHedging(h)
-
-	// Get the current transport (should be hedgingTransport)
-	_, ok := c.httpClient.Transport.(*Hedging)
-	if !ok {
-		t.Error("Transport should be hedging Transport after Enabling Hedging")
-	}
-
-	// Manually re-enable hedging without disabling first
-	// This should detect transport is already hedgingTransport and return early
-	nh := NewHedging().
-		SetDelay(30 * time.Millisecond).
-		SetMaxRequest(5).
-		SetMaxRequestPerSecond(10.0)
-	c.SetHedging(nh)
-
-	// Verify it still works
-	resp, err := c.R().Get(ts.URL + "/")
-	assertError(t, err)
-	assertEqual(t, http.StatusOK, resp.StatusCode())
-
-	time.Sleep(100 * time.Millisecond)
-
-	count := atomic.LoadInt32(&attemptCount)
-	if count < 2 {
-		t.Errorf("Expected hedging to still work, got %d request(s)", count)
-	}
+	assertFalse(t, ok, "transport should not be hedging transport")
 }
 
 func TestHedgingRateDelayBetweenRequests(t *testing.T) {
@@ -633,7 +494,7 @@ func TestHedgingRateDelayBetweenRequests(t *testing.T) {
 	defer ts.Close()
 
 	c := dcnl()
-	// delay=10ms, upTo=3, maxPerSecond=5.0 (rateDelay = 200ms)
+	// delay=10ms, maxRequest=3, maxRequestPerSecond=5.0 (rateDelay = 200ms)
 	// Expected timing: req1 at 0, req2 at ~10ms + 200ms = ~210ms, req3 at ~420ms
 	h := NewHedging().
 		SetDelay(10 * time.Millisecond).
@@ -641,7 +502,7 @@ func TestHedgingRateDelayBetweenRequests(t *testing.T) {
 		SetMaxRequestPerSecond(5.0)
 	c.SetHedging(h)
 
-	_, err := c.R().Get(ts.URL + "/")
+	_, err := c.R().Get(ts.URL)
 	assertError(t, err)
 
 	// Wait for all requests to be recorded
@@ -652,9 +513,7 @@ func TestHedgingRateDelayBetweenRequests(t *testing.T) {
 	copy(times, requestTimes)
 	mu.Unlock()
 
-	if len(times) < 2 {
-		t.Fatalf("Expected at least 2 hedged requests, got %d", len(times))
-	}
+	assertEqual(t, 3, len(times), "expected 3 hedged requests to be sent")
 
 	// Verify rate delay was applied between requests
 	// With maxPerSecond=5.0, rateDelay should be 200ms
@@ -703,4 +562,26 @@ func TestHedgingNoDoubleWrap(t *testing.T) {
 
 	// Verify the configuration is the new one
 	assertEqual(t, hedging2.Delay(), 100*time.Millisecond, "Expected 100ms delay")
+}
+
+func TestHedgingRoundTripDeadlineExpired(t *testing.T) {
+	var attemptCount int32
+	ts := createHedgingTestServer(t, &attemptCount)
+	defer ts.Close()
+
+	h := NewHedging().
+		SetDelay(10 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
+
+	c := dcnl().SetHedging(h)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Millisecond))
+	defer cancel()
+
+	_, err := c.R().SetContext(ctx).Get(ts.URL)
+	assertErrorIs(t, context.DeadlineExceeded, err, "Expected context deadline expired error")
+
+	time.Sleep(50 * time.Millisecond)
+	assertEqual(t, int32(0), atomic.LoadInt32(&attemptCount))
 }

--- a/hedging_test.go
+++ b/hedging_test.go
@@ -55,29 +55,33 @@ func TestHedgingBasic(t *testing.T) {
 	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
 	defer ts.Close()
 
-	c := dcnl()
-	c.EnableHedging(20*time.Millisecond, 3, 0)
+	h := NewHedging().
+		SetDelay(10 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
+
+	c := dcnl().SetHedging(h)
 
 	resp, err := c.R().Get(ts.URL + "/")
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
 
 	count := atomic.LoadInt32(&attemptCount)
-	if count < 2 {
-		t.Errorf("Expected at least 2 requests, got %d", count)
+	if count < 1 {
+		t.Errorf("Expected at least 1 requests, got %d", count)
 	}
 }
 
-func TestHedgingFirstWins(t *testing.T) {
+func TestHedgingSecondWins(t *testing.T) {
 	var attemptCount int32
 	firstAttempt := atomic.Int32{}
 
 	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
 		attempt := atomic.AddInt32(&attemptCount, 1)
 		if attempt == 1 {
-			time.Sleep(200 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 		} else {
-			time.Sleep(50 * time.Millisecond)
+			time.Sleep(20 * time.Millisecond)
 		}
 		firstAttempt.CompareAndSwap(0, attempt)
 
@@ -87,8 +91,12 @@ func TestHedgingFirstWins(t *testing.T) {
 	})
 	defer ts.Close()
 
-	c := dcnl()
-	c.EnableHedging(30*time.Millisecond, 2, 0)
+	h := NewHedging().
+		SetDelay(30 * time.Millisecond).
+		SetMaxRequest(2).
+		SetMaxRequestPerSecond(0)
+
+	c := dcnl().SetHedging(h)
 
 	resp, err := c.R().Get(ts.URL + "/")
 	assertError(t, err)
@@ -130,9 +138,13 @@ func TestHedgingTimeout(t *testing.T) {
 	})
 	defer ts.Close()
 
-	c := dcnl()
 	delay := 50 * time.Millisecond
-	c.EnableHedging(delay, 3, 0)
+	h := NewHedging().
+		SetDelay(delay).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
+
+	c := dcnl().SetHedging(h)
 
 	resp, err := c.R().Get(ts.URL + "/")
 	assertError(t, err)
@@ -155,8 +167,12 @@ func TestHedgingReadOnlyMethodsOnly(t *testing.T) {
 	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
 	defer ts.Close()
 
-	c := dcnl()
-	c.EnableHedging(20*time.Millisecond, 3, 0)
+	h := NewHedging().
+		SetDelay(20 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
+
+	c := dcnl().SetHedging(h)
 
 	testCases := []struct {
 		method        string
@@ -202,8 +218,12 @@ func TestHedgingRateLimit(t *testing.T) {
 	ts := createHedgingTestServer(t, &attemptCount, 500, 0)
 	defer ts.Close()
 
-	c := dcnl()
-	c.EnableHedging(10*time.Millisecond, 10, 5.0)
+	h := NewHedging().
+		SetDelay(10 * time.Millisecond).
+		SetMaxRequest(10).
+		SetMaxRequestPerSecond(5.0)
+
+	c := dcnl().SetHedging(h)
 
 	start := time.Now()
 	resp, err := c.R().Get(ts.URL + "/")
@@ -224,18 +244,23 @@ func TestHedgingWithRetryFallback(t *testing.T) {
 	c.SetRetryCount(2)
 	assertEqual(t, 2, c.RetryCount())
 
+	h := NewHedging().
+		SetDelay(50 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
+
 	// Enable hedging should disable retry by default
-	c.EnableHedging(50*time.Millisecond, 3, 0)
+	c.SetHedging(h)
 	assertEqual(t, 0, c.RetryCount())
 
 	// But user can re-enable retry as fallback
 	c.SetRetryCount(1)
 	assertEqual(t, 1, c.RetryCount())
-	assertEqual(t, true, c.IsHedgingEnabled())
+	assertEqual(t, true, c.isHedgingEnabled())
 
 	// Disable hedging
-	c.DisableHedging()
-	assertEqual(t, false, c.IsHedgingEnabled())
+	c.SetHedging(nil)
+	assertEqual(t, false, c.isHedgingEnabled())
 	assertEqual(t, 1, c.RetryCount()) // Retry count should remain
 }
 
@@ -245,12 +270,17 @@ func TestHedgingDisable(t *testing.T) {
 	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
 	defer ts.Close()
 
-	c := dcnl()
-	c.EnableHedging(20*time.Millisecond, 3, 0)
-	assertEqual(t, true, c.IsHedgingEnabled())
+	h := NewHedging().
+		SetDelay(20 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
 
-	c.DisableHedging()
-	assertEqual(t, false, c.IsHedgingEnabled())
+	c := dcnl()
+	c.SetHedging(h)
+	assertEqual(t, true, c.isHedgingEnabled())
+
+	c.SetHedging(nil)
+	assertEqual(t, false, c.isHedgingEnabled())
 
 	atomic.StoreInt32(&attemptCount, 0)
 	resp, err := c.R().Get(ts.URL + "/")
@@ -274,8 +304,12 @@ func TestHedgingContextCancellation(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := dcnl()
-	c.EnableHedging(20*time.Millisecond, 3, 0)
+	h := NewHedging().
+		SetDelay(20 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
+
+	c := dcnl().SetHedging(h)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
@@ -300,27 +334,51 @@ func TestHedgingContextCancellation(t *testing.T) {
 }
 
 func TestHedgingConfiguration(t *testing.T) {
+	h := NewHedging().
+		SetDelay(50 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(10.0)
+	assertEqual(t, 50*time.Millisecond, h.Delay())
+	assertEqual(t, 3, h.MaxRequest())
+	assertEqual(t, 10.0, h.MaxRequestPerSecond())
+
+	// Now we can update individual settings
+	h.SetDelay(100 * time.Millisecond)
+	assertEqual(t, 100*time.Millisecond, h.Delay())
+
+	h.SetMaxRequest(5)
+	assertEqual(t, 5, h.MaxRequest())
+
+	h.SetMaxRequestPerSecond(20.0)
+	assertEqual(t, 20.0, h.MaxRequestPerSecond())
+}
+
+func TestHedgingConfigurationViaClient(t *testing.T) {
 	c := dcnl()
 
 	// Setters require hedging to be enabled first
-	assertEqual(t, false, c.IsHedgingEnabled())
+	assertEqual(t, false, c.isHedgingEnabled())
 
-	c.EnableHedging(50*time.Millisecond, 3, 10.0)
+	h := NewHedging().
+		SetDelay(50 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(10.0)
+	c.SetHedging(h)
 
-	assertEqual(t, true, c.IsHedgingEnabled())
-	assertEqual(t, 50*time.Millisecond, c.HedgingDelay())
-	assertEqual(t, 3, c.HedgingUpTo())
-	assertEqual(t, 10.0, c.HedgingMaxPerSecond())
+	assertEqual(t, true, c.isHedgingEnabled())
+	assertEqual(t, 50*time.Millisecond, c.Hedging().Delay())
+	assertEqual(t, 3, c.Hedging().MaxRequest())
+	assertEqual(t, 10.0, c.Hedging().MaxRequestPerSecond())
 
 	// Now we can update individual settings
-	c.SetHedgingDelay(100 * time.Millisecond)
-	assertEqual(t, 100*time.Millisecond, c.HedgingDelay())
+	c.Hedging().SetDelay(100 * time.Millisecond)
+	assertEqual(t, 100*time.Millisecond, c.Hedging().Delay())
 
-	c.SetHedgingUpTo(5)
-	assertEqual(t, 5, c.HedgingUpTo())
+	c.Hedging().SetMaxRequest(5)
+	assertEqual(t, 5, c.Hedging().MaxRequest())
 
-	c.SetHedgingMaxPerSecond(20.0)
-	assertEqual(t, 20.0, c.HedgingMaxPerSecond())
+	c.Hedging().SetMaxRequestPerSecond(20.0)
+	assertEqual(t, 20.0, c.Hedging().MaxRequestPerSecond())
 }
 
 func TestHedgingWithCustomTransport(t *testing.T) {
@@ -332,7 +390,11 @@ func TestHedgingWithCustomTransport(t *testing.T) {
 	customTransport := &http.Transport{}
 	c := NewWithClient(&http.Client{Transport: customTransport})
 
-	c.EnableHedging(20*time.Millisecond, 3, 0)
+	h := NewHedging().
+		SetDelay(20 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
+	c.SetHedging(h)
 
 	resp, err := c.R().Get(ts.URL + "/")
 	assertError(t, err)
@@ -345,11 +407,11 @@ func TestHedgingWithCustomTransport(t *testing.T) {
 		t.Errorf("Expected hedging with custom transport, got %d request(s)", count)
 	}
 
-	c.DisableHedging()
+	c.SetHedging(nil)
 
-	ht, ok := c.httpClient.Transport.(*hedgingTransport)
+	ht, ok := c.httpClient.Transport.(*Hedging)
 	if ok {
-		t.Error("Transport should be unwrapped after DisableHedging")
+		t.Error("Transport should be unwrapped after Disabling Hedging")
 	}
 	_ = ht
 }
@@ -360,8 +422,12 @@ func TestHedgingSingleRequest(t *testing.T) {
 	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
 	defer ts.Close()
 
-	c := dcnl()
-	c.EnableHedging(20*time.Millisecond, 1, 0)
+	h := NewHedging().
+		SetDelay(20 * time.Millisecond).
+		SetMaxRequest(1).
+		SetMaxRequestPerSecond(0)
+
+	c := dcnl().SetHedging(h)
 
 	resp, err := c.R().Get(ts.URL + "/")
 	assertError(t, err)
@@ -372,46 +438,23 @@ func TestHedgingSingleRequest(t *testing.T) {
 	assertEqual(t, int32(1), atomic.LoadInt32(&attemptCount))
 }
 
-func TestHedgingSettersWhenDisabled(t *testing.T) {
-	c := dcnl()
-
-	// Verify hedging is not enabled
-	assertEqual(t, false, c.IsHedgingEnabled())
-
-	// Test setters when hedging is disabled - they should log errors but not panic
-	c.SetHedgingDelay(100 * time.Millisecond)
-	c.SetHedgingUpTo(5)
-	c.SetHedgingMaxPerSecond(20.0)
-	c.SetHedgingAllowNonReadOnly(true)
-
-	// Verify hedging is still not enabled
-	assertEqual(t, false, c.IsHedgingEnabled())
-}
-
-func TestHedgingGettersWhenDisabled(t *testing.T) {
-	c := dcnl()
-
-	// Verify hedging is not enabled
-	assertEqual(t, false, c.IsHedgingEnabled())
-
-	// Test getters when hedging is disabled - they should return defaults
-	assertEqual(t, time.Duration(0), c.HedgingDelay())
-	assertEqual(t, 0, c.HedgingUpTo())
-	assertEqual(t, 0.0, c.HedgingMaxPerSecond())
-	assertEqual(t, false, c.IsHedgingAllowNonReadOnly())
-}
-
 func TestHedgingAllowNonReadOnly(t *testing.T) {
 	var attemptCount int32
 
 	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
 	defer ts.Close()
 
-	c := dcnl()
-	c.EnableHedging(20*time.Millisecond, 3, 0)
+	h := NewHedging().
+		SetDelay(20 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
 
+	c := dcnl().SetHedging(h)
+
+	hh := c.Hedging()
+	_ = hh
 	// By default, non-read-only methods should not be hedged
-	assertEqual(t, false, c.IsHedgingAllowNonReadOnly())
+	assertEqual(t, false, c.Hedging().IsNonReadOnlyAllowed())
 
 	// Test POST without allowing non-read-only
 	atomic.StoreInt32(&attemptCount, 0)
@@ -426,8 +469,8 @@ func TestHedgingAllowNonReadOnly(t *testing.T) {
 	}
 
 	// Enable non-read-only methods
-	c.SetHedgingAllowNonReadOnly(true)
-	assertEqual(t, true, c.IsHedgingAllowNonReadOnly())
+	c.Hedging().SetNonReadOnlyAllowed(true)
+	assertEqual(t, true, c.Hedging().IsNonReadOnlyAllowed())
 
 	// Test POST with allowing non-read-only
 	atomic.StoreInt32(&attemptCount, 0)
@@ -451,7 +494,11 @@ func TestHedgingWithNilTransport(t *testing.T) {
 	// Create client with nil transport
 	c := NewWithClient(&http.Client{Transport: nil})
 
-	c.EnableHedging(20*time.Millisecond, 3, 0)
+	h := NewHedging().
+		SetDelay(20 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
+	c.SetHedging(h)
 
 	resp, err := c.R().Get(ts.URL + "/")
 	assertError(t, err)
@@ -471,18 +518,27 @@ func TestHedgingEnableMultipleTimes(t *testing.T) {
 	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
 	defer ts.Close()
 
+	h := NewHedging().
+		SetDelay(20 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
+
 	c := dcnl()
 
 	// Enable hedging first time
-	c.EnableHedging(20*time.Millisecond, 3, 0)
-	assertEqual(t, true, c.IsHedgingEnabled())
+	c.SetHedging(h)
+	assertEqual(t, true, c.isHedgingEnabled())
 
 	// Enable hedging again without disabling - should handle already wrapped transport
-	c.EnableHedging(30*time.Millisecond, 5, 10.0)
-	assertEqual(t, true, c.IsHedgingEnabled())
-	assertEqual(t, 30*time.Millisecond, c.HedgingDelay())
-	assertEqual(t, 5, c.HedgingUpTo())
-	assertEqual(t, 10.0, c.HedgingMaxPerSecond())
+	nh := NewHedging().
+		SetDelay(30 * time.Millisecond).
+		SetMaxRequest(5).
+		SetMaxRequestPerSecond(10.0)
+	c.SetHedging(nh)
+	assertEqual(t, true, c.isHedgingEnabled())
+	assertEqual(t, 30*time.Millisecond, c.Hedging().Delay())
+	assertEqual(t, 5, c.Hedging().MaxRequest())
+	assertEqual(t, 10.0, c.Hedging().MaxRequestPerSecond())
 
 	// Verify hedging still works
 	resp, err := c.R().Get(ts.URL + "/")
@@ -500,22 +556,22 @@ func TestHedgingEnableMultipleTimes(t *testing.T) {
 func TestHedgingWrapWithDisabledHedging(t *testing.T) {
 	c := dcnl()
 
+	h := NewHedging().
+		SetDelay(20 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
 	// Enable and then disable hedging
-	c.EnableHedging(20*time.Millisecond, 3, 0)
-	c.DisableHedging()
+	c.SetHedging(h)
+	assertEqual(t, true, c.isHedgingEnabled())
 
-	assertEqual(t, false, c.IsHedgingEnabled())
+	c.SetHedging(nil)
+	assertEqual(t, false, c.isHedgingEnabled())
 
 	// Verify transport is not a hedgingTransport
-	_, ok := c.httpClient.Transport.(*hedgingTransport)
+	_, ok := c.httpClient.Transport.(*Hedging)
 	if ok {
-		t.Error("Transport should not be hedgingTransport after DisableHedging")
+		t.Error("Transport should not be hedging Transport after Disabling Hedging")
 	}
-
-	// Now try SetHedgingAllowNonReadOnly when hedging is disabled
-	// This should trigger the error path and NOT call wrapTransportWithHedging
-	c.SetHedgingAllowNonReadOnly(true)
-	assertEqual(t, false, c.IsHedgingEnabled())
 }
 
 func TestHedgingWrapAlreadyWrapped(t *testing.T) {
@@ -524,20 +580,29 @@ func TestHedgingWrapAlreadyWrapped(t *testing.T) {
 	ts := createHedgingTestServer(t, &attemptCount, 0, 0)
 	defer ts.Close()
 
+	h := NewHedging().
+		SetDelay(20 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(0)
+
 	c := dcnl()
 
 	// Enable hedging first time - wraps transport
-	c.EnableHedging(20*time.Millisecond, 3, 0)
+	c.SetHedging(h)
 
 	// Get the current transport (should be hedgingTransport)
-	_, ok := c.httpClient.Transport.(*hedgingTransport)
+	_, ok := c.httpClient.Transport.(*Hedging)
 	if !ok {
-		t.Error("Transport should be hedgingTransport after EnableHedging")
+		t.Error("Transport should be hedging Transport after Enabling Hedging")
 	}
 
 	// Manually re-enable hedging without disabling first
-	// This should detect transport is already hedgingTransport and return early (line 1604)
-	c.EnableHedging(30*time.Millisecond, 5, 10.0)
+	// This should detect transport is already hedgingTransport and return early
+	nh := NewHedging().
+		SetDelay(30 * time.Millisecond).
+		SetMaxRequest(5).
+		SetMaxRequestPerSecond(10.0)
+	c.SetHedging(nh)
 
 	// Verify it still works
 	resp, err := c.R().Get(ts.URL + "/")
@@ -570,7 +635,11 @@ func TestHedgingRateDelayBetweenRequests(t *testing.T) {
 	c := dcnl()
 	// delay=10ms, upTo=3, maxPerSecond=5.0 (rateDelay = 200ms)
 	// Expected timing: req1 at 0, req2 at ~10ms + 200ms = ~210ms, req3 at ~420ms
-	c.EnableHedging(10*time.Millisecond, 3, 5.0)
+	h := NewHedging().
+		SetDelay(10 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(5.0)
+	c.SetHedging(h)
 
 	_, err := c.R().Get(ts.URL + "/")
 	assertError(t, err)

--- a/load_balancer.go
+++ b/load_balancer.go
@@ -6,6 +6,7 @@
 package resty
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -15,10 +16,13 @@ import (
 	"time"
 )
 
+// ErrNoBaseURLs error returned when no base URLs are found
+var ErrNoBaseURLs = errors.New("resty: no base URLs found")
+
 // LoadBalancer is the interface that wraps the HTTP client load-balancing
 // algorithm that returns the "Next" Base URL for the request to target
 type LoadBalancer interface {
-	Next() (string, error)
+	NextWithContext(ctx context.Context) (string, error)
 	Feedback(*RequestFeedback)
 	Close() error
 }
@@ -34,6 +38,10 @@ type RequestFeedback struct {
 // NewRoundRobin method creates the new Round-Robin(RR) request load balancer
 // instance with given base URLs
 func NewRoundRobin(baseURLs ...string) (*RoundRobin, error) {
+	if len(baseURLs) == 0 {
+		return nil, ErrNoBaseURLs
+	}
+
 	rr := &RoundRobin{lock: new(sync.Mutex)}
 	if err := rr.Refresh(baseURLs...); err != nil {
 		return rr, err
@@ -51,10 +59,21 @@ type RoundRobin struct {
 	current  int
 }
 
-// Next method returns the next Base URL based on the Round-Robin(RR) algorithm
-func (rr *RoundRobin) Next() (string, error) {
+// NextWithContext method returns the next Base URL based on the Round-Robin(RR) algorithm
+// with context support for cancellation
+func (rr *RoundRobin) NextWithContext(ctx context.Context) (string, error) {
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+	}
+
 	rr.lock.Lock()
 	defer rr.lock.Unlock()
+
+	if len(rr.baseURLs) == 0 {
+		return "", ErrNoBaseURLs
+	}
 
 	baseURL := rr.baseURLs[rr.current]
 	rr.current = (rr.current + 1) % len(rr.baseURLs)
@@ -135,7 +154,7 @@ func NewWeightedRoundRobin(recovery time.Duration, hosts ...*Host) (*WeightedRou
 		recovery = 120 * time.Second // defaults to 120 seconds
 	}
 	wrr := &WeightedRoundRobin{
-		lock:     new(sync.Mutex),
+		lock:     new(sync.RWMutex),
 		hosts:    make([]*Host, 0),
 		tick:     time.NewTicker(recovery),
 		recovery: recovery,
@@ -153,7 +172,7 @@ var _ LoadBalancer = (*WeightedRoundRobin)(nil)
 // WeightedRoundRobin struct used to represent the host details for
 // Weighted Round-Robin(WRR) algorithm implementation
 type WeightedRoundRobin struct {
-	lock          *sync.Mutex
+	lock          *sync.RWMutex
 	hosts         []*Host
 	totalWeight   int
 	tick          *time.Ticker
@@ -165,8 +184,15 @@ type WeightedRoundRobin struct {
 	recovery time.Duration
 }
 
-// Next method returns the next Base URL based on Weighted Round-Robin(WRR)
-func (wrr *WeightedRoundRobin) Next() (string, error) {
+// NextWithContext method returns the next Base URL based on Weighted Round-Robin(WRR)
+// with context support for cancellation
+func (wrr *WeightedRoundRobin) NextWithContext(ctx context.Context) (string, error) {
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+	}
+
 	wrr.lock.Lock()
 	defer wrr.lock.Unlock()
 
@@ -196,6 +222,10 @@ func (wrr *WeightedRoundRobin) Next() (string, error) {
 // Feedback method process the request feedback for Weighted Round-Robin(WRR)
 // request load balancer
 func (wrr *WeightedRoundRobin) Feedback(f *RequestFeedback) {
+	if f == nil {
+		return
+	}
+
 	wrr.lock.Lock()
 	defer wrr.lock.Unlock()
 
@@ -273,7 +303,11 @@ func (wrr *WeightedRoundRobin) SetRecoveryDuration(d time.Duration) {
 func (wrr *WeightedRoundRobin) ticker() {
 	for range wrr.tick.C {
 		wrr.lock.Lock()
-		for _, host := range wrr.hosts {
+		hosts := make([]*Host, len(wrr.hosts))
+		copy(hosts, wrr.hosts)
+		wrr.lock.Unlock()
+
+		for _, host := range hosts {
 			if host.state == HostStateInActive {
 				host.state = HostStateActive
 				host.failedRequests = 0
@@ -283,7 +317,6 @@ func (wrr *WeightedRoundRobin) ticker() {
 				}
 			}
 		}
-		wrr.lock.Unlock()
 	}
 }
 
@@ -334,9 +367,10 @@ type SRVWeightedRoundRobin struct {
 	lookupSRV func() ([]*net.SRV, error)
 }
 
-// Next method returns the next SRV Base URL based on Weighted Round-Robin(RR)
-func (swrr *SRVWeightedRoundRobin) Next() (string, error) {
-	return swrr.wrr.Next()
+// NextWithContext method returns the next SRV Base URL based on Weighted Round-Robin(RR)
+// with context support for cancellation
+func (swrr *SRVWeightedRoundRobin) NextWithContext(ctx context.Context) (string, error) {
+	return swrr.wrr.NextWithContext(ctx)
 }
 
 // Feedback method does nothing in SRV Base URL based on Weighted Round-Robin(WRR)

--- a/load_balancer_test.go
+++ b/load_balancer_test.go
@@ -6,6 +6,7 @@
 package resty
 
 import (
+	"context"
 	"errors"
 	"net"
 	"net/http"
@@ -23,8 +24,9 @@ func TestRoundRobin(t *testing.T) {
 
 		runCount := 5
 		var result []string
+		ctx := context.Background()
 		for i := 0; i < runCount; i++ {
-			baseURL, _ := rr.Next()
+			baseURL, _ := rr.NextWithContext(ctx)
 			result = append(result, baseURL)
 		}
 
@@ -49,8 +51,9 @@ func TestRoundRobin(t *testing.T) {
 
 		runCount := 30
 		var result []string
+		ctx := context.Background()
 		for i := 0; i < runCount; i++ {
-			baseURL, _ := rr.Next()
+			baseURL, _ := rr.NextWithContext(ctx)
 			result = append(result, baseURL)
 		}
 
@@ -76,8 +79,9 @@ func TestRoundRobin(t *testing.T) {
 
 		runCount := 5
 		var result []string
+		ctx := context.Background()
 		for i := 0; i < runCount; i++ {
-			baseURL, _ := rr.Next()
+			baseURL, _ := rr.NextWithContext(ctx)
 			result = append(result, baseURL)
 		}
 
@@ -92,6 +96,43 @@ func TestRoundRobin(t *testing.T) {
 
 		rr.Feedback(&RequestFeedback{})
 		rr.Close()
+	})
+
+	t.Run("NextWithContext context cancellation", func(t *testing.T) {
+		rr, _ := NewRoundRobin("https://example.com")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := rr.NextWithContext(ctx)
+		assertErrorIs(t, context.Canceled, err)
+	})
+
+	t.Run("NextWithContext normal operation", func(t *testing.T) {
+		rr, _ := NewRoundRobin("https://example1.com", "https://example2.com")
+		ctx := context.Background()
+		url1, err := rr.NextWithContext(ctx)
+		assertNil(t, err)
+		url2, err := rr.NextWithContext(ctx)
+		assertNil(t, err)
+		assertNotEqual(t, url1, url2)
+	})
+}
+
+func TestRoundRobinNoBaseURLs(t *testing.T) {
+	t.Run("new round robin no base urls", func(t *testing.T) {
+		rr, err := NewRoundRobin()
+		assertErrorIs(t, ErrNoBaseURLs, err)
+		assertNil(t, rr)
+	})
+
+	t.Run("new round robin no base urls on next with context", func(t *testing.T) {
+		rr, err := NewRoundRobin("https://example1.com")
+		assertNil(t, err)
+		assertNotNil(t, rr)
+
+		rr.Refresh()
+		ctx := context.Background()
+		_, err = rr.NextWithContext(ctx)
+		assertErrorIs(t, ErrNoBaseURLs, err)
 	})
 }
 
@@ -109,8 +150,9 @@ func TestWeightedRoundRobin(t *testing.T) {
 
 		runCount := 5
 		var result []string
+		ctx := context.Background()
 		for i := 0; i < runCount; i++ {
-			baseURL, err := wrr.Next()
+			baseURL, err := wrr.NextWithContext(ctx)
 			assertNil(t, err)
 			result = append(result, baseURL)
 		}
@@ -123,6 +165,8 @@ func TestWeightedRoundRobin(t *testing.T) {
 		assertEqual(t, runCount, len(expected))
 		assertEqual(t, runCount, len(result))
 		assertEqual(t, expected, result)
+
+		wrr.Feedback(nil)
 	})
 
 	t.Run("3 hosts with weight {2,1,10}", func(t *testing.T) {
@@ -143,8 +187,9 @@ func TestWeightedRoundRobin(t *testing.T) {
 
 		runCount := 10
 		var result []string
+		ctx := context.Background()
 		for i := 0; i < runCount; i++ {
-			baseURL, err := wrr.Next()
+			baseURL, err := wrr.NextWithContext(ctx)
 			assertNil(t, err)
 			result = append(result, baseURL)
 			if baseURL == "https://example3.com" && i%2 != 0 {
@@ -184,8 +229,9 @@ func TestWeightedRoundRobin(t *testing.T) {
 
 		runCount := 5
 		var result []string
+		ctx := context.Background()
 		for i := 0; i < runCount; i++ {
-			baseURL, err := wrr.Next()
+			baseURL, err := wrr.NextWithContext(ctx)
 			assertNil(t, err)
 			result = append(result, baseURL)
 		}
@@ -205,8 +251,30 @@ func TestWeightedRoundRobin(t *testing.T) {
 		assertNil(t, err)
 		defer wrr.Close()
 
-		_, err = wrr.Next()
+		_, err = wrr.NextWithContext(context.Background())
 		assertErrorIs(t, ErrNoActiveHost, err)
+	})
+
+	t.Run("NextWithContext context cancellation", func(t *testing.T) {
+		wrr, _ := NewWeightedRoundRobin(0, &Host{BaseURL: "https://example.com", Weight: 1})
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := wrr.NextWithContext(ctx)
+		assertErrorIs(t, context.Canceled, err)
+	})
+
+	t.Run("NextWithContext normal operation", func(t *testing.T) {
+		hosts := []*Host{
+			{BaseURL: "https://example1.com", Weight: 1},
+			{BaseURL: "https://example2.com", Weight: 1},
+		}
+		wrr, _ := NewWeightedRoundRobin(0, hosts...)
+		ctx := context.Background()
+		url1, err := wrr.NextWithContext(ctx)
+		assertNil(t, err)
+		url2, err := wrr.NextWithContext(ctx)
+		assertNil(t, err)
+		assertNotEqual(t, url1, url2)
 	})
 }
 
@@ -233,8 +301,9 @@ func TestSRVWeightedRoundRobin(t *testing.T) {
 
 		runCount := 5
 		var result []string
+		ctx := context.Background()
 		for i := 0; i < runCount; i++ {
-			baseURL, err := srv.Next()
+			baseURL, err := srv.NextWithContext(ctx)
 			assertNil(t, err)
 			result = append(result, baseURL)
 		}
@@ -271,8 +340,9 @@ func TestSRVWeightedRoundRobin(t *testing.T) {
 
 		runCount := 5
 		var result []string
+		ctx := context.Background()
 		for i := 0; i < runCount; i++ {
-			baseURL, err := srv.Next()
+			baseURL, err := srv.NextWithContext(ctx)
 			assertNil(t, err)
 			result = append(result, baseURL)
 		}
@@ -315,8 +385,9 @@ func TestSRVWeightedRoundRobin(t *testing.T) {
 
 		runCount := 20
 		var result []string
+		ctx := context.Background()
 		for i := 0; i < runCount; i++ {
-			baseURL, err := srv.Next()
+			baseURL, err := srv.NextWithContext(ctx)
 			assertNil(t, err)
 			result = append(result, baseURL)
 
@@ -363,7 +434,7 @@ func TestSRVWeightedRoundRobin(t *testing.T) {
 
 		go func() {
 			for i := 0; i < 10; i++ {
-				baseURL, _ := srv.Next()
+				baseURL, _ := srv.NextWithContext(context.Background())
 				assertNotNil(t, baseURL)
 				time.Sleep(15 * time.Millisecond)
 			}
@@ -438,7 +509,7 @@ func TestLoadBalancerRequestFlowError(t *testing.T) {
 		c.SetLoadBalancer(wrr)
 
 		resp, err := c.R().Get("/")
-		assertEqual(t, ErrNoActiveHost, err)
+		assertErrorIs(t, ErrNoActiveHost, err)
 		assertNil(t, resp)
 	})
 

--- a/middleware.go
+++ b/middleware.go
@@ -448,7 +448,7 @@ func handleFormData(c *Client, r *Request) {
 }
 
 func handleRequestBody(c *Client, r *Request) error {
-	contentType := r.Header.Get(hdrContentTypeKey)
+	contentType := strings.ToLower(r.Header.Get(hdrContentTypeKey))
 	if isStringEmpty(contentType) {
 		// it is highly recommended that the user provide a request content-type
 		// so that we can minimize memory allocation and compute.
@@ -534,11 +534,11 @@ func MiddlewareResponseAutoParse(c *Client, res *Response) (err error) {
 		return
 	}
 
-	rct := firstNonEmpty(
+	rct := strings.ToLower(firstNonEmpty(
 		res.Request.ResponseForceContentType,
 		res.Header().Get(hdrContentTypeKey),
 		res.Request.ResponseExpectContentType,
-	)
+	))
 	decKey := inferContentTypeMapKey(rct)
 	decFunc, found := c.inferContentTypeDecoder(rct, decKey)
 	if !found {

--- a/middleware.go
+++ b/middleware.go
@@ -245,7 +245,7 @@ func createRawRequest(c *Client, r *Request) (err error) {
 	r.RawRequest.Close = r.CloseConnection
 
 	// Add headers into http request
-	r.RawRequest.Header = r.Header
+	r.RawRequest.Header = r.Header.Clone()
 
 	// Add cookies from client instance into http request
 	for _, cookie := range c.Cookies() {

--- a/middleware.go
+++ b/middleware.go
@@ -131,7 +131,7 @@ func parseRequestURL(c *Client, r *Request) error {
 		}
 
 		if r.client.LoadBalancer() != nil {
-			r.baseURL, err = r.client.LoadBalancer().Next()
+			r.baseURL, err = r.client.LoadBalancer().NextWithContext(r.Context())
 			if err != nil {
 				return &invalidRequestError{Err: err}
 			}

--- a/multipart.go
+++ b/multipart.go
@@ -6,6 +6,7 @@
 package resty
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,11 @@ import (
 )
 
 var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+
+var ErrReaderNotSeekable = errors.New(
+	"resty: multipart reader is not seekable and no factory provided; " +
+		"use resty.NewMultipartFieldFromFactory for retry support with non-seekable readers",
+)
 
 func escapeQuotes(s string) string {
 	return quoteEscaper.Replace(s)
@@ -77,7 +83,7 @@ func (mf *MultipartField) resetReader() error {
 		_, err := rs.Seek(0, io.SeekStart)
 		return err
 	}
-	return nil
+	return ErrReaderNotSeekable
 }
 
 func (mf *MultipartField) isValues() bool {

--- a/multipart_test.go
+++ b/multipart_test.go
@@ -717,7 +717,7 @@ func TestMultipartCornerCoverage(t *testing.T) {
 		Reader: bytes.NewBufferString("I have no seek capability"),
 	}
 	err := mf.resetReader()
-	assertNil(t, err)
+	assertEqual(t, ErrReaderNotSeekable, err)
 
 	// wrap test writer to return 0 written value
 	mpw := multipartProgressWriter{w: &returnValueTestWriter{}}

--- a/redirect.go
+++ b/redirect.go
@@ -40,19 +40,19 @@ func (f RedirectPolicyFunc) Apply(req *http.Request, via []*http.Request) error 
 	return f(req, via)
 }
 
-// NoRedirectPolicy is used to disable the redirects in the Resty client
+// RedirectNoPolicy is used to disable the redirects in the Resty client
 //
-//	resty.SetRedirectPolicy(resty.NoRedirectPolicy())
-func NoRedirectPolicy() RedirectPolicy {
+//	resty.SetRedirectPolicy(resty.RedirectNoPolicy())
+func RedirectNoPolicy() RedirectPolicy {
 	return RedirectPolicyFunc(func(req *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
 	})
 }
 
-// FlexibleRedirectPolicy method is convenient for creating several redirect policies for Resty clients.
+// RedirectFlexiblePolicy method is convenient for creating several redirect policies for Resty clients.
 //
-//	resty.SetRedirectPolicy(FlexibleRedirectPolicy(20))
-func FlexibleRedirectPolicy(noOfRedirect int) RedirectPolicy {
+//	resty.SetRedirectPolicy(RedirectFlexiblePolicy(20))
+func RedirectFlexiblePolicy(noOfRedirect int) RedirectPolicy {
 	return RedirectPolicyFunc(func(req *http.Request, via []*http.Request) error {
 		if len(via) >= noOfRedirect {
 			return fmt.Errorf("resty: stopped after %d redirects", noOfRedirect)
@@ -62,11 +62,11 @@ func FlexibleRedirectPolicy(noOfRedirect int) RedirectPolicy {
 	})
 }
 
-// DomainCheckRedirectPolicy method is convenient for defining domain name redirect rules in Resty clients.
+// RedirectDomainCheckPolicy method is convenient for defining domain name redirect rules in Resty clients.
 // Redirect is allowed only for the host mentioned in the policy.
 //
-//	resty.SetRedirectPolicy(resty.DomainCheckRedirectPolicy("host1.com", "host2.org", "host3.net"))
-func DomainCheckRedirectPolicy(hostnames ...string) RedirectPolicy {
+//	resty.SetRedirectPolicy(resty.RedirectDomainCheckPolicy("host1.com", "host2.org", "host3.net"))
+func RedirectDomainCheckPolicy(hostnames ...string) RedirectPolicy {
 	hosts := make(map[string]bool)
 	for _, h := range hostnames {
 		hosts[strings.ToLower(h)] = true

--- a/request_test.go
+++ b/request_test.go
@@ -693,7 +693,8 @@ func TestRequestAuthScheme(t *testing.T) {
 
 		assertError(t, err)
 		assertEqual(t, http.StatusOK, resp.StatusCode())
-		assertEqual(t, tokenValue, resp.Request.Header.Get(hdrAuthorizationKey))
+		assertEqual(t, "", resp.Request.Header.Get(hdrAuthorizationKey))
+		assertEqual(t, tokenValue, resp.Request.RawRequest.Header.Get(hdrAuthorizationKey))
 	})
 
 	t.Run("empty auth scheme at request level GH954", func(t *testing.T) {
@@ -709,8 +710,8 @@ func TestRequestAuthScheme(t *testing.T) {
 			Get(ts.URL + "/profile")
 
 		assertError(t, err)
-		assertEqual(t, http.StatusOK, resp.StatusCode())
-		assertEqual(t, tokenValue, resp.Request.Header.Get(hdrAuthorizationKey))
+		assertEqual(t, "", resp.Request.Header.Get(hdrAuthorizationKey))
+		assertEqual(t, tokenValue, resp.Request.RawRequest.Header.Get(hdrAuthorizationKey))
 	})
 
 	t.Run("only client level auth token GH959", func(t *testing.T) {
@@ -725,7 +726,8 @@ func TestRequestAuthScheme(t *testing.T) {
 
 		assertError(t, err)
 		assertEqual(t, http.StatusOK, resp.StatusCode())
-		assertEqual(t, "Bearer "+tokenValue, resp.Request.Header.Get(hdrAuthorizationKey))
+		assertEqual(t, "", resp.Request.Header.Get(hdrAuthorizationKey))
+		assertEqual(t, "Bearer "+tokenValue, resp.Request.RawRequest.Header.Get(hdrAuthorizationKey))
 	})
 }
 

--- a/response.go
+++ b/response.go
@@ -108,7 +108,7 @@ func (r *Response) Result() any {
 //
 // See [Request.SetResultError], [Client.SetResultError]
 func (r *Response) ResultError() any {
-	return r.Request.Error
+	return r.Request.ResultError
 }
 
 // Header method returns the response headers
@@ -133,7 +133,7 @@ func (r *Response) Cookies() []*http.Cookie {
 // NOTE:
 //   - Returns an empty string on auto-unmarshal scenarios, unless
 //     [Client.SetResponseBodyUnlimitedReads] or [Request.SetResponseBodyUnlimitedReads] set.
-//   - Returns an empty string when [Client.SetDoNotParseResponse] or [Request.SetDoNotParseResponse] set.
+//   - Returns an empty string when [Client.SetResponseDoNotParse] or [Request.SetResponseDoNotParse] set.
 func (r *Response) String() string {
 	r.readIfRequired()
 	return strings.TrimSpace(string(r.bodyBytes))
@@ -145,7 +145,7 @@ func (r *Response) String() string {
 // NOTE:
 //   - Returns an empty byte slice on auto-unmarshal scenarios, unless
 //     [Client.SetResponseBodyUnlimitedReads] or [Request.SetResponseBodyUnlimitedReads] set.
-//   - Returns an empty byte slice when [Client.SetDoNotParseResponse] or [Request.SetDoNotParseResponse] set.
+//   - Returns an empty byte slice when [Client.SetResponseDoNotParse] or [Request.SetResponseDoNotParse] set.
 func (r *Response) Bytes() []byte {
 	r.readIfRequired()
 	return r.bodyBytes
@@ -160,7 +160,7 @@ func (r *Response) Duration() time.Duration {
 	if r.Request.trace != nil {
 		return r.Request.TraceInfo().TotalTime
 	}
-	return r.receivedAt.Sub(r.Request.Time)
+	return r.receivedAt.Sub(r.Request.StartTime)
 }
 
 // ReceivedAt method returns the time we received a response from the server for the request.
@@ -219,11 +219,11 @@ func (r *Response) setReceivedAt() {
 }
 
 func (r *Response) fmtBodyString(sl int) string {
-	if r.Request.DoNotParseResponse {
+	if r.Request.IsResponseDoNotParse {
 		return "***** DO NOT PARSE RESPONSE - Enabled *****"
 	}
 
-	if r.Request.IsSaveResponse {
+	if r.Request.IsResponseSaveToFile {
 		return "***** RESPONSE WRITTEN INTO FILE *****"
 	}
 
@@ -256,7 +256,7 @@ func (r *Response) fmtBodyString(sl int) string {
 }
 
 func (r *Response) readIfRequired() {
-	if len(r.bodyBytes) == 0 && !r.Request.DoNotParseResponse {
+	if len(r.bodyBytes) == 0 && !r.Request.IsResponseDoNotParse {
 		_ = r.readAll()
 	}
 }

--- a/response.go
+++ b/response.go
@@ -315,7 +315,7 @@ func (r *Response) wrapContentDecompresser() error {
 		return nil
 	}
 
-	if decFunc, f := r.Request.client.ContentDecompressers()[ce]; f {
+	if decFunc, f := r.Request.client.ContentDecompressers()[strings.ToLower(ce)]; f {
 		dec, err := decFunc(r.Body)
 		if err != nil {
 			if err == io.EOF {

--- a/resty.go
+++ b/resty.go
@@ -200,13 +200,13 @@ func createClient(hc *http.Client) *Client {
 
 	// request middlewares
 	c.SetRequestMiddlewares(
-		PrepareRequestMiddleware,
+		MiddlewareRequestCreate,
 	)
 
 	// response middlewares
 	c.SetResponseMiddlewares(
-		AutoParseResponseMiddleware,
-		SaveToFileResponseMiddleware,
+		MiddlewareResponseAutoParse,
+		MiddlewareResponseSaveToFile,
 	)
 
 	return c

--- a/resty_test.go
+++ b/resty_test.go
@@ -182,7 +182,7 @@ func handleLoginEndpoint(t *testing.T, w http.ResponseWriter, r *http.Request) {
 			} else if r.URL.Query().Get("ct") == "rpc" {
 				w.Header().Set(hdrContentTypeKey, "application/json-rpc")
 			} else {
-				w.Header().Set(hdrContentTypeKey, "application/json")
+				w.Header().Set(hdrContentTypeKey, "AppLicAtioN/jsON")
 			}
 
 			if err != nil {
@@ -639,7 +639,7 @@ func createGenericServer(t *testing.T) *httptest.Server {
 			// LZW
 			case "/lzw-test":
 				w.Header().Set(hdrContentTypeKey, plainTextType)
-				w.Header().Set(hdrContentEncodingKey, "compress")
+				w.Header().Set(hdrContentEncodingKey, "coMpReSs")
 				zw := lzw.NewWriter(w, lzw.LSB, 8)
 				_, _ = zw.Write([]byte("This is LZW response testing"))
 				zw.Close()

--- a/resty_test.go
+++ b/resty_test.go
@@ -920,13 +920,13 @@ func dcnl() *Client {
 }
 
 func dcnld() *Client {
-	return dcnl().EnableDebug()
+	return dcnl().SetDebug(true)
 }
 
 func dcldb() (*Client, *bytes.Buffer) {
 	logBuf := acquireBuffer()
 	c := New().
-		EnableDebug().
+		SetDebug(true).
 		outputLogTo(logBuf)
 	return c, logBuf
 }

--- a/sse_test.go
+++ b/sse_test.go
@@ -25,7 +25,7 @@ func TestEventSourceSimpleFlow(t *testing.T) {
 
 	messageCounter := 0
 	messageFunc := func(e any) {
-		event := e.(*Event)
+		event := e.(*SSE)
 		assertEqual(t, strconv.Itoa(messageCounter), event.ID)
 		assertTrue(t, strings.HasPrefix(event.Data, "The time is"))
 		messageCounter++
@@ -138,7 +138,7 @@ func TestEventSourceOverwriteFuncs(t *testing.T) {
 
 	message2Counter := 0
 	messageFunc2 := func(e any) {
-		event := e.(*Event)
+		event := e.(*SSE)
 		assertEqual(t, strconv.Itoa(message2Counter), event.ID)
 		assertTrue(t, strings.HasPrefix(event.Data, "The time is"))
 		message2Counter++
@@ -189,7 +189,7 @@ func TestEventSourceRetry(t *testing.T) {
 
 	messageCounter := 2 // 0 & 1 connection failure
 	messageFunc := func(e any) {
-		event := e.(*Event)
+		event := e.(*SSE)
 		assertEqual(t, strconv.Itoa(messageCounter), event.ID)
 		assertTrue(t, strings.HasPrefix(event.Data, "The time is"))
 		messageCounter++
@@ -404,7 +404,7 @@ func TestEventSourceParseAndReadError(t *testing.T) {
 	assertNil(t, err)
 
 	// parse error
-	parseEvent = func(_ []byte) (*rawEvent, error) {
+	parseEvent = func(_ []byte) (*rawSSE, error) {
 		return nil, errors.New("test error")
 	}
 	counter = 0
@@ -475,7 +475,7 @@ func TestEventSourceWithDifferentMethods(t *testing.T) {
 
 			messageCounter := 0
 			messageFunc := func(e any) {
-				event := e.(*Event)
+				event := e.(*SSE)
 				assertEqual(t, strconv.Itoa(messageCounter), event.ID)
 				assertTrue(t, strings.HasPrefix(event.Data, fmt.Sprintf("%s method test:", tc.method)))
 				messageCounter++
@@ -590,7 +590,7 @@ func TestEventSource_readEventFunc(t *testing.T) {
 }
 
 func TestEventSourceCoverage(t *testing.T) {
-	es := NewEventSource()
+	es := NewSSESource()
 	err1 := es.Get()
 	assertEqual(t, "resty:sse: event source URL is required", err1.Error())
 
@@ -608,8 +608,8 @@ func TestEventSourceCoverage(t *testing.T) {
 	parseEvent([]byte{})
 }
 
-func createEventSource(t *testing.T, url string, fn EventMessageFunc, rt any) *EventSource {
-	es := NewEventSource().
+func createEventSource(t *testing.T, url string, fn SSEMessageFunc, rt any) *SSESource {
+	es := NewSSESource().
 		SetURL(url).
 		SetMethod(MethodGet).
 		AddHeader("X-Test-Header-1", "test header 1").
@@ -617,7 +617,7 @@ func createEventSource(t *testing.T, url string, fn EventMessageFunc, rt any) *E
 		SetRetryCount(2).
 		SetRetryWaitTime(200 * time.Millisecond).
 		SetRetryMaxWaitTime(1000 * time.Millisecond).
-		SetMaxBufSize(1 << 14). // 16kb
+		SetSizeMaxBuffer(1 << 14). // 16kb
 		SetLogger(createLogger()).
 		OnOpen(func(url string, respHdr http.Header) {
 			t.Log("I'm connected:", url, respHdr)

--- a/stream_test.go
+++ b/stream_test.go
@@ -29,13 +29,13 @@ func TestGetMethodWhenResponseIsNull(t *testing.T) {
 		w.Write([]byte("null"))
 	}))
 
-	client := New().SetRetryCount(3).EnableGenerateCurlCmd()
+	client := New().SetRetryCount(3).SetCurlCmdGenerate(true)
 
 	var x any
 	resp, err := client.R().SetBody("{}").
 		SetHeader("Content-Type", "application/json; charset=utf-8").
-		SetForceResponseContentType("application/json").
-		SetAllowMethodGetPayload(true).
+		SetResponseForceContentType("application/json").
+		SetMethodGetAllowPayload(true).
 		SetResponseBodyUnlimitedReads(true).
 		SetResult(&x).
 		Get(server.URL + "/test")
@@ -195,7 +195,7 @@ func TestGzipReaderPanicOnConcurrentCorruptedBody(t *testing.T) {
 
 				var out map[string]any
 				client.R().
-					SetAllowNonIdempotentRetry(true).
+					SetRetryAllowNonIdempotent(true).
 					SetResult(&out).
 					Post(server.URL)
 			}()

--- a/util_test.go
+++ b/util_test.go
@@ -282,7 +282,7 @@ func TestInMemoryJSONPost(t *testing.T) {
 
 	c := dcnl().
 		AddContentTypeEncoder(jsonContentType, InMemoryJSONMarshal).
-		AddContentTypeDecoder(jsonContentType, InMemoryJSONUnmarshal)
+		AddContentTypeDecoder("appLiCaTion/JSon", InMemoryJSONUnmarshal)
 
 	r := c.R().
 		SetHeader(hdrContentTypeKey, jsonContentType).


### PR DESCRIPTION
## Summary

- Previously `resetReader()` silently returned `nil` when a multipart field reader did not implement `io.ReadSeeker`. This caused retried requests to send empty or corrupt bodies without any error signal (#770).
- Now `resetReader()` returns `ErrReaderNotSeekable`, which propagates through the retry loop and surfaces to the caller.

## Breaking Change

This is a breaking change for code that passes non-seekable readers (e.g. `bytes.Buffer`) and relies on retries. Such code should either:
- Switch to `io.ReadSeeker` (e.g. `bytes.Reader`)
- Wait for a future release with `ReaderFactory` support

As suggested by @jeevatkm in https://github.com/go-resty/resty/pull/1127#issuecomment.