### PR TITLE
fix: panics and state corruption in Request.Clone, Client.Close, SSE default logger, and invalid HTTP method handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -263,6 +263,7 @@ type Client struct {
 	contentDecompresserKeys    []string
 	contentDecompressers       map[string]ContentDecompresser
 	certWatcherStopChan        chan bool
+	isClosed                   bool
 	circuitBreaker             CircuitBreaker
 	hedging                    Hedger
 	rateLimiter                RateLimiter
@@ -2409,11 +2410,22 @@ func (c *Client) Clone(ctx context.Context) *Client {
 
 	// certain values need to be reset
 	cc.lock = &sync.RWMutex{}
+	cc.certWatcherStopChan = make(chan bool)
+	cc.isClosed = false
 	return cc
 }
 
 // Close method executes all registered [CloseHook] callbacks and releases client resources.
+// It is safe to call Close multiple times; subsequent calls are no-op.
 func (c *Client) Close() error {
+	c.lock.Lock()
+	alreadyClosed := c.isClosed
+	c.isClosed = true
+	c.lock.Unlock()
+	if alreadyClosed {
+		return nil
+	}
+
 	// Execute close hooks first
 	c.onCloseHooks()
 

--- a/client_test.go
+++ b/client_test.go
@@ -1719,6 +1719,56 @@ func TestClientCloneClose(t *testing.T) {
 	assertNil(t, cc.Close())
 }
 
+func TestClientCloseConcurrentIdempotent(t *testing.T) {
+	const goroutines = 64
+
+	closeCounter := 0
+	c := dcnl()
+	c.OnClose(func() {
+		// only one goroutine ever reaches the hook, so a plain
+		// increment is data-race free
+		closeCounter++
+	})
+
+	errs := make([]error, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = c.Close()
+		}(i)
+	}
+	wg.Wait()
+
+	// concurrent closes must not panic and every call returns nil
+	for _, err := range errs {
+		assertNil(t, err)
+	}
+	// the OnClose hook runs exactly once
+	assertEqual(t, 1, closeCounter)
+}
+
+func TestClientCloneAfterCloseLifecycle(t *testing.T) {
+	c := dcnl()
+
+	// parent closes first
+	assertNil(t, c.Close())
+	assertEqual(t, true, c.isClosed)
+
+	// a clone taken from a closed parent starts with a fresh lifecycle
+	cc := c.Clone(context.Background())
+	assertEqual(t, false, cc.isClosed)
+
+	// closing the clone is idempotent and must not panic
+	assertNil(t, cc.Close())
+	assertNil(t, cc.Close())
+	assertEqual(t, true, cc.isClosed)
+
+	// the parent remains closed and unaffected by the clone's lifecycle
+	assertEqual(t, true, c.isClosed)
+}
+
 func TestClientHedgingMutualExclusionWithRetry(t *testing.T) {
 	c := dcnl()
 

--- a/client_test.go
+++ b/client_test.go
@@ -1698,6 +1698,27 @@ func TestClientOnCloseMultipleHooks(t *testing.T) {
 	assertEqual(t, []string{"first", "second", "third"}, executionOrder)
 }
 
+func TestClientCloseIdempotent(t *testing.T) {
+	closeCounter := 0
+	c := dcnl()
+	c.OnClose(func() {
+		closeCounter++
+	})
+
+	assertNil(t, c.Close())
+	assertNil(t, c.Close()) // subsequent close is a no-op, no panic
+	assertEqual(t, 1, closeCounter)
+}
+
+func TestClientCloneClose(t *testing.T) {
+	c := dcnl()
+	cc := c.Clone(context.Background())
+
+	// the clone has its own lifecycle; closing both must not panic
+	assertNil(t, c.Close())
+	assertNil(t, cc.Close())
+}
+
 func TestClientHedgingMutualExclusionWithRetry(t *testing.T) {
 	c := dcnl()
 

--- a/middleware.go
+++ b/middleware.go
@@ -46,9 +46,11 @@ func MiddlewareRequestCreate(c *Client, r *Request) (err error) {
 		return err
 	}
 
-	// at this point, possible error from `http.NewRequestWithContext`
-	// is URL-related, and those get caught up in the `parseRequestURL`
-	createRawRequest(c, r)
+	// possible error from `http.NewRequestWithContext` is an invalid
+	// HTTP method since URL-related errors get caught up in the `parseRequestURL`
+	if err = createRawRequest(c, r); err != nil {
+		return err
+	}
 
 	addCredentials(c, r)
 

--- a/request.go
+++ b/request.go
@@ -1639,7 +1639,7 @@ func (r *Request) Clone(ctx context.Context) *Request {
 
 	// clone cookies
 	if l := len(r.Cookies); l > 0 {
-		rr.Cookies = make([]*http.Cookie, l)
+		rr.Cookies = make([]*http.Cookie, 0, l)
 		for _, cookie := range r.Cookies {
 			rr.Cookies = append(rr.Cookies, cloneCookie(cookie))
 		}
@@ -1661,9 +1661,9 @@ func (r *Request) Clone(ctx context.Context) *Request {
 	rr.StartTime = time.Time{}
 	rr.Attempt = 0
 	rr.initTraceIfEnabled()
-	r.values = make(map[string]any)
-	r.multipartErrChan = nil
-	r.ctxCancelFunc = nil
+	rr.values = make(map[string]any)
+	rr.multipartErrChan = nil
+	rr.ctxCancelFunc = nil
 
 	// copy bodyBuf
 	if r.bodyBuf != nil {

--- a/request_test.go
+++ b/request_test.go
@@ -2234,6 +2234,62 @@ func TestRequestClone(t *testing.T) {
 	assertNotEqual(t, parent.RawRequest, clone.RawRequest)
 }
 
+func TestRequestCloneCookiesAndInternalState(t *testing.T) {
+	c := dcnl()
+	parent := c.R().
+		SetCookie(&http.Cookie{Name: "go-resty-1", Value: "parent value"}).
+		SetCookie(&http.Cookie{Name: "go-resty-2", Value: "parent value 2"})
+	parent.initValuesMap()
+	parent.values["key-1"] = "value-1"
+	parent.multipartErrChan = make(chan error, 1)
+	parent.ctxCancelFunc = func() {}
+
+	clone := parent.Clone(context.Background())
+
+	// cookies are deep copied without nil entries
+	assertEqual(t, 2, len(clone.Cookies))
+	assertNotNil(t, clone.Cookies[0])
+	assertNotNil(t, clone.Cookies[1])
+	assertEqual(t, "go-resty-1", clone.Cookies[0].Name)
+	assertEqual(t, "go-resty-2", clone.Cookies[1].Name)
+
+	// mutating the clone's cookie does not affect the parent
+	clone.Cookies[0].Value = "clone value"
+	assertEqual(t, "parent value", parent.Cookies[0].Value)
+
+	// Clone does not reset the parent's internal state
+	assertEqual(t, "value-1", parent.values["key-1"])
+	assertNotNil(t, parent.multipartErrChan)
+	assertNotNil(t, parent.ctxCancelFunc)
+
+	// the clone gets a fresh values map and reset execution state
+	_, found := clone.values["key-1"]
+	assertFalse(t, found)
+	assertNil(t, clone.multipartErrChan)
+	assertNil(t, clone.ctxCancelFunc)
+	clone.values["key-2"] = "value-2"
+	_, found = parent.values["key-2"]
+	assertFalse(t, found)
+}
+
+func TestRequestInvalidMethod(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	var hookErr error
+	c := dcnl()
+	c.OnInvalid(func(r *Request, err error) {
+		hookErr = err
+	})
+
+	res, err := c.R().Execute("INVALID METHOD", ts.URL)
+
+	assertNotNil(t, err)
+	assertTrue(t, strings.Contains(err.Error(), "invalid method"))
+	assertNotNil(t, hookErr)
+	assertNil(t, res)
+}
+
 func TestResponseBodyUnlimitedReads(t *testing.T) {
 	ts := createPostServer(t)
 	defer ts.Close()

--- a/sse.go
+++ b/sse.go
@@ -120,6 +120,7 @@ func NewSSESource() *SSESource {
 		retryConditions:  make([]RetryConditionFunc, 0),
 		maxBufSize:       defaultSseMaxBufSize,
 		onEvent:          make(map[string]*callback),
+		log:              createLogger(),
 		httpClient: &http.Client{
 			Jar:       createCookieJar(),
 			Transport: createTransport(nil, nil),

--- a/sse_test.go
+++ b/sse_test.go
@@ -669,6 +669,24 @@ func TestSSESourceCoverage(t *testing.T) {
 	parseEvent([]byte{})
 }
 
+func TestSSESourceDefaultLogger(t *testing.T) {
+	es := NewSSESource()
+	assertNotNil(t, es.Logger())
+
+	lb := new(bytes.Buffer)
+	es.outputLogTo(lb)
+
+	// overwriting callbacks logs a warning; it must not panic
+	// when the user has not provided a logger
+	es.OnMessage(func(any) {}, nil)
+	es.OnMessage(func(any) {}, nil)
+	assertTrue(t, strings.Contains(lb.String(), "Overwriting an existing OnEvent callback"))
+
+	// body read failures are logged; it must not panic either
+	es.SetBody(&errorReader{})
+	assertNil(t, es.bodyBytes)
+}
+
 func TestSSESetBody(t *testing.T) {
 	t.Run("nil input", func(t *testing.T) {
 		es := createSSESource(t, "", nil, nil)


### PR DESCRIPTION
### 1. `Request.Clone` produces a corrupted cookies slice (`request.go`)

The cookies slice was created with `make([]*http.Cookie, l)` and then appended to, producing a slice of length `2l` whose first half is `nil` entries:

```go
rr.Cookies = make([]*http.Cookie, l)        // length l, all nil
for _, cookie := range r.Cookies {
    rr.Cookies = append(rr.Cookies, cloneCookie(cookie))  // appends after the nils
}
```

Executing the cloned request panics inside `http.Request.AddCookie` on the first `nil` cookie. Fixed by using `make([]*http.Cookie, 0, l)`.

### 2. `Request.Clone` resets the source request instead of the clone (`request.go`)

Three reset statements targeted the receiver `r` instead of the clone `rr`:

```go
r.values = make(map[string]any)   // wipes the parent's values map
r.multipartErrChan = nil
r.ctxCancelFunc = nil
```

This silently wiped the parent request's internal state (e.g., the debug-log entry stored in `values`) and left the clone sharing the parent's multipart error channel and context cancel function.

### 3. Calling `Client.Close` twice panics (`client.go`)

`Close` unconditionally executed `close(c.certWatcherStopChan)`, so a second call panicked with `close of closed channel`. `Close` is now idempotent (guarded by an internal flag under the client lock), and `OnClose` hooks are guaranteed to run exactly once.

`Client.Clone` now also allocates its own `certWatcherStopChan`, so closing both the parent and the clone is safe (previously they shared the channel, and closing both panicked as well).

### 4. `NewSSESource` never initializes its logger (`sse.go`)

The `log` field was left `nil` unless the user explicitly called `SetLogger`. Any code path that logs — overwriting a callback via `OnMessage`/`OnOpen`/`OnError`/`OnRequestFailure`/`AddEventListener`, or a body read failure in `SetBody` — panicked with a nil pointer dereference. The existing tests masked this because the shared test helper always calls `SetLogger`. `NewSSESource` now initializes the default logger, consistent with `createClient`.

### 5. Invalid HTTP method panics instead of returning an error (`middleware.go`)

`MiddlewareRequestCreate` discarded the error returned by `createRawRequest`:

```go
createRawRequest(c, r)  // error ignored
```

The comment assumed all errors were URL-related and already caught in `parseRequestURL`, but `http.NewRequestWithContext` also validates the HTTP method. An invalid method (e.g. `client.R().Execute("BAD METHOD", url)`) left `RawRequest` as `nil` and panicked later in `withTimeout`. The error is now propagated, so the request fails with `net/http: invalid method` as an invalid-request error and triggers the `OnInvalid` hooks.

## Behavior changes (non-breaking)

- `Client.Close()` is now documented and implemented as idempotent; subsequent calls are no-ops and `OnClose` hooks run exactly once. Previously a second call always panicked, so no working code relied on the old behavior.
- `Request.Execute` with an invalid HTTP method now returns an error and invokes `OnInvalid` hooks instead of panicking.

## Tests

- `TestRequestCloneCookiesAndInternalState` — cookies are deep-copied with no `nil` entries; mutating a cloned cookie does not affect the parent; `Clone` no longer resets the parent's `values`/`multipartErrChan`/`ctxCancelFunc`; the clone gets a fresh values map.
- `TestRequestInvalidMethod` — an invalid method returns an `invalid method` error, fires the `OnInvalid` hook, and does not panic.
- `TestClientCloseIdempotent` — double `Close` does not panic and `OnClose` hooks run exactly once.
- `TestClientCloneClose` — closing both the parent client and its clone is safe.
- `TestSSESourceDefaultLogger` — `NewSSESource` has a working default logger; overwriting callbacks and `SetBody` read failures log instead of panicking.
