### PR TITLE
fix: unwrap restyError to an error slice

### DIFF
--- a/util.go
+++ b/util.go
@@ -346,8 +346,8 @@ func (e *restyError) Error() string {
 	return e.err.Error()
 }
 
-func (e *restyError) Unwrap() error {
-	return e.inner
+func (e *restyError) Unwrap() []error {
+	return []error{e.err, e.inner}
 }
 
 // copied from net/http/clone.go

--- a/util_test.go
+++ b/util_test.go
@@ -106,7 +106,10 @@ func TestRestyErrorFuncs(t *testing.T) {
 
 	e := wrapErrors(ne1, nie1)
 	assertEqual(t, "new error 1", e.Error())
-	assertEqual(t, "inner error 1", errors.Unwrap(e).Error())
+
+	// Unwrap should expose both errors so errors.Is can traverse them.
+	assertEqual(t, true, errors.Is(e, ne1))
+	assertEqual(t, true, errors.Is(e, nie1))
 
 	e = wrapErrors(ne1, nil)
 	assertEqual(t, "new error 1", e.Error())


### PR DESCRIPTION
Return both the outer and inner errors from Unwrap so errors.Is and errors.As can traverse the full chain, not just the innermost error.

Fixes go-resty/resty#1143
Redo of (closes go-resty/resty#1144)
Related to (closes go-resty/resty#1149)