### PR TITLE
docs(sse): replace dead sse.dev example host with a live public SSE endpoint

### DIFF
--- a/sse.go
+++ b/sse.go
@@ -97,8 +97,8 @@ type (
 // NewSSESource creates a new [SSESource] with default SSE settings.
 //
 //	sse := NewSSESource().
-//		SetURL("https://sse.dev/test").
-//		OnMessage(
+//		SetURL("https://streaming.dexpaprika.com/sse/prices?method=token_price&chain=ethereum&address=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").
+//		AddEventListener("token_price",
 //			func(e any) {
 //				event := e.(*resty.SSE)
 //				fmt.Println(event)
@@ -136,7 +136,7 @@ func NewSSESource() *SSESource {
 
 // SetURL method sets the event-source URL on the [SSESource] instance.
 //
-//	sse.SetURL("https://sse.dev/test")
+//	sse.SetURL("https://streaming.dexpaprika.com/sse/prices?method=token_price&chain=ethereum&address=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
 func (sse *SSESource) SetURL(url string) *SSESource {
 	sse.url = url
 	return sse
@@ -511,8 +511,8 @@ func (sse *SSESource) AddEventListener(eventName string, ef SSEMessageFunc, resu
 // Get method establishes the connection with the server.
 //
 //	sse := NewSSESource().
-//		SetURL("https://sse.dev/test").
-//		OnMessage(
+//		SetURL("https://streaming.dexpaprika.com/sse/prices?method=token_price&chain=ethereum&address=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2").
+//		AddEventListener("token_price",
 //			func(e any) {
 //				event := e.(*resty.SSE)
 //				fmt.Println(event)

--- a/sse_test.go
+++ b/sse_test.go
@@ -655,7 +655,7 @@ func TestSSESourceCoverage(t *testing.T) {
 	err1 := es.Get()
 	assertEqual(t, "resty:sse: event source URL is required", err1.Error())
 
-	es.SetURL("https://sse.dev/test")
+	es.SetURL("https://streaming.dexpaprika.com/sse/prices?method=token_price&chain=ethereum&address=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2")
 	err2 := es.Get()
 	assertEqual(t, "resty:sse: At least one OnMessage/AddEventListener func is required", err2.Error())
 


### PR DESCRIPTION
## Summary

The SSE godoc examples in `sse.go`, plus one URL fixture in `sse_test.go`, point to `https://sse.dev/test`. That domain is gone:

```
$ host sse.dev
Host sse.dev not found: 3(NXDOMAIN)
```

Anyone copy-pasting the examples gets a DNS error instead of a stream.

This PR swaps in a live public SSE endpoint that needs no signup or API key (DexPaprika WETH price stream):

```
https://streaming.dexpaprika.com/sse/prices?method=token_price&chain=ethereum&address=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
```

It emits named `token_price` events when the tracked price updates, which for WETH works out to one every several seconds. Because the events are named, I also switched the two full examples from `OnMessage` to `AddEventListener("token_price", ...)`. `OnMessage` only fires for unnamed (`message`) events, so against a named-event stream the old example shape compiles but prints nothing. I ran both variants against this branch to confirm: the listener receives events, `OnMessage` receives zero.

The `sse_test.go` change is only the URL string in `TestSSESourceCoverage`. That test never dials (Get() fails on the "at least one OnMessage/AddEventListener" validation first), so this just removes the last reference to the dead host.

## Testing

- `diff -u <(echo -n) <(go fmt $(go list ./...))` is clean
- `go test ./... -race -count=1 -covermode=atomic -coverpkg=./... -shuffle=on` passes, coverage unchanged at 99.9%
- Ran the updated example end to end against the live endpoint through this branch's SSE implementation and confirmed event delivery

For transparency: I do DevRel for DexPaprika, which is how I knew about this endpoint. It's free and keyless, and it's meant to stay up long-term as a public example host. If you'd rather point the examples at a different public SSE host, happy to update.
