### PR TITLE
fix: stop handing out pooled buffers and aliased slices

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -18,6 +18,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 )
 
@@ -156,7 +157,7 @@ func parseRequestURL(c *Client, r *Request) error {
 			if _, ok := r.QueryParams[k]; ok {
 				continue
 			}
-			r.QueryParams[k] = v[:]
+			r.QueryParams[k] = slices.Clone(v)
 		}
 
 		// GitHub #123 Preserve query string order partially.
@@ -189,7 +190,7 @@ func parseRequestHeader(c *Client, r *Request) {
 		if _, ok := r.Header[k]; ok {
 			continue
 		}
-		r.Header[k] = v[:]
+		r.Header[k] = slices.Clone(v)
 	}
 
 	if !r.isHeaderExists(hdrUserAgentKey) {
@@ -347,7 +348,7 @@ func handleMultipart(c *Client, r *Request) error {
 		if _, ok := r.FormData[k]; ok {
 			continue
 		}
-		r.FormData[k] = v[:]
+		r.FormData[k] = slices.Clone(v)
 	}
 
 	if len(r.multipartFields) == 0 {
@@ -445,7 +446,7 @@ func handleFormData(c *Client, r *Request) {
 		if _, ok := r.FormData[k]; ok {
 			continue
 		}
-		r.FormData[k] = v[:]
+		r.FormData[k] = slices.Clone(v)
 	}
 
 	r.bodyBuf = acquireBuffer()

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1375,3 +1375,43 @@ func TestStopMultipartNilReceiver(t *testing.T) {
 	// A request with no cancel func / pipe writer / fields must also be safe.
 	(&Request{}).stopMultipart()
 }
+
+// Client-level values were assigned into the request with v[:], so the request
+// shared the client's backing array. Two requests then grew into the same spare
+// slot and silently overwrote each other's value.
+func TestClientValuesAreNotAliasedIntoRequests(t *testing.T) {
+	c := dcnl()
+	defer c.Close()
+
+	// Set then two Adds leaves len 3 in a cap 4 array: one spare slot, which is
+	// where a request's own Add would write.
+	c.SetHeader("X-Multi", "one")
+	c.Header().Add("X-Multi", "two")
+	c.Header().Add("X-Multi", "three")
+	c.SetQueryParam("tag", "a")
+	c.QueryParams().Add("tag", "b")
+	c.QueryParams().Add("tag", "c")
+
+	newRequest := func(path, marker string) *Request {
+		r := c.R()
+		r.URL = path
+		assertNil(t, parseRequestURL(c, r))
+		parseRequestHeader(c, r)
+		r.Header.Add("X-Multi", marker)
+		r.QueryParams.Add("tag", marker)
+		return r
+	}
+
+	first := newRequest("/first", "first")
+	second := newRequest("/second", "second")
+
+	// each request must keep its own marker
+	assertEqual(t, "first", first.Header["X-Multi"][3])
+	assertEqual(t, "second", second.Header["X-Multi"][3])
+	assertEqual(t, "first", first.QueryParams["tag"][3])
+	assertEqual(t, "second", second.QueryParams["tag"][3])
+
+	// and the client itself must be untouched
+	assertEqual(t, 3, len(c.Header()["X-Multi"]))
+	assertEqual(t, 3, len(c.QueryParams()["tag"]))
+}

--- a/request.go
+++ b/request.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -1491,12 +1492,15 @@ func (r *Request) Execute(method, url string) (res *Response, err error) {
 		r.SetCorrelationID(newGUID())
 	}
 
-	retryConditions := append(r.retryConditions, r.client.retryConditions...)
+	// slices.Concat allocates a fresh slice; appending to r.retryConditions
+	// directly would write into its spare capacity, which is shared with every
+	// clone of this Request.
+	retryConditions := slices.Concat(r.retryConditions, r.client.RetryConditions())
 	if r.isSetRetryConditions {
 		retryConditions = r.retryConditions
 	}
 
-	retryHooks := append(r.retryHooks, r.client.retryHooks...)
+	retryHooks := slices.Concat(r.retryHooks, r.client.RetryHooks())
 	if r.isSetRetryHooks {
 		retryHooks = r.retryHooks
 	}
@@ -1606,7 +1610,12 @@ func (r *Request) Execute(method, url string) (res *Response, err error) {
 	}
 
 	r.sendLoadBalancerFeedback(res, err)
-	backToBufPool(r.bodyBuf)
+
+	// The buffer goes back to bufPool, so this Request must stop pointing at it;
+	// another goroutine may own it by the time anyone touches r again.
+	releaseBuffer(r.bodyBuf)
+	r.bodyBuf = nil
+
 	return
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -2242,7 +2243,9 @@ func TestRequestClone(t *testing.T) {
 	// assert interface type
 	assertEqual(t, "parent", parent.credentials.Username)
 	assertEqual(t, "clone", clone.credentials.Username)
-	assertEqual(t, "", parent.bodyBuf.String())
+	// Execute releases the parent's buffer back to bufPool and drops the pointer,
+	// so it must not be readable through the Request afterwards.
+	assertNil(t, parent.bodyBuf)
 	assertEqual(t, "clone", clone.bodyBuf.String())
 
 	// parent request should have raw request while clone should not
@@ -2737,4 +2740,51 @@ func TestRequestSetLabel(t *testing.T) {
 		SetLabel("AddUser")
 
 	assertEqual(t, "AddUser", r.Label)
+}
+
+// Execute returns bodyBuf to bufPool. If the Request keeps pointing at it, a
+// later read through the Request can observe a buffer another goroutine owns.
+func TestRequestBodyBufReleasedAfterExecute(t *testing.T) {
+	ts := createPostServer(t)
+	defer ts.Close()
+
+	c := dcnl()
+	defer c.Close()
+
+	req := c.R().SetBody(map[string]string{"username": "testuser"})
+	res, err := req.Post(ts.URL + "/json")
+	assertNil(t, err)
+	assertEqual(t, http.StatusOK, res.StatusCode())
+
+	assertNil(t, req.bodyBuf)
+}
+
+// The merged retry slices must not be written into the Request's own spare
+// capacity, which every clone of that Request shares.
+func TestRequestExecuteDoesNotAliasRetryConditions(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	c := dcnl()
+	defer c.Close()
+	c.AddRetryConditions(func(*Response, error) bool { return false })
+
+	req := c.R()
+	// spare capacity beyond len is what append would scribble into
+	req.retryConditions = make([]RetryConditionFunc, 0, 8)
+	req.AddRetryConditions(func(*Response, error) bool { return false })
+
+	// the clone shares that array; give it a second condition of its own
+	clone := req.Clone(context.Background())
+	clone.AddRetryConditions(func(*Response, error) bool { return true })
+	assertEqual(t, 2, len(clone.retryConditions))
+	before := reflect.ValueOf(clone.retryConditions[1]).Pointer()
+
+	// executing req merges the client-level conditions; that must not land in the
+	// shared array where the clone's own condition lives
+	_, err := req.Get(ts.URL + "/")
+	assertNil(t, err)
+
+	after := reflect.ValueOf(clone.retryConditions[1]).Pointer()
+	assertEqual(t, before, after)
 }

--- a/util.go
+++ b/util.go
@@ -272,12 +272,6 @@ func releaseBuffer(buf *bytes.Buffer) {
 	}
 }
 
-func backToBufPool(buf *bytes.Buffer) {
-	if buf != nil {
-		bufPool.Put(buf)
-	}
-}
-
 func closeq(v any) {
 	if c, ok := v.(io.Closer); ok {
 		silently(c.Close())


### PR DESCRIPTION
Three memory-ownership defects, all the same shape: Resty handed out, or kept pointing at, memory it no longer owned.

## 1. The pooled request buffer stayed reachable through the `Request`

`Request.Execute` ended with `backToBufPool(r.bodyBuf)`, returning the buffer to `bufPool` without resetting it or clearing `r.bodyBuf`. Any later use of the same `Request` — `Clone`, `CurlCmd`, `fmtBodyString` — read a buffer another goroutine may already have taken from the pool. It is now reset and the field cleared; `backToBufPool` had no other caller and is gone.

## 2. Client-level values were aliased into every request

`parseRequestURL`, `parseRequestHeader` and `handleFormData` assigned client values into the request with `v[:]`, so the request's slice shared the client's backing array. When that array had spare capacity, a request's own `Add` wrote into it — and the next request, aliasing the same array, overwrote the value:

```
client:  tag=[a b c]           (len 3, cap 4)
req1:    tag.Add("first")   -> writes index 3
req2:    tag.Add("second")  -> writes index 3, same array
req1 now reads [a b c second]
```

Reachable through the public API: a client-level multi-value header or query param built with `Set` followed by two `Add`s leaves len 3 in a cap 4 array. Now cloned.

## 3. `Request.Execute` aliased its own retry slices

```go
retryConditions := append(r.retryConditions, r.client.retryConditions...)
```

appends into `r.retryConditions`' spare capacity, which `Request.Clone` shares with every clone, so executing one request could overwrite a condition registered on a clone. Now `slices.Concat`, reading the client lists through their locked accessors rather than the fields directly.

## Test change

`TestRequestClone` asserted that `parent.bodyBuf` was still readable after `Execute` — that is the behaviour fixed in (1). It now asserts the buffer was released.

## Verification

Four tests covering the three cases, all failing on `v3`. `go test ./... -race -count=1 -shuffle=on` green; `gofmt`, `go vet`, `staticcheck` clean.

Independent of #1201, #1202 and #1203; second wave from the same audit as #1197–#1200.