### PR TITLE
fix context cancellation leak

### DIFF
--- a/client.go
+++ b/client.go
@@ -2490,10 +2490,21 @@ func (c *Client) execute(req *Request) (*Response, error) {
 		req.multipartCancelFunc()
 	}
 
+	// Take ownership of the per-attempt timeout cancel func set by
+	// withTimeout. It must fire once the response body is fully consumed,
+	// so it is attached to the body's Close below. On a transport error
+	// there is no body to read, so release it right away to avoid leaking
+	// the context (and its timer) until the deadline elapses.
+	cancel := req.ctxCancelFunc
+	req.ctxCancelFunc = nil
+
 	response := &Response{Request: req, RawResponse: resp}
 	response.setReceivedAt()
 	if err != nil {
 		c.cbRequestError()
+		if cancel != nil {
+			cancel()
+		}
 		return response, err
 	}
 	if req.isMultiPart && req.multipartErrChan != nil {
@@ -2509,6 +2520,14 @@ func (c *Client) execute(req *Request) (*Response, error) {
 		}
 
 		response.Body = resp.Body
+		// Release the request timeout context once the body is closed,
+		// whether by the caller (do-not-parse) or by Resty while parsing
+		// or draining the body. Wrapping innermost ensures cancel runs no
+		// matter which outer reader closes the chain.
+		if cancel != nil {
+			response.Body = &cancelReadCloser{r: response.Body, cancel: cancel}
+			cancel = nil
+		}
 		if err = response.wrapContentDecompresser(); err != nil {
 			return response, response.wrapError(err, false)
 		}
@@ -2524,6 +2543,12 @@ func (c *Client) execute(req *Request) (*Response, error) {
 				}
 			}
 		}
+	}
+
+	// No response body was available to attach the cancel to (e.g. resp is
+	// nil); release the timeout context now so it does not leak.
+	if cancel != nil {
+		cancel()
 	}
 
 	debugLogger(c, response)

--- a/context_test.go
+++ b/context_test.go
@@ -317,6 +317,85 @@ func TestSSESourceSetContextCancel(t *testing.T) {
 	}
 }
 
+func TestRequestTimeoutContextReleasedAfterBodyRead(t *testing.T) {
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+	defer ts.Close()
+
+	tr := &ctxCaptureTransport{rt: http.DefaultTransport}
+	c := dcnl().SetTransport(tr)
+
+	resp, err := c.R().
+		SetTimeout(5 * time.Second).
+		Get(ts.URL + "/")
+
+	assertNil(t, err)
+	_ = resp.String() // reads and closes the body
+
+	assertNotNil(t, tr.ctx, "expected transport to have captured a context")
+	assertNotNil(t, tr.ctx.Err(), "expected timeout context to be cancelled after body is closed")
+}
+
+func TestRequestTimeoutContextReleasedOnTransportError(t *testing.T) {
+	transportErr := errors.New("simulated transport error")
+	tr := &ctxCaptureTransport{
+		rt: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return nil, transportErr
+		}),
+	}
+	c := dcnl().SetTransport(tr)
+
+	_, err := c.R().
+		SetTimeout(5 * time.Second).
+		Get("http://127.0.0.1:1/unreachable")
+
+	assertNotNil(t, err)
+	assertNotNil(t, tr.ctx, "expected transport to have captured a context")
+	assertNotNil(t, tr.ctx.Err(), "expected timeout context to be cancelled after transport error")
+}
+
+func TestRequestTimeoutContextReleasedOnDoNotParseResponse(t *testing.T) {
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+	defer ts.Close()
+
+	tr := &ctxCaptureTransport{rt: http.DefaultTransport}
+	c := dcnl().SetTransport(tr)
+
+	resp, err := c.R().
+		SetTimeout(5 * time.Second).
+		SetResponseDoNotParse(true).
+		Get(ts.URL + "/")
+
+	assertNil(t, err)
+	assertNotNil(t, resp.Body, "expected response body to be non-nil")
+
+	// Before closing, context should still be live.
+	assertNil(t, tr.ctx.Err(), "expected timeout context to still be active before body is closed")
+
+	_ = resp.Body.Close()
+
+	assertNotNil(t, tr.ctx.Err(), "expected timeout context to be cancelled after body is closed")
+}
+
+// ctxCaptureTransport records the context of the outgoing request.
+type ctxCaptureTransport struct {
+	rt  http.RoundTripper
+	ctx context.Context
+}
+
+func (t *ctxCaptureTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	t.ctx = r.Context()
+	return t.rt.RoundTrip(r)
+}
+
+// roundTripFunc is an http.RoundTripper backed by a plain function.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
 func errIsContextCanceled(err error) bool {
 	return errors.Is(err, context.Canceled)
 }

--- a/request.go
+++ b/request.go
@@ -1501,11 +1501,10 @@ func (r *Request) Execute(method, url string) (res *Response, err error) {
 				isInvalidRequestErr = true
 				break
 			}
+			// The per-attempt timeout context cancel func is owned and
+			// released by Client.execute (on transport error, or when the
+			// response body is closed), so there is nothing to cancel here.
 			if r.Context().Err() != nil {
-				if r.ctxCancelFunc != nil {
-					r.ctxCancelFunc()
-					r.ctxCancelFunc = nil
-				}
 				if !errors.Is(err, context.DeadlineExceeded) {
 					err = wrapErrors(r.Context().Err(), err)
 					break

--- a/stream.go
+++ b/stream.go
@@ -378,6 +378,33 @@ func (r *copyReadCloser) Close() error {
 	return nil
 }
 
+var _ io.ReadCloser = (*cancelReadCloser)(nil)
+
+// cancelReadCloser wraps the response body so that closing it also invokes
+// cancel, releasing the per-request timeout context created by
+// [Request.withTimeout].
+//
+// The cancel must not run before the body is fully consumed; otherwise an
+// in-flight body read would be aborted with a context error. Closing the body
+// (directly by the caller for do-not-parse responses, or by Resty while
+// parsing/draining otherwise) is therefore the correct moment to release it.
+// context cancel funcs are safe to call more than once, so repeated Close
+// calls are harmless.
+type cancelReadCloser struct {
+	r      io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (c *cancelReadCloser) Read(p []byte) (int, error) {
+	return c.r.Read(p)
+}
+
+func (c *cancelReadCloser) Close() error {
+	err := c.r.Close()
+	c.cancel()
+	return err
+}
+
 var _ io.ReadCloser = (*nopReadCloser)(nil)
 
 type nopReadCloser struct {

--- a/stream_test.go
+++ b/stream_test.go
@@ -628,7 +628,7 @@ func TestCancelReadCloser(t *testing.T) {
 		closeErr := errors.New("inner close error")
 		canceled := false
 		rc := &cancelReadCloser{
-			r: &errReadCloser{closeErr: closeErr},
+			r:      &errReadCloser{closeErr: closeErr},
 			cancel: func() { canceled = true },
 		}
 		err := rc.Close()

--- a/stream_test.go
+++ b/stream_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -597,6 +598,52 @@ func TestDecodeXML(t *testing.T) {
 		assertEqual(t, "resty: XML decode exceeded 51 objects without EOF", err.Error())
 	})
 }
+
+func TestCancelReadCloser(t *testing.T) {
+	t.Run("read delegates to inner reader", func(t *testing.T) {
+		data := []byte("hello resty")
+		rc := &cancelReadCloser{
+			r:      io.NopCloser(bytes.NewReader(data)),
+			cancel: func() {},
+		}
+		buf := make([]byte, len(data))
+		n, err := rc.Read(buf)
+		assertNil(t, err)
+		assertEqual(t, len(data), n)
+		assertEqual(t, string(data), string(buf))
+	})
+
+	t.Run("close calls cancel", func(t *testing.T) {
+		canceled := false
+		rc := &cancelReadCloser{
+			r:      io.NopCloser(strings.NewReader("")),
+			cancel: func() { canceled = true },
+		}
+		err := rc.Close()
+		assertNil(t, err)
+		assertTrue(t, canceled, "expected cancel to be called on Close")
+	})
+
+	t.Run("close returns inner error", func(t *testing.T) {
+		closeErr := errors.New("inner close error")
+		canceled := false
+		rc := &cancelReadCloser{
+			r: &errReadCloser{closeErr: closeErr},
+			cancel: func() { canceled = true },
+		}
+		err := rc.Close()
+		assertEqual(t, closeErr, err)
+		assertTrue(t, canceled, "expected cancel to be called even when inner Close errors")
+	})
+}
+
+// errReadCloser is a ReadCloser whose Close returns a fixed error.
+type errReadCloser struct {
+	closeErr error
+}
+
+func (e *errReadCloser) Read(p []byte) (int, error) { return 0, io.EOF }
+func (e *errReadCloser) Close() error               { return e.closeErr }
 
 func TestStreamMisc(t *testing.T) {
 	t.Run("wrapper gzip reader is nil", func(t *testing.T) {


### PR DESCRIPTION
On the success path the request-level timeout context's cancel func is never called, so it leaks

related to https://github.com/go-resty/resty/issues/1176