### PR TITLE
ci: pin github actions to commit shas and declare workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ matrix.go }}
           cache: true
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.go == 'stable' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ matrix.go }}
           cache: true
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.go == 'stable' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -8,6 +8,9 @@ on:
       - '**.bazel'
       - 'WORKSPACE'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Hi, drive-by CI hardening in two commits, one logical change each.

**Commit 1 pins the actions to their commit shas**, versions kept as comments. A tag like `@v4` is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's token. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066). All shas were resolved from the upstream repos and cross checked against their release tags. The pins stay maintainable: if you want them bumped automatically, a dependabot config with the `github-actions` ecosystem does it, one small block.

**Commit 2 adds `permissions: contents: read` to both workflows.** The scope is exact, not guessed: the jobs only check out, build, test and upload coverage through the dedicated CODECOV_TOKEN secret, the GitHub token itself is never used.

One heads up: if the org uses an Actions allowlist in settings, patterns written against tags (like `owner/action@v4`) stop matching once refs are shas and workflows refuse to start. Entries need to be `owner/action@*` in that case.

Found with the Plumber CLI (https://github.com/getplumber/plumber), verified on v3. I will also open a PR which adds it to CI so this does not quietly drift back, that one is a bonus, this PR stands on its own.