### PR TITLE
fix: separate URL from -F/-d in buildCurlCmd output

### DIFF
--- a/curl.go
+++ b/curl.go
@@ -46,7 +46,7 @@ func buildCurlCmd(req *Request) string {
 	contentType := req.RawRequest.Header.Get(hdrContentTypeKey)
 	if strings.HasPrefix(contentType, "multipart/form-data") {
 		// Multipart: show placeholder
-		curl += "-F '<fields omitted, see original request>'"
+		curl += "-F '<fields omitted, see original request>' "
 	} else if req.RawRequest.GetBody != nil {
 		// Handle normal body
 		body, err := req.RawRequest.GetBody()
@@ -55,7 +55,7 @@ func buildCurlCmd(req *Request) string {
 			curl += "-d " + cmdQuote(string(bytes.TrimRight(buf, "\r\n"))) + " "
 		} else {
 			req.log.Errorf("curl: %v", err)
-			curl += "-d ''"
+			curl += "-d '' "
 		}
 	}
 

--- a/curl_test.go
+++ b/curl_test.go
@@ -248,7 +248,7 @@ func TestCurlRequestGetBodyError(t *testing.T) {
 
 	if !strings.Contains(curlCmdUnexecuted, "Cookie: count=1") ||
 		!strings.Contains(curlCmdUnexecuted, "curl -X POST") ||
-		!strings.Contains(curlCmdUnexecuted, `-d ''`) {
+		!strings.Contains(curlCmdUnexecuted, `-d '' http`) {
 		t.Fatal("Incomplete curl:", curlCmdUnexecuted)
 	} else {
 		t.Log("curlCmdUnexecuted: \n", curlCmdUnexecuted)
@@ -356,8 +356,8 @@ func TestCurlMultipartFormData(t *testing.T) {
 			// Verify method is included
 			assertTrue(t, strings.Contains(curlCmd, "curl -X "+tt.method), fmt.Sprintf("Expected curl command to contain 'curl -X %s'", tt.method))
 
-			// Verify URL is included
-			assertTrue(t, strings.Contains(curlCmd, tt.url), fmt.Sprintf("Expected curl command to contain URL '%s'", tt.url))
+			// Verify URL is included and separated from the -F placeholder by a space
+			assertTrue(t, strings.Contains(curlCmd, " "+tt.url), fmt.Sprintf("Expected curl command to contain URL '%s' preceded by a space, got: %s", tt.url, curlCmd))
 
 			// Verify -d flag is NOT used for multipart
 			assertFalse(t, strings.Contains(curlCmd, "-d '"), "Multipart request should use -F flag, not -d flag")


### PR DESCRIPTION
buildCurlCmd has two body branches that forget the trailing space that the normal `-d`-with-body branch adds, so the URL ends up glued to the previous token:

    curl -X POST -H 'Content-Type: multipart/form-data' -F '<fields omitted, see original request>'http://example.com/upload
    curl -X POST ... -d ''http://unexecuted-request

curl reads those as part of the `-F` value or `-d` argument and the command isn't usable. The other branch (normal body) already appends a space, so it's just an inconsistency in two spots.

Also tightened the multipart test and `TestCurlRequestGetBodyError` to actually check there's a space before the URL. The previous `strings.Contains(curlCmd, tt.url)` and `strings.Contains(curlCmdUnexecuted, "-d ''")` matched fine even with the URL glued on, which is how this slipped through.