### PR TITLE
fix: reuse encoded request body on retry attempts

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -460,13 +460,12 @@ func handleRequestBody(c *Client, r *Request) error {
 		r.Header.Set(hdrContentTypeKey, contentType)
 	}
 
-	r.bodyBuf = acquireBuffer()
-
-	switch body := r.Body.(type) {
+	switch r.Body.(type) {
 	case io.Reader:
-		// Resty v3 onwards io.Reader used as-is with the request body.
-		releaseBuffer(r.bodyBuf)
-		r.bodyBuf = nil
+		if r.bodyBuf != nil {
+			releaseBuffer(r.bodyBuf)
+			r.bodyBuf = nil
+		}
 
 		// enable multiple reads if body is *bytes.Buffer
 		if b, ok := r.Body.(*bytes.Buffer); ok {
@@ -487,6 +486,24 @@ func handleRequestBody(c *Client, r *Request) error {
 			}
 		}
 		return nil
+	}
+
+	if len(r.encodedBody) > 0 {
+		if r.bodyBuf == nil {
+			r.bodyBuf = acquireBuffer()
+		} else {
+			r.bodyBuf.Reset()
+		}
+		r.bodyBuf.Write(r.encodedBody)
+		return nil
+	}
+
+	if r.bodyBuf != nil {
+		releaseBuffer(r.bodyBuf)
+	}
+	r.bodyBuf = acquireBuffer()
+
+	switch body := r.Body.(type) {
 	case []byte:
 		r.bodyBuf.Write(body)
 	case string:
@@ -495,7 +512,10 @@ func handleRequestBody(c *Client, r *Request) error {
 		encKey := inferContentTypeMapKey(contentType)
 		if jsonKey == encKey {
 			if !r.jsonEscapeHTML {
-				return encodeJSONEscapeHTML(r.bodyBuf, r.Body, r.jsonEscapeHTML)
+				if err := encodeJSONEscapeHTML(r.bodyBuf, r.Body, r.jsonEscapeHTML); err != nil {
+					return err
+				}
+				break
 			}
 		} else if xmlKey == encKey {
 			if inferKind(r.Body) != reflect.Struct {
@@ -517,6 +537,10 @@ func handleRequestBody(c *Client, r *Request) error {
 			r.bodyBuf = nil
 			return err
 		}
+	}
+
+	if r.bodyBuf != nil && r.bodyBuf.Len() > 0 {
+		r.encodedBody = append(r.encodedBody[:0], r.bodyBuf.Bytes()...)
 	}
 
 	return nil

--- a/request.go
+++ b/request.go
@@ -108,6 +108,7 @@ type Request struct {
 	unescapeQueryParams  bool
 	multipartErrChan     chan error
 	multipartCancelFunc  context.CancelFunc
+	encodedBody          []byte
 }
 
 // SetCorrelationID method is used to set the correlation ID for the request
@@ -1669,6 +1670,9 @@ func (r *Request) Clone(ctx context.Context) *Request {
 	if r.bodyBuf != nil {
 		rr.bodyBuf = acquireBuffer()
 		rr.bodyBuf.Write(r.bodyBuf.Bytes())
+	}
+	if len(r.encodedBody) > 0 {
+		rr.encodedBody = append([]byte(nil), r.encodedBody...)
 	}
 
 	return rr

--- a/retry_body_test.go
+++ b/retry_body_test.go
@@ -1,0 +1,48 @@
+package resty
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestRetryReusesEncodedRequestBody(t *testing.T) {
+	var encodes atomic.Int32
+	attempts := atomic.Int32{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := dcnl().
+		SetRetryCount(2).
+		SetRetryDefaultConditions(false).
+		SetRetryAllowNonIdempotent(true).
+		AddRetryConditions(func(r *Response, err error) bool {
+			return err != nil || (r != nil && r.StatusCode() >= 500)
+		})
+	c.AddContentTypeEncoder("application/json", func(w io.Writer, body any) error {
+		encodes.Add(1)
+		return encodeJSON(w, body)
+	})
+
+	type payload struct {
+		Value string `json:"value"`
+	}
+
+	resp, err := c.R().
+		SetHeader(hdrContentTypeKey, "application/json").
+		SetBody(payload{Value: "test"}).
+		Post(srv.URL)
+
+	assertNil(t, err)
+	assertEqual(t, 3, resp.Request.Attempt)
+	assertEqual(t, int32(1), encodes.Load())
+}


### PR DESCRIPTION
## Summary

Fixes #1160

Non-`io.Reader` request bodies were re-encoded on every retry because the shared `bodyBuf` was drained by the HTTP transport after the first attempt.

Cache the encoded payload after the first encode and refill `bodyBuf` on later attempts.

## Test plan

- [x] Added `TestRetryReusesEncodedRequestBody`
- [x] `go test -run 'TestRetry|parseRequestBody'`

Made with [Cursor](https://cursor.com)