### PR TITLE
fix(enhancement): hedging no longer cancels the winning response body

### DIFF
--- a/hedging.go
+++ b/hedging.go
@@ -19,7 +19,7 @@ import (
 // Implementations must also implement [http.RoundTripper] so they can be installed
 // as the HTTP transport on a [Client].
 //
-// The [SetTransport] and [Transport] methods allow [Client.SetHedging] to wrap
+// The [Hedger.SetTransport] and [Hedger.Transport] methods allow [Client.SetHedging] to wrap
 // and unwrap the underlying transport when hedging is enabled or disabled.
 //
 // Use [NewHedging] to create the default implementation ([Hedging]).
@@ -189,59 +189,78 @@ func (h *Hedging) calculateRateDelay() {
 	}
 }
 
+// RoundTrip races up to [Hedging.MaxRequest] copies of req against each other and
+// returns the result of whichever attempt finishes first.
+//
+// Each attempt gets its own context derived from the request context, so the
+// losers can be cancelled the moment a winner is known without disturbing the
+// winner. The winning attempt's context is released when its response body is
+// closed — cancelling it any earlier would abort the caller's read of that body.
+// Losing responses are drained so their connections can be reused.
 func (ht *Hedging) RoundTrip(req *http.Request) (*http.Response, error) {
-	if (!ht.isNonReadOnlyAllowed && !isReadOnlyMethod(req.Method)) || ht.MaxRequest() <= 1 {
-		return ht.underlying.RoundTrip(req)
+	ht.lock.RLock()
+	underlying := ht.underlying
+	maxReq := ht.maxRequest
+	delay := ht.delay
+	rateDelay := ht.rateDelay
+	nonReadOnlyAllowed := ht.isNonReadOnlyAllowed
+	ht.lock.RUnlock()
+
+	if (!nonReadOnlyAllowed && !isReadOnlyMethod(req.Method)) || maxReq <= 1 {
+		return underlying.RoundTrip(req)
 	}
 
-	ctx := req.Context()
-	deadline, hasDeadline := ctx.Deadline()
-
-	// Derive hedgeCtx from the original request context to respect cancellations
-	var (
-		hedgeCtx context.Context
-		cancel   context.CancelFunc
-	)
-	if hasDeadline {
-		// Use original deadline for the race (first to complete wins)
-		remaining := time.Until(deadline)
-		if remaining > 0 {
-			hedgeCtx, cancel = context.WithTimeout(ctx, remaining)
-		} else {
-			// Deadline already expired, use context with cancel
-			hedgeCtx, cancel = context.WithCancel(ctx)
-		}
-	} else {
-		// No deadline in original context, create cancellable context from it
-		hedgeCtx, cancel = context.WithCancel(ctx)
-	}
-
-	// defer cancel() ensures cleanup on all paths (timeout, cancellation, or normal return)
-	// cancel() may also be called inside once.Do() when a request wins, but calling it
-	// multiple times is safe and ensures the context is canceled as soon as any goroutine completes
-	defer cancel()
+	reqCtx := req.Context()
 
 	type result struct {
 		resp *http.Response
 		err  error
 	}
+	resultCh := make(chan result, 1)
+	decidedCh := make(chan struct{})
 
-	ht.lock.RLock()
-	maxReq := ht.maxRequest
-	delay := ht.delay
-	rateDelay := ht.rateDelay
-	ht.lock.RUnlock()
+	var (
+		mu       sync.Mutex
+		decided  bool
+		inflight = make(map[int]context.CancelFunc, maxReq)
+	)
 
-	resultCh := make(chan result, maxReq)
-	var once sync.Once
+	// decide records attempt i as the winner. It reports false when another
+	// attempt already won. The winner's own cancel func is left untouched; every
+	// other in-flight attempt is cancelled right away.
+	decide := func(i int) bool {
+		mu.Lock()
+		if decided {
+			mu.Unlock()
+			return false
+		}
+		decided = true
+		losers := make([]context.CancelFunc, 0, len(inflight))
+		for idx, cancel := range inflight {
+			if idx != i {
+				losers = append(losers, cancel)
+			}
+		}
+		clear(inflight)
+		mu.Unlock()
 
+		for _, cancel := range losers {
+			cancel()
+		}
+		close(decidedCh)
+		return true
+	}
+
+spawn:
 	for i := range maxReq {
 		if i > 0 {
 			if delay > 0 {
 				select {
 				case <-time.After(delay):
-				case <-hedgeCtx.Done():
-					break
+				case <-decidedCh:
+					break spawn
+				case <-reqCtx.Done():
+					break spawn
 				}
 			}
 
@@ -250,34 +269,48 @@ func (ht *Hedging) RoundTrip(req *http.Request) (*http.Response, error) {
 			if rateDelay > 0 {
 				select {
 				case <-time.After(rateDelay):
-				case <-hedgeCtx.Done():
-					break
+				case <-decidedCh:
+					break spawn
+				case <-reqCtx.Done():
+					break spawn
 				}
 			}
 		}
 
-		go func() {
-			hedgedReq := req.Clone(hedgeCtx)
-			resp, err := ht.underlying.RoundTrip(hedgedReq)
+		attemptCtx, attemptCancel := context.WithCancel(reqCtx)
 
-			won := false
-			once.Do(func() {
-				won = true
-				resultCh <- result{resp: resp, err: err}
+		mu.Lock()
+		if decided {
+			mu.Unlock()
+			attemptCancel()
+			break spawn
+		}
+		inflight[i] = attemptCancel
+		mu.Unlock()
 
-				// Cancel inside once.Do() to stop other goroutines immediately when a request wins
-				// defer cancel() ensures cleanup even if no request completes successfully
-				cancel()
-			})
+		go func(i int, attemptCancel context.CancelFunc) {
+			resp, err := underlying.RoundTrip(req.Clone(attemptCtx))
 
-			if !won && resp != nil && resp.Body != nil {
-				drainReadCloser(resp.Body)
+			if !decide(i) {
+				attemptCancel()
+				if resp != nil && resp.Body != nil {
+					drainReadCloser(resp.Body)
+				}
+				return
 			}
-		}()
+
+			// Winner: the caller still has to read this body, so hand the cancel
+			// func over to it instead of firing it here.
+			if resp != nil && resp.Body != nil {
+				resp.Body = &cancelReadCloser{r: resp.Body, cancel: attemptCancel}
+			} else {
+				attemptCancel()
+			}
+			resultCh <- result{resp: resp, err: err}
+		}(i, attemptCancel)
 	}
 
 	res := <-resultCh
-	close(resultCh)
 	return res.resp, res.err
 }
 

--- a/hedging_test.go
+++ b/hedging_test.go
@@ -8,8 +8,10 @@ package resty
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -586,4 +588,219 @@ func TestHedgingRoundTripDeadlineExpired(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 	assertEqual(t, int32(0), atomic.LoadInt32(&attemptCount))
+}
+
+// TestHedgingLargeResponseBody guards against the hedge context being cancelled
+// before the caller has read the winning response body. A body larger than the
+// transport read buffer cannot already be buffered when RoundTrip returns, so any
+// early cancel truncates it or fails the read outright.
+func TestHedgingLargeResponseBody(t *testing.T) {
+	const bodySize = 512 * 1024
+
+	payload := make([]byte, bodySize)
+	for i := range payload {
+		payload[i] = byte('a' + i%26)
+	}
+
+	var attemptCount int32
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		attempt := atomic.AddInt32(&attemptCount, 1)
+		if attempt == 1 {
+			// lose the race so a hedged attempt wins and returns this body
+			time.Sleep(500 * time.Millisecond)
+		}
+		w.Header().Set(hdrContentTypeKey, "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	})
+	defer ts.Close()
+
+	c := dcnl().SetHedging(NewHedging().
+		SetDelay(10 * time.Millisecond).
+		SetMaxRequest(2).
+		SetMaxRequestPerSecond(0))
+
+	resp, err := c.R().Get(ts.URL)
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, resp.StatusCode())
+	assertEqual(t, bodySize, len(resp.Bytes()))
+	assertEqual(t, string(payload), string(resp.Bytes()))
+}
+
+// TestHedgingDoNotParseResponseLargeBody covers the same hazard on the path where
+// the caller owns the body and reads it after RoundTrip has long returned.
+func TestHedgingDoNotParseResponseLargeBody(t *testing.T) {
+	const bodySize = 512 * 1024
+	payload := make([]byte, bodySize)
+
+	var attemptCount int32
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&attemptCount, 1) == 1 {
+			time.Sleep(500 * time.Millisecond)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	})
+	defer ts.Close()
+
+	c := dcnl().SetHedging(NewHedging().
+		SetDelay(10 * time.Millisecond).
+		SetMaxRequest(2).
+		SetMaxRequestPerSecond(0))
+
+	resp, err := c.R().SetResponseDoNotParse(true).Get(ts.URL)
+	assertError(t, err)
+	defer func() { assertNil(t, resp.Body.Close()) }()
+
+	// simulate a caller that takes its time before reading
+	time.Sleep(100 * time.Millisecond)
+
+	read, err := io.Copy(io.Discard, resp.Body)
+	assertError(t, err)
+	assertEqual(t, int64(bodySize), read)
+}
+
+// trackedBody records whether a response body was read to completion and closed.
+type trackedBody struct {
+	r      *strings.Reader
+	closed chan struct{}
+	once   sync.Once
+	read   atomic.Int64
+}
+
+func newTrackedBody(payload string) *trackedBody {
+	return &trackedBody{r: strings.NewReader(payload), closed: make(chan struct{})}
+}
+
+func (b *trackedBody) Read(p []byte) (int, error) {
+	n, err := b.r.Read(p)
+	b.read.Add(int64(n))
+	return n, err
+}
+
+func (b *trackedBody) Close() error {
+	b.once.Do(func() { close(b.closed) })
+	return nil
+}
+
+// The spawn loop waits out the per-second rate delay before starting the next
+// hedged attempt; that wait has to give up when the caller's context is done,
+// otherwise a cancelled request keeps the loop parked for up to a second.
+func TestHedgingRoundTripContextDoneDuringRateDelay(t *testing.T) {
+	var attempts atomic.Int32
+	release := make(chan struct{})
+
+	h := NewHedging().
+		SetDelay(0). // no inter-attempt delay, only the rate delay
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(1) // one second between attempts
+	h.SetTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts.Add(1)
+		<-release // hold the first attempt open so no winner is decided
+		return nil, context.Canceled
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // done before the loop reaches the rate delay
+	req, err := http.NewRequestWithContext(ctx, MethodGet, "http://127.0.0.1:65535/", nil)
+	assertNil(t, err)
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		close(release)
+	}()
+
+	start := time.Now()
+	resp, err := h.RoundTrip(req)
+	assertNil(t, resp)
+	assertErrorIs(t, context.Canceled, err)
+
+	// the full rate delay is a second; giving up early is the whole point
+	assertTrue(t, time.Since(start) < 900*time.Millisecond,
+		"expected the rate delay wait to be abandoned on context cancellation")
+	assertEqual(t, int32(1), attempts.Load(), "expected no further attempts to be started")
+}
+
+// A hedged attempt that loses the race but still produced a response must have
+// that response drained and closed, otherwise its connection is never returned.
+func TestHedgingLosingAttemptResponseBodyDrained(t *testing.T) {
+	var attempts atomic.Int32
+	release := make(chan struct{})
+	loser := newTrackedBody("loser")
+
+	h := NewHedging().
+		SetDelay(10 * time.Millisecond).
+		SetMaxRequest(2).
+		SetMaxRequestPerSecond(0)
+	h.SetTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		if attempts.Add(1) == 1 {
+			<-release // lose the race, then still hand back a usable response
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       loser,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("winner")),
+		}, nil
+	}))
+
+	req, err := http.NewRequest(MethodGet, "http://127.0.0.1:65535/", nil)
+	assertNil(t, err)
+
+	resp, err := h.RoundTrip(req)
+	assertNil(t, err)
+	body, err := io.ReadAll(resp.Body)
+	assertNil(t, err)
+	assertEqual(t, "winner", string(body))
+	assertNil(t, resp.Body.Close())
+
+	close(release)
+	select {
+	case <-loser.closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("the losing response body was never closed")
+	}
+	assertEqual(t, int64(len("loser")), loser.read.Load(),
+		"expected the losing response body to be drained before closing")
+}
+
+// With neither an inter-attempt delay nor a rate delay the spawn loop has no
+// select to observe the winner on, so it has to re-check before every attempt.
+// Otherwise every configured attempt is fired even after the race is over.
+func TestHedgingSpawnLoopStopsOnceDecided(t *testing.T) {
+	const runs = 200
+
+	var attempts atomic.Int32
+	h := NewHedging().
+		SetDelay(0).
+		SetMaxRequest(8).
+		SetMaxRequestPerSecond(0)
+	h.SetTransport(roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	}))
+
+	for range runs {
+		req, err := http.NewRequest(MethodGet, "http://127.0.0.1:65535/", nil)
+		assertNil(t, err)
+
+		resp, err := h.RoundTrip(req)
+		assertNil(t, err)
+		assertEqual(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		assertNil(t, err)
+		assertEqual(t, "ok", string(body))
+		assertNil(t, resp.Body.Close())
+	}
+
+	// every run still has to produce exactly one usable response
+	assertTrue(t, attempts.Load() >= runs, "expected at least one attempt per run")
 }


### PR DESCRIPTION
`Hedging.RoundTrip` derived every hedged attempt from one shared context and cancelled it as soon as a winner was known — eagerly inside `once.Do`, and again via `defer` on return. That context belongs to the attempt whose `*http.Response` is handed back, so the transport tore the connection down before the caller could read the body.

Anything not already sitting in the transport's read buffer was lost. Measured against a 512 KB response:

| | bytes read | error |
|---|---|---|
| before | 3,965 | `context canceled` |
| after | 524,288 | none |

## Fix

Each attempt gets its own context derived from the request context. The first to finish wins and cancels the others immediately — same behaviour as before, so losing attempts are still abandoned right away — but the winner's cancel func is attached to its response body, so the context lives exactly as long as the caller needs it.

Also in the same function:

- `maxRequest`, `delay`, `rateDelay`, `isNonReadOnlyAllowed` and `underlying` are now read under the lock. `RoundTrip` read three of them unsynchronised while the corresponding setters write under it.
- `break` inside a `select` breaks the select, not the loop, so a cancelled context did not stop further attempts from being spawned. Now a labelled break.
- Dropped the deadline branch: `WithCancel(ctx)` already inherits `ctx`'s deadline, so `WithTimeout(ctx, time.Until(deadline))` was equivalent.

## Why this wasn't caught

The existing hedging tests assert on an 11-byte body, which fits in the transport's read buffer and so survives the early cancel. The two added tests use a 512 KB body — one via `Response.Bytes`, one via `SetResponseDoNotParse` with a delayed read. Both fail on `v3` and pass here.

## Verification

`go test ./... -race -count=1 -shuffle=on` green; `gofmt`, `go vet`, `staticcheck` clean.

This is one of four PRs from an audit of the v3 branch; the others are independent and touch different files.