### PR TITLE
fix: return error for non-seekable readers on request retry

### DIFF
--- a/multipart.go
+++ b/multipart.go
@@ -6,6 +6,7 @@
 package resty
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,8 @@ import (
 )
 
 var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+
+var ErrReaderNotSeekable = errors.New("resty: multipart reader is not seekable on request retry")
 
 func escapeQuotes(s string) string {
 	return quoteEscaper.Replace(s)
@@ -75,7 +78,7 @@ func (mf *MultipartField) resetReader() error {
 		_, err := rs.Seek(0, io.SeekStart)
 		return err
 	}
-	return nil
+	return ErrReaderNotSeekable
 }
 
 func (mf *MultipartField) isValues() bool {

--- a/multipart_test.go
+++ b/multipart_test.go
@@ -12,6 +12,7 @@ import (
 	"io/fs"
 	"mime/multipart"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -717,11 +718,40 @@ func TestMultipartCornerCoverage(t *testing.T) {
 		Reader: bytes.NewBufferString("I have no seek capability"),
 	}
 	err := mf.resetReader()
-	assertNil(t, err)
+	assertEqual(t, ErrReaderNotSeekable, err)
 
 	// wrap test writer to return 0 written value
 	mpw := multipartProgressWriter{w: &returnValueTestWriter{}}
 	n, err := mpw.Write([]byte("test return value"))
 	assertNil(t, err)
 	assertEqual(t, 0, n)
+}
+
+func TestRetryNonSeekableReaderWithoutFactoryReturnsError(t *testing.T) {
+	attemptCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attemptCount++
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	client := dcnl()
+	client.AddRetryConditions(func(r *Response, err error) bool {
+		return r.StatusCode() == http.StatusServiceUnavailable
+	})
+	_, err := client.R().
+		SetRetryCount(2).
+		SetRetryWaitTime(10 * time.Millisecond).
+		SetRetryAllowNonIdempotent(true).
+		SetMultipartFields(&MultipartField{
+			Name:        "file",
+			FileName:    "test.txt",
+			ContentType: "text/plain",
+			Reader:      bytes.NewBufferString("non-seekable"),
+		}).
+		Post(srv.URL)
+
+	assertErrorIs(t, ErrReaderNotSeekable, err)
+	assertEqual(t, 1, attemptCount)
 }


### PR DESCRIPTION
## Summary

- Previously `resetReader()` silently returned `nil` when a multipart field reader did not implement `io.ReadSeeker`. This caused retried requests to send empty or corrupt bodies without any error signal (#770).
- Now `resetReader()` returns `ErrReaderNotSeekable`, which propagates through the retry loop and surfaces to the caller.

## Breaking Change

This is a breaking change for code that passes non-seekable readers (e.g. `bytes.Buffer`) and relies on retries. Such code should either:
- Switch to `io.ReadSeeker` (e.g. `bytes.Reader`)
- Wait for a future release with `ReaderFactory` support

As suggested by @jeevatkm in https://github.com/go-resty/resty/pull/1127#issuecomment.