### PR TITLE
ci: add plumber workflow security check

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -32,3 +32,5 @@ jobs:
           # Gate at 85 points instead of the all-or-nothing default,
           # leaves room for a small finding without blocking PRs.
           min-points: 85
+          # Let's start with report only
+          soft-fail: true

--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,34 @@
+name: Plumber
+
+on:
+  push:
+    branches: [v3]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - uses: getplumber/plumber@7ad9d267ee5a00163cec9e5c749a088d5f565167 # v0.4.26
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 <p align="center"><strong>Simple HTTP, REST, and SSE client library for Go</strong></p>
 
-<p align="center" style="margin-top:3rem"><a href="https://github.com/go-resty/resty/actions/workflows/ci.yml?query=branch%3Av3" target="_blank"><img src="https://github.com/go-resty/resty/actions/workflows/ci.yml/badge.svg?branch=v3" alt="Resty Build Status">
+<p align="center" style="margin-top:3rem"><a href="https://github.com/go-resty/resty/actions/workflows/ci.yml?query=branch%3Av3" target="_blank"><img src="https://github.com/go-resty/resty/actions/workflows/ci.yml/badge.svg?branch=v3" alt="Resty Build Status"></a> <a href="https://score.getplumber.io/github.com/go-resty/resty" target="_blank"><img src="https://score.getplumber.io/github.com/go-resty/resty.svg" alt="Plumber Score">
 </a><a href="https://app.codecov.io/gh/go-resty/resty/tree/v3" target="_blank"><img src="https://codecov.io/gh/go-resty/resty/branch/v3/graph/badge.svg" alt="Resty Code Coverage">
 </a><a href="https://goreportcard.com/report/resty.dev/v3" target="_blank"><img src="https://goreportcard.com/badge/resty.dev/v3" alt="Go Report Card">
 </a><a href="https://pkg.go.dev/resty.dev/v3" target="_blank"><img src="https://pkg.go.dev/badge/resty.dev/v3" alt="Resty GoDoc">

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 </p>
 <p align="center"><strong>Simple HTTP, REST, and SSE client library for Go</strong></p>
 
-<p align="center" style="margin-top:3rem"><a href="https://github.com/go-resty/resty/actions/workflows/ci.yml?query=branch%3Av3" target="_blank"><img src="https://github.com/go-resty/resty/actions/workflows/ci.yml/badge.svg?branch=v3" alt="Resty Build Status"></a> <a href="https://score.getplumber.io/github.com/go-resty/resty" target="_blank"><img src="https://score.getplumber.io/github.com/go-resty/resty.svg" alt="Plumber Score">
-</a><a href="https://app.codecov.io/gh/go-resty/resty/tree/v3" target="_blank"><img src="https://codecov.io/gh/go-resty/resty/branch/v3/graph/badge.svg" alt="Resty Code Coverage">
-</a><a href="https://goreportcard.com/report/resty.dev/v3" target="_blank"><img src="https://goreportcard.com/badge/resty.dev/v3" alt="Go Report Card">
+<p align="center" style="margin-top:3rem"><a href="https://github.com/go-resty/resty/actions/workflows/ci.yml?query=branch%3Av3" target="_blank"><img src="https://github.com/go-resty/resty/actions/workflows/ci.yml/badge.svg?branch=v3" alt="Resty Build Status"></a> <a href="https://app.codecov.io/gh/go-resty/resty/tree/v3" target="_blank"><img src="https://codecov.io/gh/go-resty/resty/branch/v3/graph/badge.svg" alt="Resty Code Coverage">
+</a> <a href="https://score.getplumber.io/github.com/go-resty/resty?branch=v3" target="_blank"><img src="https://score.getplumber.io/github.com/go-resty/resty.svg?branch=v3" alt="Plumber Score">
+</a> <a href="https://goreportcard.com/report/resty.dev/v3" target="_blank"><img src="https://goreportcard.com/badge/resty.dev/v3" alt="Go Report Card">
 </a><a href="https://pkg.go.dev/resty.dev/v3" target="_blank"><img src="https://pkg.go.dev/badge/resty.dev/v3" alt="Resty GoDoc">
 </a><a href="LICENSE"><img src="https://img.shields.io/github/license/go-resty/resty.svg" alt="License"></a> <a href="https://github.com/avelino/awesome-go" target="_blank"><img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Go"></a></p>
 <p align="center" style="margin-bottom:1rem"><a href="https://app.fossa.com/projects/git%2Bgithub.com%2Fgo-resty%2Fresty?ref=badge_shield&amp;issueType=license" alt="FOSSA Status"><img src="https://app.fossa.com/api/projects/git%2Bgithub.com%2Fgo-resty%2Fresty.svg?type=shield&amp;issueType=license"></a>


### PR DESCRIPTION
Companion to https://github.com/go-resty/resty/pull/1193, merge that one first: the check added here flags the unpinned actions and the missing permissions blocks until the hardening lands, then it goes green.

This adds [Plumber](https://github.com/getplumber/plumber) to CI, the tool I used to find those issues in the first place. It scans the workflows on each push to v3 and on each PR, and fails when something regresses: an unpinned action, a job without a permissions block, an archived dependency, a known CVE, that kind of thing.

- `plumber.yml`: pinned by sha, minimal permissions, findings go to the security tab as SARIF (skipped on PRs from forks, the report stays as an artifact there). It runs on the CLI's built-in defaults, no config file to review.
- `README.md`: one badge in your badge row, between build status and coverage.

## Score badge

I enabled `score-push` on the action. It works like OpenSSF Scorecard's published results: every run, on any branch, publishes the score to score.getplumber.io, and that feeds the badge in the README. Scores are public and the badge always shows the state of the default branch. A failed publish never fails your CI. Until the first run the badge reads UNKNOWN in gray, then it flips to the grade. If you would rather not have it, drop the README badge and the `score-push` input, the rest works the same.

With the hardening in, this runs green with a score of A. Set `soft-fail: true` if you prefer report only, without gating PRs.

To be fully transparent: I work on Plumber. If you do not want the tool in your CI, no hard feelings, the hardening PR is the one that matters and it stands on its own.