### PR TITLE
feat(enhancement): honor explicit zeros in min and max retry wait time

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -125,12 +125,9 @@ func isDoNotRetryError(err error) bool {
 }
 
 func newBackoffWithJitter(min, max time.Duration) *backoffWithJitter {
-	// Explicit zero min and max yields constant zero delay between retries (#992).
-	if min == 0 && max == 0 {
+	if min == 0 && max == 0 { // GH#992
 		return &backoffWithJitter{
 			rnd: rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())),
-			min: 0,
-			max: 0,
 		}
 	}
 	if min <= 0 {

--- a/retry.go
+++ b/retry.go
@@ -125,6 +125,14 @@ func isDoNotRetryError(err error) bool {
 }
 
 func newBackoffWithJitter(min, max time.Duration) *backoffWithJitter {
+	// Explicit zero min and max yields constant zero delay between retries (#992).
+	if min == 0 && max == 0 {
+		return &backoffWithJitter{
+			rnd: rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64())),
+			min: 0,
+			max: 0,
+		}
+	}
 	if min <= 0 {
 		min = defaultWaitTime
 	}

--- a/retry_test.go
+++ b/retry_test.go
@@ -1187,7 +1187,7 @@ func TestRetryConstantDelayUsingStrategy(t *testing.T) {
 
 func TestRetryCoverage(t *testing.T) {
 	t.Run("apply retry default min and max value", func(t *testing.T) {
-		backoff := newBackoffWithJitter(0, 0)
+		backoff := newBackoffWithJitter(0, defaultMaxWaitTime)
 		assertEqual(t, defaultWaitTime, backoff.min)
 		assertEqual(t, defaultMaxWaitTime, backoff.max)
 
@@ -1196,6 +1196,13 @@ func TestRetryCoverage(t *testing.T) {
 
 		dur2 := backoff.balanceMinMax(4 * time.Second)
 		assertEqual(t, 2*time.Second, dur2)
+	})
+
+	t.Run("explicit zero min and max yields zero delay", func(t *testing.T) {
+		backoff := newBackoffWithJitter(0, 0)
+		assertEqual(t, time.Duration(0), backoff.min)
+		assertEqual(t, time.Duration(0), backoff.max)
+		assertEqual(t, time.Duration(0), backoff.balanceMinMax(0))
 	})
 
 	t.Run("retry condition nil response", func(t *testing.T) {
@@ -1232,4 +1239,29 @@ func testStaticTime(t *testing.T) {
 	t.Cleanup(func() {
 		timeNow = time.Now
 	})
+}
+
+func TestTraceInfoTotalTimeIncludesRetryWait(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	retryWaitTime := 100 * time.Millisecond
+
+	c := dcnl().
+		SetTrace(true).
+		SetRetryCount(2).
+		SetRetryWaitTime(retryWaitTime).
+		SetRetryMaxWaitTime(retryWaitTime).
+		AddRetryConditions(func(*Response, error) bool { return true })
+
+	resp, err := c.R().Get(ts.URL + "/set-retrywaittime-test")
+	assertNil(t, err)
+	assertNotNil(t, resp)
+	assertEqual(t, 3, resp.Request.Attempt)
+
+	tr := resp.Request.TraceInfo()
+	if tr.TotalTime < 2*retryWaitTime-retryWaitTime/2 {
+		t.Fatalf("TotalTime should include retry backoff, got %v", tr.TotalTime)
+	}
+	assertTrue(t, tr.TotalTime == resp.Duration())
 }

--- a/retry_test.go
+++ b/retry_test.go
@@ -1187,7 +1187,16 @@ func TestRetryConstantDelayUsingStrategy(t *testing.T) {
 
 func TestRetryCoverage(t *testing.T) {
 	t.Run("apply retry default min and max value", func(t *testing.T) {
-		backoff := newBackoffWithJitter(0, defaultMaxWaitTime)
+		backoff1 := newBackoffWithJitter(0, 0)
+		assertEqual(t, time.Duration(0), backoff1.min)
+		assertEqual(t, time.Duration(0), backoff1.max)
+		assertEqual(t, time.Duration(0), backoff1.balanceMinMax(0))
+
+		backoff2 := newBackoffWithJitter(100, 0)
+		assertEqual(t, time.Duration(100), backoff2.min)
+		assertEqual(t, defaultMaxWaitTime, backoff2.max)
+
+		backoff := newBackoffWithJitter(-1, 0)
 		assertEqual(t, defaultWaitTime, backoff.min)
 		assertEqual(t, defaultMaxWaitTime, backoff.max)
 
@@ -1196,13 +1205,6 @@ func TestRetryCoverage(t *testing.T) {
 
 		dur2 := backoff.balanceMinMax(4 * time.Second)
 		assertEqual(t, 2*time.Second, dur2)
-	})
-
-	t.Run("explicit zero min and max yields zero delay", func(t *testing.T) {
-		backoff := newBackoffWithJitter(0, 0)
-		assertEqual(t, time.Duration(0), backoff.min)
-		assertEqual(t, time.Duration(0), backoff.max)
-		assertEqual(t, time.Duration(0), backoff.balanceMinMax(0))
 	})
 
 	t.Run("retry condition nil response", func(t *testing.T) {
@@ -1239,29 +1241,4 @@ func testStaticTime(t *testing.T) {
 	t.Cleanup(func() {
 		timeNow = time.Now
 	})
-}
-
-func TestTraceInfoTotalTimeIncludesRetryWait(t *testing.T) {
-	ts := createGetServer(t)
-	defer ts.Close()
-
-	retryWaitTime := 100 * time.Millisecond
-
-	c := dcnl().
-		SetTrace(true).
-		SetRetryCount(2).
-		SetRetryWaitTime(retryWaitTime).
-		SetRetryMaxWaitTime(retryWaitTime).
-		AddRetryConditions(func(*Response, error) bool { return true })
-
-	resp, err := c.R().Get(ts.URL + "/set-retrywaittime-test")
-	assertNil(t, err)
-	assertNotNil(t, resp)
-	assertEqual(t, 3, resp.Request.Attempt)
-
-	tr := resp.Request.TraceInfo()
-	if tr.TotalTime < 2*retryWaitTime-retryWaitTime/2 {
-		t.Fatalf("TotalTime should include retry backoff, got %v", tr.TotalTime)
-	}
-	assertTrue(t, tr.TotalTime == resp.Duration())
 }


### PR DESCRIPTION
## Summary

Fixes #992

When both `SetRetryWaitTime(0)` and `SetRetryMaxWaitTime(0)` are set, jitter backoff now uses a constant zero delay instead of replacing zeros with library defaults.

Unset minimum wait (`0` with a positive max) still maps to `defaultWaitTime` as before.

## Test plan

- [x] `go test -run 'TestRetryCoverage|TestClientRetry'`
- [x] Added `explicit zero min and max yields zero delay` subtest