### PR TITLE
Return ErrReaderNotSeekable instead of sending empty bodies on retry

### DIFF
--- a/client.go
+++ b/client.go
@@ -60,6 +60,11 @@ var (
 	// ErrUnsupportedRequestBodyKind is returned when the request body is of an unsupported kind.
 	ErrUnsupportedRequestBodyKind = errors.New("resty: unsupported request body kind")
 
+	// ErrReaderNotSeekable is returned when a non-seekable request body reader is
+	// used on a retry attempt. This applies to both generic [io.Reader] request
+	// bodies (see [Request.SetBody]) and to [MultipartField.Reader] when retrying.
+	ErrReaderNotSeekable = errors.New("resty: reader is not seekable on request retry")
+
 	hdrUserAgentKey       = http.CanonicalHeaderKey("User-Agent")
 	hdrAcceptKey          = http.CanonicalHeaderKey("Accept")
 	hdrAcceptEncodingKey  = http.CanonicalHeaderKey("Accept-Encoding")

--- a/middleware.go
+++ b/middleware.go
@@ -475,10 +475,15 @@ func handleRequestBody(c *Client, r *Request) error {
 		}
 
 		// do seek start for retry attempt if io.ReadSeeker
-		// interface supported
+		// interface supported; otherwise fail loudly rather than
+		// silently retrying the request with an empty body.
 		if r.Attempt > 1 {
-			if rs, ok := r.Body.(io.ReadSeeker); ok {
-				_, _ = rs.Seek(0, io.SeekStart)
+			rs, ok := r.Body.(io.ReadSeeker)
+			if !ok {
+				return ErrReaderNotSeekable
+			}
+			if _, err := rs.Seek(0, io.SeekStart); err != nil {
+				return err
 			}
 		}
 		return nil

--- a/multipart.go
+++ b/multipart.go
@@ -6,7 +6,6 @@
 package resty
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,8 +16,6 @@ import (
 )
 
 var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
-
-var ErrReaderNotSeekable = errors.New("resty: multipart reader is not seekable on request retry")
 
 func escapeQuotes(s string) string {
 	return quoteEscaper.Replace(s)

--- a/retry_test.go
+++ b/retry_test.go
@@ -931,6 +931,35 @@ func TestRequestRetryNonSeekableReaderReturnsError(t *testing.T) {
 	assertEqual(t, int32(1), atomic.LoadInt32(&attempts))
 }
 
+func TestRequestRetryReadSeekerReturnsSeekError(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	seekErr := errors.New("seek failed")
+	body := &seekErrorReader{
+		r:   strings.NewReader("the-original-request-body"),
+		err: seekErr,
+	}
+
+	c := dcnl().AddRetryConditions(func(r *Response, err error) bool {
+		return r != nil && r.StatusCode() == http.StatusServiceUnavailable
+	})
+
+	_, err := c.R().
+		SetRetryCount(2).
+		SetRetryWaitTime(10 * time.Millisecond).
+		SetRetryAllowNonIdempotent(true).
+		SetBody(body).
+		Post(srv.URL)
+
+	assertErrorIs(t, seekErr, err)
+	assertEqual(t, int32(1), atomic.LoadInt32(&attempts))
+}
+
 // nonSeekableReader hides any seek/rewind capability of the underlying reader,
 // simulating a user-provided streaming body (pipe, network stream, decompressing
 // reader, etc.).
@@ -940,6 +969,19 @@ type nonSeekableReader struct {
 
 func (n *nonSeekableReader) Read(p []byte) (int, error) {
 	return n.r.Read(p)
+}
+
+type seekErrorReader struct {
+	r   io.Reader
+	err error
+}
+
+func (s *seekErrorReader) Read(p []byte) (int, error) {
+	return s.r.Read(p)
+}
+
+func (s *seekErrorReader) Seek(int64, int) (int64, error) {
+	return 0, s.err
 }
 
 func TestRequestRetryHooks(t *testing.T) {

--- a/retry_test.go
+++ b/retry_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -892,6 +893,53 @@ func TestRequestRetryPostIoReadSeeker(t *testing.T) {
 	assertEqual(t, 4, resp.Request.Attempt)
 	assertEqual(t, http.StatusInternalServerError, resp.StatusCode())
 	assertEqual(t, "", resp.String())
+}
+
+// TestRequestRetryNonSeekableReaderReturnsError ensures that when the request
+// body is a non-seekable io.Reader (e.g. a streaming reader, a pipe, or any
+// reader that cannot rewind), Resty stops after the first attempt and returns
+// ErrReaderNotSeekable instead of silently retrying the request with an empty
+// body.
+//
+// This mirrors TestRetryNonSeekableReaderWithoutFactoryReturnsError which
+// covers the same guarantee for multipart bodies (see PR #1133).
+func TestRequestRetryNonSeekableReaderReturnsError(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	payload := "the-original-request-body"
+	// bytes.Buffer implements io.Reader but not io.Seeker. We wrap it to be
+	// explicit about the test intent: this is a non-seekable streaming body.
+	body := &nonSeekableReader{r: bytes.NewBufferString(payload)}
+
+	c := dcnl().AddRetryConditions(func(r *Response, err error) bool {
+		return r != nil && r.StatusCode() == http.StatusServiceUnavailable
+	})
+
+	_, err := c.R().
+		SetRetryCount(2).
+		SetRetryWaitTime(10 * time.Millisecond).
+		SetRetryAllowNonIdempotent(true).
+		SetBody(body).
+		Post(srv.URL)
+
+	assertErrorIs(t, ErrReaderNotSeekable, err)
+	assertEqual(t, int32(1), atomic.LoadInt32(&attempts))
+}
+
+// nonSeekableReader hides any seek/rewind capability of the underlying reader,
+// simulating a user-provided streaming body (pipe, network stream, decompressing
+// reader, etc.).
+type nonSeekableReader struct {
+	r io.Reader
+}
+
+func (n *nonSeekableReader) Read(p []byte) (int, error) {
+	return n.r.Read(p)
 }
 
 func TestRequestRetryHooks(t *testing.T) {


### PR DESCRIPTION
If we `SetBody()` is called with a non-retriable reader, retries will be sent with empty body.

A similar bug with the multipart reader was fixed in https://github.com/go-resty/resty/pull/1133.
The original discussion: https://github.com/go-resty/resty/pull/1127.

This PR follows the same logic: return `ErrReaderNotSeekable` instead of silently sending an empty body.

Breaking: the actual text of `ErrReaderNotSeekable` is changed to make the error generic, `multipart` is removed.