### PR TITLE
fix: content decoder not found error when do not parse response is enabled and unsupported content-encoding header present

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -1547,6 +1547,23 @@ func TestRequestDoNotParseResponse(t *testing.T) {
 		assertEqual(t, 0, resp.StatusCode())
 		assertEqual(t, "", resp.String())
 	})
+
+	t.Run("no error when DoNotParse is enabled and content decompressor is not found", func(t *testing.T) {
+		testFileBin := filepath.Join(getTestDataPath(), "test-octet-stream.bin")
+		defer cleanupFiles(testFileBin)
+
+		resp, err := dcnl().R().
+			SetResponseDoNotParse(true).
+			SetResponseSaveFileName(testFileBin).
+			Get(ts.URL + "/do-not-parse-and-save-to-file")
+
+		assertError(t, err)
+		assertEqual(t, http.StatusOK, resp.StatusCode())
+
+		testFileBinInfo, err := os.Stat(testFileBin)
+		assertError(t, err)
+		assertTrue(t, testFileBinInfo.Size() > 0)
+	})
 }
 
 func TestRequestDoNotParseResponseDebugLog(t *testing.T) {

--- a/response.go
+++ b/response.go
@@ -329,6 +329,14 @@ func (r *Response) wrapContentDecompresser() error {
 		r.Header().Del(hdrContentEncodingKey)
 		r.Header().Del(hdrContentLengthKey)
 		r.RawResponse.ContentLength = -1
+	} else if r.Request.IsResponseDoNotParse {
+		// GH#1168 Don't return an error if DoNotParse is enabled and the content
+		// decompresser is not found. Possibly the user is handling content decompression
+		// in their own way, so instead of returning an error and breaking the response
+		// processing, just log it and let the caller handle it when they try to read the body.
+		r.Request.log.Warnf("Response.wrapContentDecompresser: DoNotParse is enabled and the content"+
+			" decompresser is not found for encoding '%s', just log it and let the caller handle it", ce)
+		return nil
 	} else {
 		return ErrContentDecompresserNotFound
 	}

--- a/resty_test.go
+++ b/resty_test.go
@@ -70,6 +70,10 @@ func createGetServer(t *testing.T) *httptest.Server {
 			case "/long-json":
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"TestGet": "JSON response with size > 30"}`))
+			case "/do-not-parse-and-save-to-file":
+				w.Header().Set("Content-Type", "application/octet-stream")
+				w.Header().Set("Content-Encoding", "binary")
+				_, _ = w.Write([]byte(`This is octet-stream response`))
 			case "/mypage":
 				w.WriteHeader(http.StatusBadRequest)
 			case "/mypage2":


### PR DESCRIPTION
fixes #1168 