### PR TITLE
feat: add support for the HTTP QUERY method (RFC 10008)

### DIFF
--- a/client.go
+++ b/client.go
@@ -47,6 +47,9 @@ const (
 
 	// MethodTrace is the HTTP TRACE method.
 	MethodTrace = "TRACE"
+
+	// MethodQuery is the HTTP QUERY method.
+	MethodQuery = "QUERY"
 )
 
 const (

--- a/hedging.go
+++ b/hedging.go
@@ -284,7 +284,7 @@ func (ht *Hedging) RoundTrip(req *http.Request) (*http.Response, error) {
 // isReadOnlyMethod reports whether the HTTP method is read-only (safe for hedging).
 func isReadOnlyMethod(method string) bool {
 	switch method {
-	case MethodGet, MethodHead, MethodOptions, MethodTrace:
+	case MethodGet, MethodHead, MethodOptions, MethodTrace, MethodQuery:
 		return true
 	default:
 		return false

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,41 @@
+package resty
+
+import (
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestQuery(t *testing.T) {
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != MethodQuery {
+			t.Errorf("expected method %q, got %q", MethodQuery, r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})
+	defer ts.Close()
+
+	resp, err := dcnl().R().
+		SetHeader("Content-Type", "application/sql").
+		SetBody("select * from users limit 10").
+		Query(ts.URL + "/")
+
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
+	assertEqual(t, "select * from users limit 10", resp.String())
+
+	logResponse(t, resp)
+}
+
+func TestQueryMethodClassification(t *testing.T) {
+	// QUERY is safe and idempotent per RFC 10008, so it must be treated as
+	// read-only (hedging) and idempotent (automatic retries).
+	assertEqual(t, true, isReadOnlyMethod(MethodQuery))
+
+	r := dcnl().R()
+	r.Method = MethodQuery
+	assertEqual(t, true, r.isIdempotent())
+}

--- a/request.go
+++ b/request.go
@@ -1438,6 +1438,14 @@ func (r *Request) Trace(url string) (*Response, error) {
 	return r.Execute(MethodTrace, url)
 }
 
+// Query method does QUERY HTTP request. QUERY is a safe, idempotent method that
+// carries the query as request content; it's defined in section 2 of [RFC 10008].
+//
+// [RFC 10008]: https://datatracker.ietf.org/doc/html/rfc10008.html#section-2
+func (r *Request) Query(url string) (*Response, error) {
+	return r.Execute(MethodQuery, url)
+}
+
 // Send method performs the HTTP request using the method and URL already defined
 // for current [Request].
 //
@@ -1800,7 +1808,8 @@ func (r *Request) isPayloadSupported() bool {
 		return true
 	}
 
-	if r.Method == MethodPost || r.Method == MethodPut || r.Method == MethodPatch {
+	// QUERY (RFC 10008) always carries the query as request content.
+	if r.Method == MethodPost || r.Method == MethodPut || r.Method == MethodPatch || r.Method == MethodQuery {
 		return true
 	}
 
@@ -1853,6 +1862,7 @@ var idempotentMethods = map[string]struct{}{
 	MethodHead:    {},
 	MethodOptions: {},
 	MethodPut:     {},
+	MethodQuery:   {},
 	MethodTrace:   {},
 }
 

--- a/request.go
+++ b/request.go
@@ -1441,6 +1441,10 @@ func (r *Request) Trace(url string) (*Response, error) {
 // Query method does QUERY HTTP request. QUERY is a safe, idempotent method that
 // carries the query as request content; it's defined in section 2 of [RFC 10008].
 //
+// NOTE:
+//   - RFC is in the early stage of adoption in the industry; server side and browsers
+//     are yet to add support. You may run into unexpected failures due to infrastructure/environment.
+//
 // [RFC 10008]: https://datatracker.ietf.org/doc/html/rfc10008.html#section-2
 func (r *Request) Query(url string) (*Response, error) {
 	return r.Execute(MethodQuery, url)


### PR DESCRIPTION
## What

[RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html) (Proposed Standard, June 2026) defines **QUERY**, a **safe** and **idempotent** HTTP method that carries the query as request content — combining GET's safety, cacheability and retryability with POST's arbitrary request body. This PR adds first-class support for it to Resty.

## Changes

- Add the `MethodQuery` constant (`client.go`).
- Add the `Request.Query(url)` helper, matching the existing verb helpers such as `Get`/`Post`/`Trace` (`request.go`).
- Send the request body for QUERY in `isPayloadSupported()` — QUERY always carries content, so this is required for the method to be usable (`request.go`).
- Classify QUERY as **idempotent** (so automatic retries apply) and **read-only** (so hedging applies), consistent with its RFC 10008 safe + idempotent semantics (`request.go`, `hedging.go`).

## Ecosystem context

QUERY is registered in the IANA HTTP Method Registry as safe + idempotent (RFC 10008 Section 5.1), and the Go router ecosystem is already adopting it — **chi** (`Router.Query`) and **echo** (`Echo.QUERY`) both ship it. This brings the same first-class support to Resty's client.

## Tests

- `TestQuery` — end-to-end `Query()` call with a body against a test server.
- `TestQueryMethodClassification` — asserts QUERY is treated as read-only and idempotent.

`go test ./...` passes.

## Notes

Happy to split this up or adjust naming if you'd prefer.
