### PR TITLE
fix: unwrap both errors in restyError for errors.Is/As support

### DIFF
--- a/util.go
+++ b/util.go
@@ -346,8 +346,8 @@ func (e *restyError) Error() string {
 	return e.err.Error()
 }
 
-func (e *restyError) Unwrap() error {
-	return e.inner
+func (e *restyError) Unwrap() []error {
+	return []error{e.err, e.inner}
 }
 
 // copied from net/http/clone.go


### PR DESCRIPTION
Fixes #1143

## Problem

`restyError` wraps two errors (`err` and `inner`) but `Unwrap()` only returns `inner`. This means `errors.Is` and `errors.As` cannot find the outer error (`err`), which is confusing since `Error()` displays the outer error's message.

```go
combined := wrapErrors(errA, errB)
errors.Is(combined, errA) // false ❌ (errA is displayed by Error())
errors.Is(combined, errB) // true  ✅
```

## Fix

Use the Go 1.20+ multi-error `Unwrap` signature:

```go
// Before
func (e *restyError) Unwrap() error { return e.inner }

// After
func (e *restyError) Unwrap() []error { return []error{e.err, e.inner} }
```

This follows the same pattern as `errors.Join` and allows both wrapped errors to be found by `errors.Is` and `errors.As`.