### PR TITLE
fix: preserve trailing slash in SetBaseURL

### DIFF
--- a/client.go
+++ b/client.go
@@ -299,7 +299,7 @@ func (c *Client) BaseURL() string {
 func (c *Client) SetBaseURL(url string) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.baseURL = strings.TrimRight(url, "/")
+	c.baseURL = url
 	return c
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -1519,6 +1519,11 @@ func TestUnixSocket(t *testing.T) {
 	assertEqual(t, "Hello resty client from a server running on endpoint /hello!", res.String())
 }
 
+func TestSetBaseURLPreservesTrailingSlash(t *testing.T) {
+	c := dcnl().SetBaseURL("http://example.com/")
+	assertEqual(t, "http://example.com/", c.BaseURL())
+}
+
 func TestClientClone(t *testing.T) {
 	parent := New()
 


### PR DESCRIPTION
## Summary

Fixes #1061
Fixes #119

`SetBaseURL` used `strings.TrimRight` to strip trailing slashes, so `BaseURL()` no longer matched the configured value. This regressed the v1.2 behavior for callers that rely on a trailing slash when composing URLs.

## Test plan

- [x] Added `TestSetBaseURLPreservesTrailingSlash`
- [x] `go test -run 'TestSetBaseURLPreservesTrailingSlash|TestClientClone'`
- [x] `go test -run 'Test_parseRequestURL/using_BaseURL'`

Made with [Cursor](https://cursor.com)