### PR TITLE
fix: digest challenge parsing per RFC 7616

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -169,6 +169,13 @@ func (dt *digestTransport) parseChallenge(input string) (*digestChallenge, error
 		}
 	}
 
+	// nonce is REQUIRED by RFC 7616 section 3.3. Unrecognized directives are
+	// ignored, so this is what distinguishes a usable challenge from one that
+	// carried nothing we understand.
+	if isStringEmpty(c.nonce) {
+		return nil, ErrDigestBadChallenge
+	}
+
 	return c, nil
 }
 
@@ -276,7 +283,12 @@ func (dc *digestChallenge) setValue(k, v string) error {
 		dc.algorithm = v
 	case "qop":
 		if !isStringEmpty(v) {
+			// Servers commonly send `qop="auth, auth-int"`; the directive is a
+			// comma-separated list and each token may carry surrounding space.
 			dc.qop = strings.Split(v, ",")
+			for i := range dc.qop {
+				dc.qop[i] = strings.TrimSpace(dc.qop[i])
+			}
 		}
 	case "charset":
 		if strings.ToUpper(v) != "UTF-8" {
@@ -291,7 +303,8 @@ func (dc *digestChallenge) setValue(k, v string) error {
 	case "userhash":
 		dc.userHash = v
 	default:
-		return ErrDigestBadChallenge
+		// RFC 7616 section 3.3 requires unrecognized auth-param directives to be
+		// ignored, so a server sending an extension parameter still works.
 	}
 	return nil
 }

--- a/digest_test.go
+++ b/digest_test.go
@@ -380,3 +380,49 @@ func TestClientDigestAuthNoUserhash(t *testing.T) {
 	assertError(t, err)
 	assertEqual(t, http.StatusOK, resp.StatusCode())
 }
+
+// qop is a comma-separated list whose tokens may carry space, and unrecognized
+// challenge directives must be ignored rather than rejected (RFC 7616 3.3).
+func TestDigestChallengeParsing(t *testing.T) {
+	dt := &digestTransport{credentials: &credentials{"u", "p"}}
+
+	t.Run("qop tokens are trimmed", func(t *testing.T) {
+		cha, err := dt.parseChallenge(`Digest realm="r", nonce="n", qop="foo, auth"`)
+		assertNil(t, err)
+		assertTrue(t, cha.isQopSupported(qopAuth))
+
+		cred := &digestCredentials{}
+		assertNil(t, cred.parseQop(cha))
+		assertEqual(t, qopAuth, cred.qop)
+	})
+
+	t.Run("unknown directives are ignored", func(t *testing.T) {
+		cha, err := dt.parseChallenge(`Digest realm="r", nonce="n", extension="x", userhash=false`)
+		assertNil(t, err)
+		assertEqual(t, "r", cha.realm)
+		assertEqual(t, "n", cha.nonce)
+	})
+
+	t.Run("a challenge without nonce is rejected", func(t *testing.T) {
+		_, err := dt.parseChallenge(`Digest extension="x"`)
+		assertErrorIs(t, ErrDigestBadChallenge, err)
+	})
+}
+
+// A server offering an unsupported qop alongside a supported one must still
+// authenticate rather than fail with ErrDigestQopNotSupported.
+func TestClientDigestAuthQopListWithSpaces(t *testing.T) {
+	conf := *defaultDigestServerConf()
+	conf.qop = "some-future-qop, auth"
+	ts := createDigestServer(t, &conf)
+	defer ts.Close()
+
+	c := dcnl().
+		SetBaseURL(ts.URL+"/").
+		SetDigestAuth(conf.username, conf.password)
+	defer c.Close()
+
+	res, err := c.R().SetResult(&AuthSuccess{}).Get(conf.uri)
+	assertNil(t, err)
+	assertEqual(t, http.StatusOK, res.StatusCode())
+}


### PR DESCRIPTION
Two conformance problems in the `WWW-Authenticate` parser, both of which make Resty reject challenges real servers send.

## 1. qop tokens were not trimmed

```go
dc.qop = strings.Split(v, ",")
```

`qop="auth, auth-int"` parsed as `["auth", " auth-int"]`, and the leading space meant `isQopSupported` never matched the second token. So a server that offers a qop Resty doesn't know *first* — `qop="some-future-qop, auth"` — failed the request outright:

```
before: Get "http://…/dir/index.html": resty: digest: qop is not supported
after:  200 OK
```

even though `auth` was on offer. Each token is now trimmed.

## 2. Unknown directives were rejected

`setValue` returned `ErrDigestBadChallenge` from its `default` branch, so a single unrecognized auth-param anywhere in the challenge failed the whole request. RFC 7616 §3.3 requires unrecognized directives to be ignored. They are now skipped.

That change alone would have made an all-unknown challenge such as `Digest unknown_param=true` parse "successfully" into an empty challenge and then compute a credential from an empty realm and nonce. `nonce` is REQUIRED by §3.3, so `parseChallenge` now rejects a challenge carrying none — which is also what keeps the `/unknown_param` case in `TestClientDigestAuthErrors` failing for a real reason instead of passing silently.

## Verification

Added unit coverage for trimmed qop lists, ignored extension directives and the nonce requirement, plus an end-to-end test against the digest test server offering `qop="some-future-qop, auth"`. All fail on `v3`. `go test ./... -race -count=1 -shuffle=on` green; `gofmt`, `go vet`, `staticcheck` clean.

Independent of #1201, #1202 and #1204; second wave from the same audit as #1197–#1200.