### PR TITLE
fix(enhancement): load balancer data race, duplicate state-change hooks, ticker goroutine leak

### DIFF
--- a/load_balancer.go
+++ b/load_balancer.go
@@ -157,13 +157,17 @@ func NewWeightedRoundRobin(recovery time.Duration, hosts ...*Host) (*WeightedRou
 		hosts:    make([]*Host, 0),
 		tick:     time.NewTicker(recovery),
 		recovery: recovery,
+		done:     make(chan struct{}),
 	}
 
-	err := wrr.Refresh(hosts...)
+	if err := wrr.Refresh(hosts...); err != nil {
+		wrr.tick.Stop()
+		return wrr, err
+	}
 
 	go wrr.ticker()
 
-	return wrr, err
+	return wrr, nil
 }
 
 var _ LoadBalancer = (*WeightedRoundRobin)(nil)
@@ -173,9 +177,14 @@ var _ LoadBalancer = (*WeightedRoundRobin)(nil)
 type WeightedRoundRobin struct {
 	lock          *sync.RWMutex
 	hosts         []*Host
-	totalWeight   int
 	tick          *time.Ticker
 	onStateChange HostStateChangeFunc
+
+	// done is closed by Close to stop the recovery ticker goroutine.
+	// Ticker.Stop does not close its channel, so the goroutine needs
+	// a separate shutdown signal.
+	done      chan struct{}
+	closeOnce sync.Once
 
 	// Recovery duration is used to set the timer to put
 	// the host back in the pool for the next turn and
@@ -226,27 +235,37 @@ func (wrr *WeightedRoundRobin) Feedback(f *RequestFeedback) {
 	}
 
 	wrr.lock.Lock()
-	defer wrr.lock.Unlock()
-
+	deactivated := ""
+	onStateChange := wrr.onStateChange
 	for _, host := range wrr.hosts {
-		if host.BaseURL == f.BaseURL {
-			if !f.Success {
-				host.failedRequests++
-			}
-			if host.failedRequests >= host.MaxFailures {
-				host.state = HostStateInActive
-				if wrr.onStateChange != nil {
-					wrr.onStateChange(host.BaseURL, HostStateActive, HostStateInActive)
-				}
-			}
-			break
+		if host.BaseURL != f.BaseURL {
+			continue
 		}
+		if !f.Success {
+			host.failedRequests++
+		}
+		// Report the transition only on the crossing from active to inactive.
+		// Feedback for a host that is already inactive (in-flight requests that
+		// were dispatched before it was taken out) must not re-fire the hook.
+		if host.state == HostStateActive && host.failedRequests >= host.MaxFailures {
+			host.state = HostStateInActive
+			deactivated = host.BaseURL
+		}
+		break
+	}
+	wrr.lock.Unlock()
+
+	if onStateChange != nil && deactivated != "" {
+		onStateChange(deactivated, HostStateActive, HostStateInActive)
 	}
 }
 
 // Close stops the internal recovery ticker used by the Weighted Round-Robin (WRR)
-// load balancer.
+// load balancer. It is safe to call Close more than once.
 func (wrr *WeightedRoundRobin) Close() error {
+	wrr.closeOnce.Do(func() {
+		close(wrr.done)
+	})
 	wrr.lock.Lock()
 	defer wrr.lock.Unlock()
 	wrr.tick.Stop()
@@ -254,33 +273,46 @@ func (wrr *WeightedRoundRobin) Close() error {
 }
 
 // Refresh method replaces the existing host list with the given [Host] slice.
+//
+// The [Host] values are copied, so the balancer does not observe later changes
+// the caller makes to them and the caller does not observe the balancer's
+// internal bookkeeping.
 func (wrr *WeightedRoundRobin) Refresh(hosts ...*Host) error {
 	if hosts == nil {
 		return nil
 	}
 
-	wrr.lock.Lock()
-	defer wrr.lock.Unlock()
-	newTotalWeight := 0
+	updated := make([]*Host, 0, len(hosts))
 	for _, h := range hosts {
 		baseURL, err := extractBaseURL(h.BaseURL)
 		if err != nil {
 			return err
 		}
 
-		h.BaseURL = baseURL
-		h.state = HostStateActive
-		newTotalWeight += h.Weight
+		hc := new(Host)
+		*hc = *h
+		hc.BaseURL = baseURL
+		hc.state = HostStateActive
+		hc.currentWeight = 0
+		hc.failedRequests = 0
 
 		// assign defaults if not provided
-		if h.MaxFailures == 0 {
-			h.MaxFailures = 5 // default value is 5
+		if hc.MaxFailures == 0 {
+			hc.MaxFailures = 5 // default value is 5
 		}
+		if hc.Weight <= 0 {
+			// A non-positive weight never raises currentWeight, so such a host
+			// would only ever be picked as the fallback first entry.
+			hc.Weight = 1
+		}
+
+		updated = append(updated, hc)
 	}
 
 	// after processing, assign the updates
-	wrr.hosts = hosts
-	wrr.totalWeight = newTotalWeight
+	wrr.lock.Lock()
+	defer wrr.lock.Unlock()
+	wrr.hosts = updated
 	return nil
 }
 
@@ -300,22 +332,38 @@ func (wrr *WeightedRoundRobin) SetRecoveryDuration(d time.Duration) {
 }
 
 func (wrr *WeightedRoundRobin) ticker() {
-	for range wrr.tick.C {
-		wrr.lock.Lock()
-		hosts := make([]*Host, len(wrr.hosts))
-		copy(hosts, wrr.hosts)
-		wrr.lock.Unlock()
-
-		for _, host := range hosts {
-			if host.state == HostStateInActive {
-				host.state = HostStateActive
-				host.failedRequests = 0
-
-				if wrr.onStateChange != nil {
-					wrr.onStateChange(host.BaseURL, HostStateInActive, HostStateActive)
-				}
-			}
+	for {
+		select {
+		case <-wrr.done:
+			return
+		case <-wrr.tick.C:
+			wrr.recoverHosts()
 		}
+	}
+}
+
+// recoverHosts returns inactive hosts to the pool and resets their failure
+// counters. The [Host] values are shared with NextWithContext and Feedback, so
+// they are mutated under the write lock; the state change hooks run after the
+// lock is released so a hook is free to call back into the balancer.
+func (wrr *WeightedRoundRobin) recoverHosts() {
+	wrr.lock.Lock()
+	recovered := make([]string, 0, len(wrr.hosts))
+	for _, host := range wrr.hosts {
+		if host.state == HostStateInActive {
+			host.state = HostStateActive
+			host.failedRequests = 0
+			recovered = append(recovered, host.BaseURL)
+		}
+	}
+	onStateChange := wrr.onStateChange
+	wrr.lock.Unlock()
+
+	if onStateChange == nil {
+		return
+	}
+	for _, baseURL := range recovered {
+		onStateChange(baseURL, HostStateInActive, HostStateActive)
 	}
 }
 
@@ -329,6 +377,17 @@ func NewSRVWeightedRoundRobin(service, proto, domainName, httpScheme string) (*S
 		httpScheme = "https"
 	}
 
+	return newSRVWeightedRoundRobin(service, proto, domainName, httpScheme,
+		func() ([]*net.SRV, error) {
+			_, addrs, err := net.LookupSRV(service, proto, domainName)
+			return addrs, err
+		})
+}
+
+// newSRVWeightedRoundRobin builds the balancer around the given SRV resolver so
+// it can be replaced in tests.
+func newSRVWeightedRoundRobin(service, proto, domainName, httpScheme string,
+	lookupSRV func() ([]*net.SRV, error)) (*SRVWeightedRoundRobin, error) {
 	wrr, _ := NewWeightedRoundRobin(0) // with this input error will not occur
 	swrr := &SRVWeightedRoundRobin{
 		Service:    service,
@@ -338,17 +397,20 @@ func NewSRVWeightedRoundRobin(service, proto, domainName, httpScheme string) (*S
 		wrr:        wrr,
 		tick:       time.NewTicker(180 * time.Second), // default is 180 seconds
 		lock:       new(sync.Mutex),
-		lookupSRV: func() ([]*net.SRV, error) {
-			_, addrs, err := net.LookupSRV(service, proto, domainName)
-			return addrs, err
-		},
+		done:       make(chan struct{}),
+		log:        createLogger(),
+		lookupSRV:  lookupSRV,
 	}
 
-	err := swrr.Refresh()
+	if err := swrr.Refresh(); err != nil {
+		swrr.tick.Stop()
+		silently(swrr.wrr.Close())
+		return swrr, err
+	}
 
 	go swrr.ticker()
 
-	return swrr, err
+	return swrr, nil
 }
 
 var _ LoadBalancer = (*SRVWeightedRoundRobin)(nil)
@@ -365,6 +427,12 @@ type SRVWeightedRoundRobin struct {
 	tick      *time.Ticker
 	lock      *sync.Mutex
 	lookupSRV func() ([]*net.SRV, error)
+	log       Logger
+
+	// done is closed by Close to stop the SRV refresh goroutine; see the same
+	// field on [WeightedRoundRobin].
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 // NextWithContext returns the next SRV-derived base URL using the underlying
@@ -379,10 +447,14 @@ func (swrr *SRVWeightedRoundRobin) Feedback(f *RequestFeedback) {
 }
 
 // Close stops the SRV refresh ticker and closes the underlying WRR load balancer.
+// It is safe to call Close more than once.
 func (swrr *SRVWeightedRoundRobin) Close() error {
+	swrr.closeOnce.Do(func() {
+		close(swrr.done)
+	})
 	swrr.lock.Lock()
 	defer swrr.lock.Unlock()
-	swrr.wrr.Close()
+	silently(swrr.wrr.Close())
 	swrr.tick.Stop()
 	return nil
 }
@@ -424,8 +496,17 @@ func (swrr *SRVWeightedRoundRobin) SetRecoveryDuration(d time.Duration) {
 }
 
 func (swrr *SRVWeightedRoundRobin) ticker() {
-	for range swrr.tick.C {
-		swrr.Refresh()
+	for {
+		select {
+		case <-swrr.done:
+			return
+		case <-swrr.tick.C:
+			// A failed periodic refresh keeps the previous host list; surface it
+			// rather than dropping it, otherwise a broken SRV record is silent.
+			if err := swrr.Refresh(); err != nil {
+				swrr.log.Errorf("resty: SRV load balancer refresh: %v", err)
+			}
+		}
 	}
 }
 

--- a/load_balancer_test.go
+++ b/load_balancer_test.go
@@ -6,11 +6,15 @@
 package resty
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
+	"runtime"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -624,4 +628,228 @@ func TestLoadBalancerCoverage(t *testing.T) {
 			StatusCode: http.StatusInternalServerError,
 		}}, nil)
 	})
+}
+
+// Ticker.Stop does not close its channel, so the recovery goroutines needed a
+// separate shutdown signal.
+func TestLoadBalancerCloseStopsTickerGoroutines(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	for range 20 {
+		wrr, err := NewWeightedRoundRobin(10*time.Millisecond,
+			&Host{BaseURL: "https://example1.com", Weight: 1},
+			&Host{BaseURL: "https://example2.com", Weight: 1},
+		)
+		assertNil(t, err)
+		assertNil(t, wrr.Close())
+		assertNil(t, wrr.Close()) // Close is idempotent
+	}
+
+	// give the goroutines a moment to observe the closed done channel
+	deadline := time.Now().Add(2 * time.Second)
+	for runtime.NumGoroutine() > before+2 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	assertTrue(t, runtime.NumGoroutine() <= before+2,
+		"recovery goroutines did not exit after Close")
+}
+
+// Feedback must report the active -> inactive transition once, not on every
+// report that arrives while the host is already out of the pool.
+func TestWeightedRoundRobinStateChangeFiresOnce(t *testing.T) {
+	wrr, err := NewWeightedRoundRobin(time.Hour,
+		&Host{BaseURL: "https://example1.com", Weight: 1, MaxFailures: 2},
+	)
+	assertNil(t, err)
+	defer func() { assertNil(t, wrr.Close()) }()
+
+	var changes int32
+	wrr.SetOnStateChange(func(_ string, from, to HostState) {
+		atomic.AddInt32(&changes, 1)
+		assertEqual(t, HostStateActive, from)
+		assertEqual(t, HostStateInActive, to)
+	})
+
+	for range 5 {
+		wrr.Feedback(&RequestFeedback{BaseURL: "https://example1.com", Success: false, Attempt: 1})
+	}
+	assertEqual(t, int32(1), atomic.LoadInt32(&changes))
+}
+
+// Refresh must not hand the balancer's bookkeeping back to the caller, nor read
+// the caller's later edits.
+func TestWeightedRoundRobinRefreshCopiesHosts(t *testing.T) {
+	h := &Host{BaseURL: "https://example.com/some/path", Weight: 1}
+	wrr, err := NewWeightedRoundRobin(time.Hour, h)
+	assertNil(t, err)
+	defer func() { assertNil(t, wrr.Close()) }()
+
+	// the caller's value is untouched
+	assertEqual(t, "https://example.com/some/path", h.BaseURL)
+
+	// and mutating it afterwards does not reach the balancer
+	h.BaseURL = "https://elsewhere.example"
+	got, err := wrr.NextWithContext(context.Background())
+	assertNil(t, err)
+	assertEqual(t, "https://example.com", got)
+}
+
+// A zero SRV weight never raises currentWeight, which left WRR always returning
+// the first host.
+func TestWeightedRoundRobinZeroWeightRotates(t *testing.T) {
+	wrr, err := NewWeightedRoundRobin(time.Hour,
+		&Host{BaseURL: "https://example1.com"},
+		&Host{BaseURL: "https://example2.com"},
+	)
+	assertNil(t, err)
+	defer func() { assertNil(t, wrr.Close()) }()
+
+	seen := make(map[string]int)
+	for range 4 {
+		got, err := wrr.NextWithContext(context.Background())
+		assertNil(t, err)
+		seen[got]++
+	}
+	assertEqual(t, 2, len(seen))
+}
+
+// The recovery ticker puts inactive hosts back into rotation, resets their
+// failure counters and reports the transition once the lock has been released,
+// so a hook is free to call back into the balancer.
+func TestWeightedRoundRobinHostRecovery(t *testing.T) {
+	const host1, host2 = "https://example1.com", "https://example2.com"
+
+	wrr, err := NewWeightedRoundRobin(50*time.Millisecond,
+		&Host{BaseURL: host1, Weight: 10, MaxFailures: 1},
+		&Host{BaseURL: host2, Weight: 10, MaxFailures: 1},
+	)
+	assertNil(t, err)
+	defer func() { assertNil(t, wrr.Close()) }()
+
+	recovered := make(chan string, 4)
+	wrr.SetOnStateChange(func(baseURL string, from, to HostState) {
+		if from == HostStateInActive && to == HostStateActive {
+			// calling back in has to be safe: the hook runs without the lock held
+			_, _ = wrr.NextWithContext(context.Background())
+			recovered <- baseURL
+		}
+	})
+
+	wrr.Feedback(&RequestFeedback{BaseURL: host1, Success: false})
+
+	// only the healthy host is handed out while the other one is out of the pool
+	for range 3 {
+		baseURL, err := wrr.NextWithContext(context.Background())
+		assertNil(t, err)
+		assertEqual(t, host2, baseURL)
+	}
+
+	select {
+	case baseURL := <-recovered:
+		assertEqual(t, host1, baseURL)
+	case <-time.After(5 * time.Second):
+		t.Fatal("the inactive host was never returned to the pool")
+	}
+
+	wrr.lock.RLock()
+	defer wrr.lock.RUnlock()
+	for _, h := range wrr.hosts {
+		assertEqual(t, HostStateActive, h.state, "expected every host to be active again")
+		assertEqual(t, 0, h.failedRequests, "expected the failure count to be reset")
+	}
+}
+
+// Recovery must still work when no state change hook is registered.
+func TestWeightedRoundRobinHostRecoveryWithoutHook(t *testing.T) {
+	const host1 = "https://example1.com"
+
+	wrr, err := NewWeightedRoundRobin(50*time.Millisecond,
+		&Host{BaseURL: host1, Weight: 10, MaxFailures: 1},
+	)
+	assertNil(t, err)
+	defer func() { assertNil(t, wrr.Close()) }()
+
+	wrr.Feedback(&RequestFeedback{BaseURL: host1, Success: false})
+	_, err = wrr.NextWithContext(context.Background())
+	assertErrorIs(t, ErrNoActiveHost, err)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		baseURL, err := wrr.NextWithContext(context.Background())
+		if err == nil {
+			assertEqual(t, host1, baseURL)
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the inactive host was never returned to the pool")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// The SRV refresh goroutine keeps running across a failed lookup, logs it rather
+// than dropping it, and stops when Close is called.
+func TestSRVWeightedRoundRobinTickerRefresh(t *testing.T) {
+	srv, err := NewSRVWeightedRoundRobin("_sample-server", "", "example.com", "")
+	assertNotNil(t, err) // example.com has no such SRV record, so no ticker was started
+	assertNotNil(t, srv)
+
+	var logBuf bytes.Buffer
+	srv.log = &logger{l: log.New(&logBuf, "", 0)}
+
+	var lookups atomic.Int32
+	errLookup := errors.New("srv lookup failed")
+	srv.lookupSRV = func() ([]*net.SRV, error) {
+		if lookups.Add(1) == 1 {
+			return nil, errLookup // the first refresh fails
+		}
+		return []*net.SRV{
+			{Target: "service1.example.com.", Port: 443, Priority: 10, Weight: 50},
+		}, nil
+	}
+
+	srv.SetRefreshDuration(20 * time.Millisecond)
+	go srv.ticker()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for lookups.Load() < 2 {
+		if time.Now().After(deadline) {
+			t.Fatal("the SRV refresh ticker did not run")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	assertTrue(t, strings.Contains(logBuf.String(), errLookup.Error()),
+		"expected the failed refresh to be logged, got: "+logBuf.String())
+
+	baseURL, err := srv.NextWithContext(context.Background())
+	assertNil(t, err)
+	assertEqual(t, "https://service1.example.com:443", baseURL)
+
+	assertNil(t, srv.Close())
+	assertNil(t, srv.Close()) // Close is documented to be idempotent
+
+	// the goroutine is gone, so no further lookups happen
+	settled := lookups.Load()
+	time.Sleep(100 * time.Millisecond)
+	assertEqual(t, settled, lookups.Load(), "expected the refresh goroutine to have stopped")
+}
+
+// The successful construction path starts the SRV refresh goroutine, which Close
+// then has to shut down.
+func TestSRVWeightedRoundRobinResolvedAtConstruction(t *testing.T) {
+	srv, err := newSRVWeightedRoundRobin("_sample-server", "tcp", "example.com", "https",
+		func() ([]*net.SRV, error) {
+			return []*net.SRV{
+				{Target: "service1.example.com.", Port: 8443, Priority: 10, Weight: 50},
+			}, nil
+		})
+	assertNil(t, err)
+	assertNotNil(t, srv)
+
+	baseURL, err := srv.NextWithContext(context.Background())
+	assertNil(t, err)
+	assertEqual(t, "https://service1.example.com:8443", baseURL)
+
+	assertNil(t, srv.Close())
 }


### PR DESCRIPTION
Three defects in `WeightedRoundRobin` / `SRVWeightedRoundRobin`.

## 1. Goroutine leak on Close

`Close` calls `tick.Stop()`, but `Ticker.Stop` does not close the channel, so `for range wrr.tick.C` never returns. **Every load balancer created leaks one goroutine for the life of the process.** Both types now select on a `done` channel that `Close` closes; `Close` is idempotent.

## 2. Data race in the recovery ticker

`ticker()` copied the `[]*Host` slice under the lock, then mutated `host.state` and `host.failedRequests` — values shared with `Feedback` and `NextWithContext` — outside it, and read `wrr.onStateChange` unlocked. Recovery now happens under the write lock, in `recoverHosts`.

## 3. Duplicate state-change hooks

`Feedback` fired `onStateChange(baseURL, Active, InActive)` on **every** call once `failedRequests >= MaxFailures`, including for a host that was already inactive. In-flight requests dispatched before a host was taken out therefore each re-reported the transition, with a `from` state that was already wrong. The hook now fires only on the crossing from active to inactive.

State-change hooks are invoked after the lock is released, so a hook may call back into the balancer without deadlocking.

## Adjacent fixes in the same functions

- `Refresh` took the caller's `*Host` values into the balancer and mutated them in place (rewriting `BaseURL`, resetting `state`, filling `MaxFailures`). It now copies.
- A `Host` with `Weight <= 0` never raises `currentWeight`, so it could only ever be picked as the fallback first entry. Reachable from SRV records, which commonly carry weight 0 — such a setup silently pinned all traffic to one host. Defaults to 1.
- The periodic SRV refresh discarded its error, so a broken SRV record was silent. Now logged.
- Constructors started the ticker goroutine even when `Refresh` failed.
- Removed `wrr.totalWeight`, computed in `Refresh` and never read.

## Verification

Four added tests, all failing on `v3`: goroutine count settles after `Close`; the hook fires exactly once across 5 failure reports; `Refresh` neither mutates nor observes the caller's `Host`; zero-weight hosts rotate.

`go test ./... -race -count=1 -shuffle=on` green; `gofmt`, `go vet`, `staticcheck` clean.

One of four independent PRs from an audit of the v3 branch.