### PR TITLE
fix(retry): protect parseRetryAfterHeader from integer and time duration overflow

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -222,6 +222,9 @@ func parseRetryAfterHeader(v string) (time.Duration, bool) {
 		if delay < 0 { // a negative delay doesn't make sense
 			return 0, false
 		}
+		if delay > int64(math.MaxInt64/time.Second) {
+			return time.Duration(math.MaxInt64), true
+		}
 		return time.Second * time.Duration(delay), true
 	}
 
@@ -230,10 +233,13 @@ func parseRetryAfterHeader(v string) (time.Duration, bool) {
 	if err != nil {
 		return 0, false
 	}
-	if until := retryTime.Sub(timeNow()); until > 0 {
-		return until, true
+	if retryTime.Before(timeNow()) {
+		return 0, true // date is in the past
 	}
 
-	// date is in the past
-	return 0, true
+	duration := retryTime.Sub(timeNow())
+	if duration < 0 { // overflow wrapped to negative
+		duration = time.Duration(math.MaxInt64)
+	}
+	return duration, true
 }

--- a/retry_test.go
+++ b/retry_test.go
@@ -758,6 +758,29 @@ func TestParseRetryAfterHeader(t *testing.T) {
 	}
 }
 
+func TestParseRetryAfterHeaderDateNowMovesForward(t *testing.T) {
+	retryAt, err := time.Parse(time.RFC1123, "Fri, 31 Dec 1999 23:59:59 GMT")
+	assertNil(t, err)
+
+	callCount := 0
+	// Simulate the clock moving forward between the past-check and Sub call.
+	timeNow = func() time.Time {
+		callCount++
+		if callCount == 1 {
+			return retryAt.Add(-1 * time.Second)
+		}
+		return retryAt.Add(1 * time.Second)
+	}
+	t.Cleanup(func() {
+		timeNow = time.Now
+	})
+
+	sleep, ok := parseRetryAfterHeader("Fri, 31 Dec 1999 23:59:59 GMT")
+	assertTrue(t, ok)
+	assertEqual(t, time.Duration(math.MaxInt64), sleep)
+	assertEqual(t, 2, callCount)
+}
+
 func TestRequestRetryTooManyRequestsHeaderRetryAfter(t *testing.T) {
 	ts := createGetServer(t)
 	defer ts.Close()

--- a/retry_test.go
+++ b/retry_test.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -741,6 +742,8 @@ func TestParseRetryAfterHeader(t *testing.T) {
 		{"negative", "-2", 0, false},
 		{"bad-date", "Fri, 32 Dec 1999 23:59:59 GMT", 0, false},
 		{"bad-date-format", "badbadbad", 0, false},
+		{"overflow-seconds", "9223372037", time.Duration(math.MaxInt64), true},
+		{"overflow-date", "Fri, 31 Dec 2293 23:59:59 GMT", time.Duration(math.MaxInt64), true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
### Description
This PR addresses an un-guarded integer and time duration overflow vulnerability within the automatic retry header parsing engine (`parseRetryAfterHeader`). By introducing safe multiplication boundary thresholds, we ensure the client cleanly caps astronomical server-provided delays instead of corrupting the backoff context scheduler or causing a runtime panic.

### Technical Context
When parsing an HTTP `Retry-After` header value, the client evaluates either delta-seconds or a specific HTTP-Date string. 
* In the seconds track, multiplying an arbitrary 64-bit integer directly by `time.Second` ($1,000,000,000$ nanoseconds) easily overflows the internal maximum limit of a Go `time.Duration` structure ($2^{63}-1$). This calculation error wraps the resulting delay into a negative duration, causing sub-system scheduling panics.
* In the date fallback track, subtracting the current epoch time from an extreme future date parameter creates a differential calculation that can similarly exceed duration storage limits.

### Resolution Strategy
* **Multiplication Ceiling Fencing:** Injected an inline arithmetic boundary check using `math.MaxInt64 / time.Second` inside `retry.go` to intercept excessive delay parameters out of the gate.
* **Duration Range Normalization:** Forced the computed date subtraction result to validate within expected positive limits, defaulting seamlessly to maximum bounds if a range wrap or negative anomaly is encountered.