### PR TITLE
docs(sse): replace the dead sse.dev host with example.com

### DIFF
--- a/sse.go
+++ b/sse.go
@@ -97,7 +97,7 @@ type (
 // NewSSESource creates a new [SSESource] with default SSE settings.
 //
 //	sse := NewSSESource().
-//		SetURL("https://sse.dev/test").
+//		SetURL("https://example.com/events").
 //		OnMessage(
 //			func(e any) {
 //				event := e.(*resty.SSE)
@@ -136,7 +136,7 @@ func NewSSESource() *SSESource {
 
 // SetURL method sets the event-source URL on the [SSESource] instance.
 //
-//	sse.SetURL("https://sse.dev/test")
+//	sse.SetURL("https://example.com/events")
 func (sse *SSESource) SetURL(url string) *SSESource {
 	sse.url = url
 	return sse
@@ -511,7 +511,7 @@ func (sse *SSESource) AddEventListener(eventName string, ef SSEMessageFunc, resu
 // Get method establishes the connection with the server.
 //
 //	sse := NewSSESource().
-//		SetURL("https://sse.dev/test").
+//		SetURL("https://example.com/events").
 //		OnMessage(
 //			func(e any) {
 //				event := e.(*resty.SSE)

--- a/sse_test.go
+++ b/sse_test.go
@@ -655,7 +655,7 @@ func TestSSESourceCoverage(t *testing.T) {
 	err1 := es.Get()
 	assertEqual(t, "resty:sse: event source URL is required", err1.Error())
 
-	es.SetURL("https://sse.dev/test")
+	es.SetURL("https://example.com/events")
 	err2 := es.Get()
 	assertEqual(t, "resty:sse: At least one OnMessage/AddEventListener func is required", err2.Error())
 


### PR DESCRIPTION
`sse.dev` no longer resolves, so three godoc examples in `sse.go` and one URL fixture in `sse_test.go` point at a host that cannot answer:

```
$ host sse.dev
Host sse.dev not found: 3(NXDOMAIN)
```

Anyone copying an SSE example out of the docs gets a DNS error rather than a stream.

This replaces the four references with `https://example.com/events`. I picked `example.com` because the package already uses it for illustrative URLs in 60-odd places, so the examples stay consistent with the godoc around them instead of introducing another host.

The test fixture is safe to change. `TestSSESourceCoverage` never dials: `Get()` fails the "at least one OnMessage/AddEventListener" validation before it opens a connection, so the URL on that line is only a placeholder.

Nothing else changes. `OnMessage` in the two full examples is untouched.

### Testing

```
$ gofmt -l sse.go sse_test.go     # no output
$ go vet ./...                    # clean
$ go test ./... -race -count=1 -covermode=atomic -coverpkg=./... -shuffle=on
ok  resty.dev/v3  52.261s  coverage: 99.9% of statements in ./...
```

### On the earlier attempt

This supersedes #1185. There I swapped in a live public SSE endpoint so the examples would actually stream, but that endpoint was my employer's and you said you could not take a PR with business references in it. Fair enough, so this version has none. It only removes the dead host.

The trade-off worth naming: a placeholder documents the API shape but cannot be run as-is, whereas `sse.dev/test` used to give readers something they could paste and watch. If you would rather keep a runnable example, a small `httptest` server in the godoc would do it without depending on anyone's domain staying up, and I am happy to write that instead. Your call on which you prefer.
