### PR TITLE
fix: include retry wait in TraceInfo TotalTime

### DIFF
--- a/client.go
+++ b/client.go
@@ -2471,7 +2471,9 @@ func (c *Client) execute(req *Request) (*Response, error) {
 
 	prepareRequestDebugInfo(c, req)
 
-	req.StartTime = time.Now()
+	if req.StartTime.IsZero() {
+		req.StartTime = time.Now()
+	}
 	resp, err := c.Client().Do(req.withTimeout())
 	// Cancel multipart context for io.Copy to stop reading/writing further
 	if req.isMultiPart && req.multipartCancelFunc != nil {

--- a/request.go
+++ b/request.go
@@ -1344,14 +1344,15 @@ func (r *Request) TraceInfo() TraceInfo {
 		ti.ServerTime = ct.gotFirstResponseByte.Sub(ct.gotConn)
 	}
 
-	// Calculate the total time accordingly when connection is reused,
-	// and DNS start and get conn time may be zero if the request is invalid.
-	// See issue #1016.
+	// Wall-clock from the first attempt (includes retry backoff). See issue #1142.
+	// For invalid requests without StartTime, fall back to trace timestamps (#1016).
 	requestStartTime := r.StartTime
-	if ct.gotConnInfo.Reused && !ct.getConn.IsZero() {
-		requestStartTime = ct.getConn
-	} else if !ct.dnsStart.IsZero() {
-		requestStartTime = ct.dnsStart
+	if requestStartTime.IsZero() {
+		if ct.gotConnInfo.Reused && !ct.getConn.IsZero() {
+			requestStartTime = ct.getConn
+		} else if !ct.dnsStart.IsZero() {
+			requestStartTime = ct.dnsStart
+		}
 	}
 	ti.TotalTime = ct.endTime.Sub(requestStartTime)
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -1233,3 +1233,28 @@ func testStaticTime(t *testing.T) {
 		timeNow = time.Now
 	})
 }
+
+func TestTraceInfoTotalTimeIncludesRetryWait(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	retryWaitTime := 100 * time.Millisecond
+
+	c := dcnl().
+		SetTrace(true).
+		SetRetryCount(2).
+		SetRetryWaitTime(retryWaitTime).
+		SetRetryMaxWaitTime(retryWaitTime).
+		AddRetryConditions(func(*Response, error) bool { return true })
+
+	resp, err := c.R().Get(ts.URL + "/set-retrywaittime-test")
+	assertNil(t, err)
+	assertNotNil(t, resp)
+	assertEqual(t, 3, resp.Request.Attempt)
+
+	tr := resp.Request.TraceInfo()
+	if tr.TotalTime < 2*retryWaitTime-retryWaitTime/2 {
+		t.Fatalf("TotalTime should include retry backoff, got %v", tr.TotalTime)
+	}
+	assertTrue(t, tr.TotalTime == resp.Duration())
+}


### PR DESCRIPTION
## Summary

`TraceInfo().TotalTime` and `Response.Duration()` now cover the full request lifecycle including retry backoff, not only the final HTTP attempt.

## Changes

- Set `Request.StartTime` only on the first attempt (before `http.Client.Do`)
- Compute `TraceInfo.TotalTime` from `StartTime` when set; keep trace-timestamp fallback for invalid requests (#1016)
- Add `TestTraceInfoTotalTimeIncludesRetryWait`

Fixes #1142