### PR TITLE
docs: fix "allows to provide" wording on SetResponseExpectContentType

### DIFF
--- a/request.go
+++ b/request.go
@@ -973,7 +973,7 @@ func (r *Request) SetPathRawParams(params map[string]string) *Request {
 	return r
 }
 
-// SetResponseExpectContentType method allows to provide fallback `Content-Type`
+// SetResponseExpectContentType method allows providing a fallback `Content-Type`
 // for automatic unmarshalling when the `Content-Type` response header is unavailable.
 func (r *Request) SetResponseExpectContentType(contentType string) *Request {
 	r.ResponseExpectContentType = contentType


### PR DESCRIPTION
## Summary
Godoc: \"allows to provide fallback\" → \"allows providing a fallback\".

## Test plan
- [x] `go test -short -run 'TestClientSetScheme|TestClientBasic' .`