### PR TITLE
fix: handle Windows connection refused load balancer feedback

### DIFF
--- a/load_balancer_test.go
+++ b/load_balancer_test.go
@@ -600,6 +600,23 @@ func TestLoadBalancerRequestFailures(t *testing.T) {
 	assertEqual(t, 7, ts2URL)
 }
 
+func TestLoadBalancerConnectionRefusedMarksHostInactive(t *testing.T) {
+	ts := createGetServer(t)
+	ts.Close()
+
+	wrr, err := NewWeightedRoundRobin(time.Second, &Host{BaseURL: ts.URL, Weight: 1, MaxFailures: 1})
+	assertNil(t, err)
+	defer wrr.Close()
+
+	c := dcnl()
+	defer c.Close()
+	c.SetLoadBalancer(wrr)
+
+	_, _ = c.R().Get("/")
+
+	assertEqual(t, HostStateInActive, wrr.hosts[0].state)
+}
+
 type mockTimeoutErr struct{}
 
 func (e *mockTimeoutErr) Error() string { return "i/o timeout" }

--- a/request.go
+++ b/request.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -1857,7 +1858,7 @@ func (r *Request) sendLoadBalancerFeedback(res *Response, err error) {
 	if err != nil {
 		var noe *net.OpError
 		if errors.As(err, &noe) {
-			success = !errors.Is(noe.Err, syscall.ECONNREFUSED) || noe.Timeout()
+			success = !isConnectionRefused(noe.Err) || noe.Timeout()
 		}
 	}
 	if success && res != nil &&
@@ -1870,6 +1871,18 @@ func (r *Request) sendLoadBalancerFeedback(res *Response, err error) {
 		Success: success,
 		Attempt: r.Attempt,
 	})
+}
+
+const windowsWSAECONNREFUSED syscall.Errno = 10061
+
+func isConnectionRefused(err error) bool {
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return true
+	}
+	if runtime.GOOS == "windows" && errors.Is(err, windowsWSAECONNREFUSED) {
+		return true
+	}
+	return false
 }
 
 func (r *Request) resetFileReaders() error {


### PR DESCRIPTION
## Summary

Treat Windows `WSAECONNREFUSED` (`syscall.Errno(10061)`) the same as `syscall.ECONNREFUSED` when Resty reports request feedback to a load balancer.

## Reproduction

On Windows, a request routed by `WeightedRoundRobin` to a closed backend returns an error chain containing `*os.SyscallError` with `syscall.Errno(10061)`. `errors.Is(err, syscall.ECONNREFUSED)` does not match that errno, so `sendLoadBalancerFeedback` reports the attempt as successful and the backend never reaches `MaxFailures`.

## Root cause

The load-balancer feedback path only recognized `syscall.ECONNREFUSED`. Windows uses Winsock error 10061 (`WSAECONNREFUSED`) for the same condition, so connection-refused failures were ignored on Windows.

## Fix

Add a small `isConnectionRefused` helper that recognizes both the portable `syscall.ECONNREFUSED` value and Windows `WSAECONNREFUSED`, and cover the behavior with `TestLoadBalancerConnectionRefusedMarksHostInactive`.

## Compatibility

No API changes and no new dependencies. Non-Windows behavior remains unchanged.

## Validation

- `go test -run "TestLoadBalancerConnectionRefusedMarksHostInactive|TestLoadBalancerRequestFailures" -count=1` — PASS
- Regression check: `TestLoadBalancerConnectionRefusedMarksHostInactive` fails on the previous implementation on Windows (`Expected [0], got [1]`).
- `go build ./...` — PASS
- `go vet ./...` — PASS
- `gofmt -l .` — empty
- `go test ./...` — attempted 3 times on Windows; this fix removes the prior `TestLoadBalancerRequestFailures` failure, but the full suite still has unrelated/pre-existing Windows issues: `TestTraceInfo/enable_trace_on_invalid_request,_issue_#1016` observes `TotalTime == 0` for an immediate invalid scheme, `TestOutputPathDirNotExists` intermittently fails, and `TestClient_SetRootCertificateWatcher` once hit a Windows file-lock error deleting `root-ca.crt`.