### PR TITLE
security: strip sensitive headers on cross-domain redirects by default

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -228,6 +228,82 @@ func TestRedirectHeaderStripSensitivePolicyRealChainBehavior(t *testing.T) {
 	})
 }
 
+func TestCheckHostAndAddHeadersCrossDomainStrip(t *testing.T) {
+	t.Run("same host copies all headers", func(t *testing.T) {
+		pre, _ := http.NewRequest(http.MethodGet, "https://example.com/api", nil)
+		pre.Header.Set("Authorization", "Bearer secret")
+		pre.Header.Set("X-Api-Key", "my-api-key")
+		pre.Header.Set("X-Safe-Header", "safe")
+
+		cur, _ := http.NewRequest(http.MethodGet, "https://example.com/other", nil)
+
+		checkHostAndAddHeaders(cur, pre)
+
+		assertEqual(t, "Bearer secret", cur.Header.Get("Authorization"))
+		assertEqual(t, "my-api-key", cur.Header.Get("X-Api-Key"))
+		assertEqual(t, "safe", cur.Header.Get("X-Safe-Header"))
+	})
+
+	t.Run("cross domain strips sensitive headers", func(t *testing.T) {
+		pre, _ := http.NewRequest(http.MethodGet, "https://example.com/api", nil)
+		pre.Header.Set("X-Api-Key", "my-api-key")
+		pre.Header.Set("X-Custom-Auth-Token", "custom-token")
+		pre.Header.Set("X-My-Secret", "secret-value")
+		pre.Header.Set("X-Safe-Header", "safe")
+
+		// Simulate Go's net/http forwarding all custom headers on cross-domain
+		// redirect (Go only strips standard Authorization/Cookie headers).
+		cur, _ := http.NewRequest(http.MethodGet, "https://evil.com/steal", nil)
+		cur.Header.Set("X-Api-Key", "my-api-key")
+		cur.Header.Set("X-Custom-Auth-Token", "custom-token")
+		cur.Header.Set("X-My-Secret", "secret-value")
+		cur.Header.Set("X-Safe-Header", "safe")
+
+		checkHostAndAddHeaders(cur, pre)
+
+		// Sensitive headers must be stripped
+		assertEqual(t, "", cur.Header.Get("X-Api-Key"))
+		assertEqual(t, "", cur.Header.Get("X-Custom-Auth-Token"))
+		assertEqual(t, "", cur.Header.Get("X-My-Secret"))
+		// Non-sensitive headers must remain
+		assertEqual(t, "safe", cur.Header.Get("X-Safe-Header"))
+	})
+
+	t.Run("cross domain with SetHeaderAuthorizationKey pattern", func(t *testing.T) {
+		// Simulates the exact vulnerability: user sets a custom authorization
+		// header name via SetHeaderAuthorizationKey("X-Corp-Access"), which
+		// addCredentials() places on the request. On cross-domain redirect,
+		// Go's net/http does NOT strip it because it only knows about
+		// the standard "Authorization" header.
+		pre, _ := http.NewRequest(http.MethodGet, "https://api.corp.com/data", nil)
+		pre.Header.Set("X-Corp-Access-Token", "Bearer CORP_SECRET_123")
+		pre.Header.Set("Content-Type", "application/json")
+
+		cur, _ := http.NewRequest(http.MethodGet, "https://attacker.com/collect", nil)
+		cur.Header.Set("X-Corp-Access-Token", "Bearer CORP_SECRET_123")
+		cur.Header.Set("Content-Type", "application/json")
+
+		checkHostAndAddHeaders(cur, pre)
+
+		// Custom auth header must be stripped (contains "token")
+		assertEqual(t, "", cur.Header.Get("X-Corp-Access-Token"))
+		// Safe headers must remain
+		assertEqual(t, "application/json", cur.Header.Get("Content-Type"))
+	})
+
+	t.Run("cross domain case insensitive hostname comparison", func(t *testing.T) {
+		pre, _ := http.NewRequest(http.MethodGet, "https://Example.COM/api", nil)
+		pre.Header.Set("X-Api-Key", "key")
+
+		cur, _ := http.NewRequest(http.MethodGet, "https://example.com/other", nil)
+
+		checkHostAndAddHeaders(cur, pre)
+
+		// Same host (case insensitive) → headers copied, not stripped
+		assertEqual(t, "key", cur.Header.Get("X-Api-Key"))
+	})
+}
+
 func TestClientTimeout(t *testing.T) {
 	ts := createGetServer(t)
 	defer ts.Close()

--- a/redirect.go
+++ b/redirect.go
@@ -136,12 +136,26 @@ func getHostname(host string) (hostname string) {
 // https://github.com/golang/go/issues/4800
 // Resty will add all the headers during a redirect for the same host and
 // adds library user-agent if the Host is different.
+//
+// For cross-domain redirects, sensitive headers (matching [isSanitizeHeader])
+// are stripped from the redirected request. Go's net/http only strips standard
+// headers such as Authorization and Cookie; custom authentication headers
+// (e.g. those set via [Client.SetHeaderAuthorizationKey]) are forwarded
+// verbatim unless explicitly removed. See https://github.com/go-resty/resty/issues/1128.
 func checkHostAndAddHeaders(cur *http.Request, pre *http.Request) {
 	curHostname := getHostname(cur.URL.Host)
 	preHostname := getHostname(pre.URL.Host)
 	if strings.EqualFold(curHostname, preHostname) {
 		for key, val := range pre.Header {
 			cur.Header[key] = val
+		}
+	} else {
+		// Cross-domain redirect: strip sensitive headers that Go's
+		// net/http does not know about (custom auth, token, api-key, etc.).
+		for key := range cur.Header {
+			if isSanitizeHeader(key) {
+				cur.Header.Del(key)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Addresses the remaining security gap from #1128: custom authentication headers set via `SetHeaderAuthorizationKey()` are leaked to cross-domain redirect targets when using the default redirect policies (`RedirectFlexiblePolicy`, `RedirectDomainCheckPolicy`).

Go's `net/http` only strips standard headers (`Authorization`, `Cookie`, etc.) during cross-domain redirects. Custom auth headers (e.g., `X-API-Key`, `X-Auth-Token`) are forwarded verbatim to the redirect target, leaking credentials to potentially untrusted domains.

While `RedirectHeaderStripSensitivePolicy` (#1134) provides excellent opt-in protection, the default redirect behavior should also be safe. This change makes `checkHostAndAddHeaders` automatically strip headers matching the existing `isSanitizeHeader` filter on cross-domain redirects.

## Changes

- **`redirect.go`**: Modified `checkHostAndAddHeaders` to strip sensitive headers (matching `isSanitizeHeader`: authorization, auth, token, api-key, secret) when the redirect crosses domain boundaries
- **`client_test.go`**: Added `TestCheckHostAndAddHeadersCrossDomainStrip` with 4 subtests:
  - Same-host redirects still copy all headers (no regression)
  - Cross-domain redirects strip sensitive headers
  - Cross-domain with `SetHeaderAuthorizationKey` pattern (the exact vulnerability scenario)
  - Case-insensitive hostname comparison

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Same-host redirect | All headers copied ✅ | All headers copied ✅ |
| Cross-domain redirect, standard `Authorization` | Stripped by Go ✅ | Stripped by Go ✅ |
| Cross-domain redirect, custom `X-API-Key` | **Leaked** ❌ | Stripped ✅ |
| Cross-domain redirect, `Content-Type` | Forwarded ✅ | Forwarded ✅ |

## Test Plan

- [x] All 4 new subtests pass
- [x] All existing redirect tests pass (`TestClientRedirectPolicy`, `TestRedirectHeaderStripSensitivePolicy`, `TestRedirectHeaderStripSensitivePolicyRealChainBehavior`, `TestHTTPAutoRedirectUpTo10`, `TestHostCheckRedirectPolicy`, `TestPostRedirectWithBody`, `TestPostMapTemporaryRedirect`)
- [x] `go build ./...` clean

Ref: #1128