### PR TITLE
improve string request body parsing memory allocs

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -492,7 +492,7 @@ func handleRequestBody(c *Client, r *Request) error {
 	case []byte:
 		r.bodyBuf.Write(body)
 	case string:
-		r.bodyBuf.Write([]byte(body))
+		r.bodyBuf.WriteString(body)
 	default:
 		encKey := inferContentTypeMapKey(contentType)
 		if jsonKey == encKey {


### PR DESCRIPTION
`bodyBuf.Write([]byte(body))` allocates memory for `[]byte`. There is `WriteString` method on `bytes.Buffer` that accepts a string and does not allocate.