### PR TITLE
fix: SSE connect deadlock from a recursive read lock, plus a leaked response body

### DIFF
--- a/sse.go
+++ b/sse.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -138,6 +139,8 @@ func NewSSESource() *SSESource {
 //
 //	sse.SetURL("https://example.com/events")
 func (sse *SSESource) SetURL(url string) *SSESource {
+	sse.lock.Lock()
+	defer sse.lock.Unlock()
 	sse.url = url
 	return sse
 }
@@ -146,6 +149,8 @@ func (sse *SSESource) SetURL(url string) *SSESource {
 //
 //	sse.SetMethod("POST"), or sse.SetMethod(resty.MethodPost)
 func (sse *SSESource) SetMethod(method string) *SSESource {
+	sse.lock.Lock()
+	defer sse.lock.Unlock()
 	sse.method = method
 	return sse
 }
@@ -522,9 +527,23 @@ func (sse *SSESource) AddEventListener(eventName string, ef SSEMessageFunc, resu
 //
 //	err := sse.Get()
 //	fmt.Println(err)
+//
+// Get blocks until the stream ends, the context is done, or [SSESource.Close] is
+// called.
+//
+// NOTE: Get does not reconnect. The retry settings ([SSESource.SetRetryCount],
+// [SSESource.SetRetryWaitTime], [SSESource.SetRetryMaxWaitTime]) apply only while
+// establishing the initial connection. Once connected, a stream that ends returns
+// [io.EOF] to the caller; call Get again to reconnect. Resty tracks the last event
+// ID and any server-sent `retry:` value, and sends `Last-Event-ID` on the next
+// connect, so calling Get again resumes where the stream left off.
+//
+// Get returns nil only when [SSESource.Close] was called.
 func (sse *SSESource) Get() error {
-	// Validate required values
+	// Validate required values and reset to begin, all under one write lock
+	sse.lock.Lock()
 	if isStringEmpty(sse.url) {
+		sse.lock.Unlock()
 		return fmt.Errorf("resty:sse: event source URL is required")
 	}
 
@@ -535,11 +554,12 @@ func (sse *SSESource) Get() error {
 	}
 
 	if len(sse.onEvent) == 0 {
+		sse.lock.Unlock()
 		return fmt.Errorf("resty:sse: At least one OnMessage/AddEventListener func is required")
 	}
 
-	// reset to begin
-	sse.enableConnect()
+	sse.closed = false
+	sse.lock.Unlock()
 
 	for {
 		ctx := sse.Context()
@@ -568,12 +588,6 @@ func (sse *SSESource) Close() {
 	sse.lock.Lock()
 	defer sse.lock.Unlock()
 	sse.closed = true
-}
-
-func (sse *SSESource) enableConnect() {
-	sse.lock.Lock()
-	defer sse.lock.Unlock()
-	sse.closed = false
 }
 
 func (sse *SSESource) isClosed() bool {
@@ -607,44 +621,72 @@ func (sse *SSESource) triggerOnRequestFailure(err error, res *http.Response) {
 }
 
 func (sse *SSESource) createRequest() (*http.Request, error) {
+	// Resolve the context before taking the read lock; Context also acquires it
+	// and sync.RWMutex read locks are not reentrant.
+	ctx := sse.Context()
+
+	sse.lock.RLock()
+	method, url := sse.method, sse.url
+	hdr := sse.header.Clone()
+	lastEventID := sse.lastEventID
 	var reqBody io.Reader
 	if sse.bodyBytes != nil {
 		// create reader from bytes on each request
 		reqBody = bytes.NewReader(sse.bodyBytes)
 	}
+	sse.lock.RUnlock()
 
-	req, err := http.NewRequestWithContext(sse.Context(), sse.method, sse.url, reqBody)
+	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
 	if err != nil {
 		return nil, err
 	}
 
-	req.Header = sse.header.Clone()
+	req.Header = hdr
 	req.Header.Set(hdrAcceptKey, "text/event-stream")
 	req.Header.Set(hdrCacheControlKey, "no-cache")
 	req.Header.Set(hdrConnectionKey, "keep-alive")
-	if len(sse.lastEventID) > 0 {
-		req.Header.Set(hdrLastEvevntID, sse.lastEventID)
+	if len(lastEventID) > 0 {
+		req.Header.Set(hdrLastEvevntID, lastEventID)
 	}
 
 	return req, nil
 }
 
+// sseConnectError describes a non-OK connect response, or nil when no response
+// was received.
+func sseConnectError(res *Response) error {
+	if res == nil {
+		return nil
+	}
+	return fmt.Errorf("resty:sse: %v", res.Status())
+}
+
 func (sse *SSESource) connect() (*http.Response, error) {
+	// Snapshot the settings this attempt needs, then release the lock. Holding
+	// it across httpClient.Do, the retry wait, and the nested read locks taken
+	// by createRequest and triggerOnRequestFailure would deadlock against any
+	// concurrent Close or setter call, since read locks are not reentrant.
 	sse.lock.RLock()
-	defer sse.lock.RUnlock()
+	serverSentRetry := sse.serverSentRetry
+	retryWaitTime := sse.retryWaitTime
+	retryMaxWaitTime := sse.retryMaxWaitTime
+	retryCount := sse.retryCount
+	retryConditions := slices.Clone(sse.retryConditions)
+	httpClient := sse.httpClient
+	sse.lock.RUnlock()
 
 	var backoff *backoffWithJitter
-	if sse.serverSentRetry > 0 {
-		backoff = newBackoffWithJitter(sse.serverSentRetry, sse.serverSentRetry)
+	if serverSentRetry > 0 {
+		backoff = newBackoffWithJitter(serverSentRetry, serverSentRetry)
 	} else {
-		backoff = newBackoffWithJitter(sse.retryWaitTime, sse.retryMaxWaitTime)
+		backoff = newBackoffWithJitter(retryWaitTime, retryMaxWaitTime)
 	}
 
 	var (
 		err     error
 		attempt int
 	)
-	for i := 0; i <= sse.retryCount; i++ {
+	for i := 0; i <= retryCount; i++ {
 		attempt++
 		req, reqErr := sse.createRequest()
 		if reqErr != nil {
@@ -652,23 +694,26 @@ func (sse *SSESource) connect() (*http.Response, error) {
 			break
 		}
 
-		resp, doErr := sse.httpClient.Do(req)
+		resp, doErr := httpClient.Do(req)
 		if resp != nil && resp.StatusCode == http.StatusOK {
 			// successful connection, return response to listenStream
 			return resp, nil
 		}
 
+		rRes := wrapResponse(resp, req)
+
 		// we have reached the maximum no. of requests
 		// first attempt + retry count = total attempts
-		if attempt-1 == sse.retryCount {
-			err = doErr
+		if attempt-1 == retryCount {
+			err = wrapErrors(sseConnectError(rRes), doErr)
+			// nothing is returned to the caller, so this body is ours to release
+			drainBody(rRes)
 			break
 		}
 
-		rRes := wrapResponse(resp, req)
 		needsRetry := isDoNotRetryError(doErr)
-		if !needsRetry && resp != nil {
-			for _, retryCondition := range sse.retryConditions {
+		if !needsRetry && rRes != nil {
+			for _, retryCondition := range retryConditions {
 				if needsRetry = retryCondition(rRes, doErr); needsRetry {
 					break
 				}
@@ -677,14 +722,13 @@ func (sse *SSESource) connect() (*http.Response, error) {
 
 		// retry not required stop here
 		if !needsRetry {
-			if rRes != nil {
-				err = wrapErrors(fmt.Errorf("resty:sse: %v", rRes.Status()), doErr)
-			} else {
-				err = doErr
-			}
+			err = wrapErrors(sseConnectError(rRes), doErr)
 			if err != nil {
+				// the callback is documented to own the body, so hand it over
+				// first and only then release whatever is left of it
 				sse.triggerOnRequestFailure(err, resp)
 			}
+			drainBody(rRes)
 			break
 		}
 
@@ -693,7 +737,12 @@ func (sse *SSESource) connect() (*http.Response, error) {
 
 		waitDuration, _ := backoff.NextWaitDuration(nil, rRes, doErr, attempt)
 		timer := time.NewTimer(waitDuration)
-		<-timer.C
+		select {
+		case <-sse.Context().Done():
+			timer.Stop()
+			return nil, sse.Context().Err()
+		case <-timer.C:
+		}
 		timer.Stop()
 	}
 
@@ -745,7 +794,7 @@ func (sse *SSESource) listenStream(res *http.Response) error {
 func (sse *SSESource) processEvent(scanner *bufio.Scanner) error {
 	e, err := readEvent(scanner)
 	if err != nil {
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return err
 		}
 		sse.triggerOnError(err)
@@ -854,8 +903,12 @@ func parseEventFunc(msg []byte) (*rawSSE, error) {
 		case bytes.HasPrefix(line, headerID):
 			e.ID = append([]byte(nil), trimHeader(len(headerID), line)...)
 		case bytes.HasPrefix(line, headerData):
-			// The spec allows for multiple data fields per event, concatenated them with "\n"
-			e.Data = append(e.Data[:], append(trimHeader(len(headerData), line), byte('\n'))...)
+			// The spec allows for multiple data fields per event, concatenated them with "\n".
+			// Append into e.Data rather than onto the trimmed slice: that slice aliases
+			// bufio.Scanner's buffer, so appending to it can write over bytes the
+			// scanner has not handed out yet.
+			e.Data = append(e.Data, trimHeader(len(headerData), line)...)
+			e.Data = append(e.Data, '\n')
 		// The spec says that a line that simply contains the string "data" should be treated as a data field with an empty body.
 		case bytes.Equal(line, bytes.TrimSuffix(headerData, []byte(":"))):
 			e.Data = append(e.Data, byte('\n'))

--- a/sse_test.go
+++ b/sse_test.go
@@ -8,6 +8,7 @@ package resty
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -17,6 +18,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -819,4 +821,154 @@ func createMethodVerifyingSSETestServer(
 			}
 		}
 	})
+}
+
+// The data field used to be appended onto a slice aliasing the scanner buffer.
+func TestSSEParseEventDoesNotCorruptScannerBuffer(t *testing.T) {
+	raw := "id: 1\ndata: first\ndata: second\n\nid: 2\ndata: third\n\n"
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	scanner.Split(func(data []byte, atEOF bool) (int, []byte, error) {
+		if atEOF && len(data) == 0 {
+			return 0, nil, nil
+		}
+		if i := bytes.Index(data, []byte{'\n', '\n'}); i >= 0 {
+			return i + 1, data[0:i], nil
+		}
+		if atEOF {
+			return len(data), data, nil
+		}
+		return 0, nil, nil
+	})
+
+	var got []string
+	for {
+		ev, err := readEvent(scanner)
+		if err != nil {
+			break
+		}
+		parsed, err := parseEvent(ev)
+		if err != nil {
+			continue
+		}
+		if len(parsed.Data) > 0 {
+			// the splitter leaves the second newline of each "\n\n" pair in the
+			// stream, which yields a trailing data-less token
+			got = append(got, string(parsed.Data))
+		}
+		putRawEvent(parsed)
+	}
+
+	assertEqual(t, 2, len(got))
+	assertEqual(t, "first\nsecond", got[0])
+	assertEqual(t, "third", got[1])
+}
+
+// connect must not hold the read lock across httpClient.Do, the retry wait, or
+// the nested read locks taken by createRequest and the failure callback: a
+// concurrent Close taking the write lock in between would deadlock both.
+func TestSSESourceConcurrentCloseDoesNotDeadlock(t *testing.T) {
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+	defer ts.Close()
+
+	es := NewSSESource().
+		SetURL(ts.URL).
+		SetRetryCount(5).
+		SetRetryWaitTime(20 * time.Millisecond).
+		SetRetryMaxWaitTime(40 * time.Millisecond)
+	es.OnMessage(func(any) {}, nil)
+
+	done := make(chan error, 1)
+	go func() { done <- es.Get() }()
+
+	// Hammer the write lock while connect is retrying, from its own goroutine:
+	// under the old code SetHeader itself blocks, so doing this on the test
+	// goroutine would hang the whole binary instead of reporting a failure.
+	stopProbe := make(chan struct{})
+	probeDone := make(chan struct{})
+	go func() {
+		defer close(probeDone)
+		for {
+			select {
+			case <-stopProbe:
+				return
+			default:
+				es.SetHeader("X-Probe", "1")
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("SSESource.Get did not return; connect deadlocked against a concurrent setter")
+	}
+
+	close(stopProbe)
+	select {
+	case <-probeDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SSESource.SetHeader is blocked; connect is holding the read lock")
+	}
+	es.Close()
+}
+
+// A connect attempt that is not returned to the caller must not leak its body,
+// and the resulting error must carry the status code.
+func TestSSESourceConnectFailureReportsStatus(t *testing.T) {
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+	defer ts.Close()
+
+	es := NewSSESource().
+		SetURL(ts.URL).
+		SetRetryCount(1).
+		SetRetryWaitTime(time.Millisecond).
+		SetRetryMaxWaitTime(2 * time.Millisecond)
+	es.OnMessage(func(any) {}, nil)
+
+	err := es.Get()
+	assertNotNil(t, err)
+	assertTrue(t, strings.Contains(err.Error(), "429 Too Many Requests"),
+		"error should name the status, got: "+err.Error())
+}
+
+// The retry backoff between connect attempts must observe the source context.
+// Without it, Get sits out the whole wait after the caller has given up, and
+// then goes on to make another connection attempt.
+func TestSSESourceConnectContextDoneDuringRetryWait(t *testing.T) {
+	var attempts atomic.Int32
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusInternalServerError) // retryable, per the defaults
+	})
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	es := createSSESource(t, ts.URL, func(any) {}, nil).
+		SetContext(ctx).
+		SetRetryCount(5).
+		SetRetryWaitTime(3 * time.Second).
+		SetRetryMaxWaitTime(5 * time.Second)
+
+	go func() {
+		for attempts.Load() == 0 {
+			time.Sleep(time.Millisecond)
+		}
+		// the first attempt has failed, so connect is now in the retry wait
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := es.Get()
+	assertErrorIs(t, context.Canceled, err)
+	assertTrue(t, time.Since(start) < 2*time.Second,
+		"expected the retry wait to be abandoned when the context is done")
+	assertEqual(t, int32(1), attempts.Load(), "expected no further connect attempts")
 }


### PR DESCRIPTION
## Deadlock

`SSESource.connect` held `sse.lock.RLock()` for its entire body — across `httpClient.Do`, the retry wait, and the nested `RLock` acquisitions in `createRequest` → `Context()` and in `triggerOnRequestFailure`.

`sync.RWMutex` read locks are **not reentrant**. A concurrent `Close` or setter taking the write lock between the outer and the inner `RLock` blocks both permanently: the writer waits on `connect`'s read lock, and `connect`'s nested read lock queues behind the waiting writer. Any application calling `Close`, `SetHeader` or `SetContext` while a connection is being established could hang forever.

`connect` now snapshots the settings it needs under one short read lock and does its I/O without holding it. `createRequest` resolves the context before taking the lock, for the same reason.

The added test starts `Get()` against a server that returns 429 (so `connect` retries), hammers `SetHeader` from another goroutine, and fails with a message rather than hanging. On `v3` it deadlocks:

```
--- FAIL: TestSSESourceConcurrentCloseDoesNotDeadlock (10.01s)
    SSESource.Get did not return; connect deadlocked against a concurrent setter
```

## Leaked body, and a lost status code

Two further problems in the same function:

- A response not returned to the caller was never drained or closed. The non-retryable path released it only if an `OnRequestFailure` callback was registered; the retry-exhausted path never did.
- When the final attempt yielded a non-2xx response with no transport error, `err = doErr` left `err` nil, so `connect` fell through to the generic `resty:sse: unable to connect stream` and the status code was lost:

```
before: resty:sse: unable to connect stream
after:  resty:sse: 429 Too Many Requests
```

The failure callback still receives the body first, as documented; the body is released only after it returns.

## Also

- `SetURL` and `SetMethod` wrote `sse.url` / `sse.method` without the lock, unlike every other setter, and `Get` read and wrote them unlocked. `Get` now validates and resets in one critical section.
- `parseEventFunc` appended the `\n` separator onto a slice aliasing `bufio.Scanner`'s buffer, which can write over bytes the scanner has not yet handed out. It appends into the event buffer instead. Benign today only because the byte it overwrites happens to be the delimiter.
- Sentinel `err == io.EOF` replaced with `errors.Is`.

## Verification

`go test ./... -race -count=1 -shuffle=on` green; `gofmt`, `go vet`, `staticcheck` clean.

One of four independent PRs from an audit of the v3 branch.