### PR TITLE
fix(enhancement): guard the debug-log type assertion and keep the rate limiter's context cause

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -137,8 +137,15 @@ func debugLogger(c *Client, res *Response) {
 		Body:       res.fmtBodyString(res.Request.DebugBodyLimit),
 	}
 
+	// prepareRequestDebugInfo populates this before the request is sent. Guard the
+	// assertion anyway so a logging path can never panic.
+	rql, _ := req.values[debugRequestLogKey].(*DebugLogRequest)
+	if rql == nil {
+		rql = &DebugLogRequest{}
+	}
+
 	dl := &DebugLog{
-		Request:  req.values[debugRequestLogKey].(*DebugLogRequest),
+		Request:  rql,
 		Response: rdl,
 	}
 

--- a/rate_limiter.go
+++ b/rate_limiter.go
@@ -8,6 +8,7 @@ package resty
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 )
@@ -16,7 +17,22 @@ import (
 // rejects a request. This occurs when the context is cancelled or the deadline
 // expires before a token becomes available, or immediately if the rate limiter
 // implementation rejects the request for any other reason.
+//
+// The limiters shipped with Resty wrap the context error alongside this sentinel,
+// so both [errors.Is] checks succeed:
+//
+//	errors.Is(err, resty.ErrRateLimitExceeded)
+//	errors.Is(err, context.DeadlineExceeded)
 var ErrRateLimitExceeded = errors.New("resty: rate limit exceeded")
+
+// rateLimitError joins ErrRateLimitExceeded with the context error that caused
+// the wait to be abandoned, so callers can tell cancellation from a deadline.
+func rateLimitError(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("%w: %w", ErrRateLimitExceeded, err)
+	}
+	return ErrRateLimitExceeded
+}
 
 // RateLimiter is the interface that wraps the rate limiting behavior used by
 // [Client]. Implement this interface to provide custom rate limiting strategies.
@@ -117,7 +133,7 @@ func (l *RateLimitTokenBucket) Allow(ctx context.Context) error {
 		// Check context first to avoid acquiring the lock unnecessarily.
 		select {
 		case <-ctx.Done():
-			return ErrRateLimitExceeded
+			return rateLimitError(ctx)
 		default:
 		}
 
@@ -138,7 +154,7 @@ func (l *RateLimitTokenBucket) Allow(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return ErrRateLimitExceeded
+			return rateLimitError(ctx)
 		case <-timer.C:
 		}
 	}
@@ -232,7 +248,7 @@ func (l *RateLimitSlidingWindow) Allow(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ErrRateLimitExceeded
+			return rateLimitError(ctx)
 		default:
 		}
 
@@ -268,7 +284,7 @@ func (l *RateLimitSlidingWindow) Allow(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return ErrRateLimitExceeded
+			return rateLimitError(ctx)
 		case <-timer.C:
 		}
 	}

--- a/rate_limiter_test.go
+++ b/rate_limiter_test.go
@@ -252,3 +252,42 @@ func TestRateLimiterSlidingWindowConfig(t *testing.T) {
 		assertEqual(t, time.Second, l.WindowSize(), "expected default window of 1s")
 	})
 }
+
+// Both limiters collapsed cancellation and deadline expiry into the bare
+// sentinel, so callers could not tell them apart.
+func TestRateLimiterErrorWrapsContextCause(t *testing.T) {
+	limiters := map[string]RateLimiter{
+		"token bucket":   NewRateLimitTokenBucket(1, 1),
+		"sliding window": NewRateLimitSlidingWindow(1, time.Hour),
+	}
+
+	for name, l := range limiters {
+		t.Run(name, func(t *testing.T) {
+			assertNil(t, l.Allow(context.Background())) // consume the only slot
+
+			t.Run("cancelled", func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				err := l.Allow(ctx)
+				assertErrorIs(t, ErrRateLimitExceeded, err)
+				assertErrorIs(t, context.Canceled, err)
+			})
+
+			t.Run("deadline exceeded", func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+				defer cancel()
+				err := l.Allow(ctx)
+				assertErrorIs(t, ErrRateLimitExceeded, err)
+				assertErrorIs(t, context.DeadlineExceeded, err)
+			})
+		})
+	}
+}
+
+// A context that is not done has no cause to join, so the caller still gets the
+// bare sentinel back.
+func TestRateLimiterErrorWithoutContextCause(t *testing.T) {
+	err := rateLimitError(context.Background())
+	assertEqual(t, ErrRateLimitExceeded, err)
+	assertErrorIs(t, ErrRateLimitExceeded, err)
+}

--- a/resty_test.go
+++ b/resty_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1076,4 +1077,24 @@ func createBinFile(fileName string, size int64) string {
 	_ = f.Truncate(size)
 	_ = f.Close()
 	return fp
+}
+
+// debugLogger asserted req.values[debugRequestLogKey] unconditionally, so a
+// debug-enabled request whose values map has no entry panicked in a logging path.
+func TestDebugLoggerWithoutPreparedRequestLog(t *testing.T) {
+	var logBuf bytes.Buffer
+	c := New().SetLogger(&logger{l: log.New(&logBuf, "", 0)})
+	defer c.Close()
+
+	req := c.R()
+	req.IsDebug = true
+	req.initValuesMap() // deliberately empty: no debugRequestLogKey
+
+	res := &Response{Request: req}
+	res.setReceivedAt()
+
+	debugLogger(c, res) // must not panic
+
+	assertTrue(t, strings.Contains(logBuf.String(), "RESPONSE"),
+		"expected the debug log to be written, got: "+logBuf.String())
 }


### PR DESCRIPTION
Two small robustness fixes in unrelated files.

## 1. `debugLogger` asserted an interface value unconditionally

```go
Request: req.values[debugRequestLogKey].(*DebugLogRequest),
```

`prepareRequestDebugInfo` populates that key before the request is sent, so it is normally present — but when it is not, this panics inside a logging path:

```
panic: interface conversion: interface {} is nil, not *resty.DebugLogRequest
```

Now guarded with the two-value form and an empty fallback, so debug logging degrades instead of taking the process down.

## 2. Rate limiter errors erased the context cause

`RateLimitTokenBucket.Allow` and `RateLimitSlidingWindow.Allow` both returned the bare `ErrRateLimitExceeded` sentinel whether the wait ended in cancellation or a deadline, so callers could not tell the two apart and `errors.Is(err, context.Canceled)` never matched. The context error is now wrapped alongside the sentinel:

```go
errors.Is(err, resty.ErrRateLimitExceeded)   // still true
errors.Is(err, context.DeadlineExceeded)     // now also true
```

⚠️ **Behaviour change:** anyone comparing with `err == resty.ErrRateLimitExceeded` is affected; `errors.Is` is not. Happy to drop this half if you'd rather it waited for a major version.

## Verification

Both cases covered by added tests — the debug one panics on `v3`, the limiter one fails both `errors.Is` assertions. `go test ./... -race -count=1 -shuffle=on` green; `gofmt`, `go vet`, `staticcheck` clean.

Independent of #1201, #1202 and #1203; second wave from the same audit as #1197–#1200.