### PR TITLE
fix: release the response body when no result is registered, and stop handing out live client maps

### DIFF
--- a/client.go
+++ b/client.go
@@ -323,10 +323,27 @@ func (c *Client) SetLoadBalancer(b LoadBalancer) *Client {
 }
 
 // Header method returns the headers from the client instance.
+//
+// The returned value is a snapshot; mutating it does not affect the client, and
+// the client may be modified concurrently without disturbing it.
 func (c *Client) Header() http.Header {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.header
+	return c.header.Clone()
+}
+
+// mergeHeaderInto copies the client headers into dst, skipping keys dst already
+// carries. The lock is held across the whole copy; [Client.Header] cannot be used
+// for this because the caller would iterate the snapshot after releasing it.
+func (c *Client) mergeHeaderInto(dst http.Header) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for k, v := range c.header {
+		if _, ok := dst[k]; ok {
+			continue
+		}
+		dst[k] = slices.Clone(v)
+	}
 }
 
 // SetHeader method sets a single header and its value in the client instance.
@@ -383,6 +400,36 @@ func (c *Client) SetHeaders(headers map[string]string) *Client {
 	defer c.lock.Unlock()
 	for h, v := range headers {
 		c.header.Set(h, v)
+	}
+	return c
+}
+
+// AddHeader method adds a single header and its value to the client instance,
+// keeping any values already present for that key.
+//
+// See [Client.SetHeader] to replace the existing values instead.
+//
+//	client.
+//		AddHeader("Accept", "text/html").
+//		AddHeader("Accept", "application/json")
+func (c *Client) AddHeader(header, value string) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.header.Add(header, value)
+	return c
+}
+
+// SetHeaderMultiValues method sets multiple headers along with their multiple
+// values from a map in the client instance.
+//
+// See [Request.SetHeaderMultiValues].
+//
+//	client.SetHeaderMultiValues(map[string][]string{
+//		"Accept": []string{"text/html", "application/xhtml+xml", "application/xml;q=0.9"},
+//	})
+func (c *Client) SetHeaderMultiValues(headers map[string][]string) *Client {
+	for key, values := range headers {
+		c.SetHeader(key, strings.Join(values, ", "))
 	}
 	return c
 }
@@ -459,10 +506,13 @@ func (c *Client) SetCookieJar(jar http.CookieJar) *Client {
 }
 
 // Cookies method returns all cookies registered in the client instance.
+//
+// The returned slice is a snapshot; appending to it does not affect the client.
+// The [http.Cookie] values themselves are shared and must not be mutated.
 func (c *Client) Cookies() []*http.Cookie {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.cookies
+	return slices.Clone(c.cookies)
 }
 
 // SetCookie method appends a single cookie to the client instance.
@@ -503,10 +553,27 @@ func (c *Client) SetCookies(cs []*http.Cookie) *Client {
 }
 
 // QueryParams method returns all query parameters and their values from the client instance.
+//
+// The returned value is a snapshot; mutating it does not affect the client, and
+// the client may be modified concurrently without disturbing it.
 func (c *Client) QueryParams() url.Values {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.queryParams
+	return cloneURLValues(c.queryParams)
+}
+
+// mergeQueryParamsInto copies the client query parameters into dst, skipping keys
+// dst already carries. See [Client.mergeHeaderInto] for why this is not built on
+// the public accessor.
+func (c *Client) mergeQueryParamsInto(dst url.Values) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for k, v := range c.queryParams {
+		if _, ok := dst[k]; ok {
+			continue
+		}
+		dst[k] = slices.Clone(v)
+	}
 }
 
 // SetQueryParam method sets a single parameter and its value in the client instance.
@@ -573,10 +640,61 @@ func (c *Client) SetQueryParams(params map[string]string) *Client {
 }
 
 // FormData method returns the form parameters and their values from the client instance.
+//
+// The returned value is a snapshot; mutating it does not affect the client, and
+// the client may be modified concurrently without disturbing it.
 func (c *Client) FormData() url.Values {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.formData
+	return cloneURLValues(c.formData)
+}
+
+// mergeFormDataInto copies the client form data into dst, skipping keys dst
+// already carries. See [Client.mergeHeaderInto] for why this is not built on the
+// public accessor.
+func (c *Client) mergeFormDataInto(dst url.Values) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for k, v := range c.formData {
+		if _, ok := dst[k]; ok {
+			continue
+		}
+		dst[k] = slices.Clone(v)
+	}
+}
+
+// AddQueryParam method adds a single query parameter and its value to the client
+// instance, keeping any values already present for that key.
+//
+// See [Client.SetQueryParam] to replace the existing values instead.
+//
+//	client.
+//		AddQueryParam("status", "pending").
+//		AddQueryParam("status", "approved")
+func (c *Client) AddQueryParam(param, value string) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.queryParams.Add(param, value)
+	return c
+}
+
+// SetQueryParamsFromValues method sets multiple query parameters with multiple
+// values from [url.Values] in the client instance.
+//
+// See [Request.SetQueryParamsFromValues].
+//
+//	client.SetQueryParamsFromValues(url.Values{
+//		"status": []string{"pending", "approved", "open"},
+//	})
+func (c *Client) SetQueryParamsFromValues(params url.Values) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for p, v := range params {
+		for _, pv := range v {
+			c.queryParams.Add(p, pv)
+		}
+	}
+	return c
 }
 
 // SetFormData method sets Form parameters and their values in the client instance.
@@ -595,6 +713,25 @@ func (c *Client) SetFormData(data map[string]string) *Client {
 	defer c.lock.Unlock()
 	for k, v := range data {
 		c.formData.Set(k, v)
+	}
+	return c
+}
+
+// SetFormDataFromValues method sets multiple form parameters with multiple values
+// from [url.Values] in the client instance.
+//
+// See [Request.SetFormDataFromValues].
+//
+//	client.SetFormDataFromValues(url.Values{
+//		"search_criteria": []string{"book", "glass", "pencil"},
+//	})
+func (c *Client) SetFormDataFromValues(data url.Values) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for k, v := range data {
+		for _, kv := range v {
+			c.formData.Add(k, kv)
+		}
 	}
 	return c
 }
@@ -1039,7 +1176,7 @@ func (c *Client) inferContentTypeDecoder(ct ...string) (ContentTypeDecoder, bool
 func (c *Client) ContentDecompressers() map[string]ContentDecompresser {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.contentDecompressers
+	return maps.Clone(c.contentDecompressers)
 }
 
 // AddContentDecompresser method adds a Content-Encoding ([RFC 9110]) decompresser
@@ -1491,7 +1628,7 @@ func (c *Client) SetRetryAllowNonIdempotent(b bool) *Client {
 func (c *Client) RetryConditions() []RetryConditionFunc {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.retryConditions
+	return slices.Clone(c.retryConditions)
 }
 
 // AddRetryConditions method adds one or more retry condition functions to the client.
@@ -1517,7 +1654,7 @@ func (c *Client) AddRetryConditions(conditions ...RetryConditionFunc) *Client {
 func (c *Client) RetryHooks() []RetryHookFunc {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.retryHooks
+	return slices.Clone(c.retryHooks)
 }
 
 // AddRetryHooks method appends one or more retry hook functions to the client;
@@ -2079,10 +2216,27 @@ func (c *Client) SetResponseDoNotParse(notParse bool) *Client {
 }
 
 // PathParams method returns the path parameters set on the client.
+//
+// The returned value is a snapshot; mutating it does not affect the client, and
+// the client may be modified concurrently without disturbing it.
 func (c *Client) PathParams() map[string]string {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.pathParams
+	return maps.Clone(c.pathParams)
+}
+
+// mergePathParamsInto copies the client path parameters into dst, skipping keys
+// dst already carries. See [Client.mergeHeaderInto] for why this is not built on
+// the public accessor.
+func (c *Client) mergePathParamsInto(dst map[string]string) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for k, v := range c.pathParams {
+		if _, ok := dst[k]; ok {
+			continue
+		}
+		dst[k] = v
+	}
 }
 
 // SetPathParam method sets a single URL path key-value pair in the

--- a/client_test.go
+++ b/client_test.go
@@ -1794,3 +1794,123 @@ func TestClientHedgingMutualExclusionWithRetry(t *testing.T) {
 	assertEqual(t, false, c.isHedgingEnabled())
 	assertEqual(t, 1, c.RetryCount()) // Retry count should remain
 }
+
+// Client.Header, QueryParams, FormData, PathParams and Cookies used to return the
+// live maps and slices, so request middleware iterated them after the read lock
+// had been released. Mutating the client concurrently was then a data race that
+// could escalate to an uncatchable "concurrent map read and map write".
+func TestClientAccessorsReturnSnapshots(t *testing.T) {
+	c := dcnl()
+	defer c.Close()
+
+	c.SetHeader("X-Snap", "one")
+	c.SetQueryParam("q", "one")
+	c.SetFormData(map[string]string{"f": "one"})
+	c.SetPathParam("p", "one")
+	c.SetCookie(&http.Cookie{Name: "c", Value: "one"})
+
+	// mutating what the accessors hand back must not reach the client
+	c.Header().Set("X-Snap", "mutated")
+	c.Header().Set("X-Added", "nope")
+	c.QueryParams().Set("q", "mutated")
+	c.FormData().Set("f", "mutated")
+	c.PathParams()["p"] = "mutated"
+	cookies := c.Cookies()
+	cookies = append(cookies, &http.Cookie{Name: "extra", Value: "nope"})
+	_ = cookies
+
+	assertEqual(t, "one", c.Header().Get("X-Snap"))
+	assertEqual(t, "", c.Header().Get("X-Added"))
+	assertEqual(t, "one", c.QueryParams().Get("q"))
+	assertEqual(t, "one", c.FormData().Get("f"))
+	assertEqual(t, "one", c.PathParams()["p"])
+	assertEqual(t, 1, len(c.Cookies()))
+
+	// the slice-returning accessors are snapshots too
+	assertEqual(t, 0, len(c.RetryConditions()))
+	c.AddRetryConditions(func(_ *Response, _ error) bool { return false })
+	rc := c.RetryConditions()
+	assertEqual(t, 1, len(rc))
+	rc = append(rc, func(_ *Response, _ error) bool { return true })
+	assertEqual(t, 2, len(rc))
+	assertEqual(t, 1, len(c.RetryConditions()))
+
+	assertEqual(t, 0, len(c.RetryHooks()))
+	c.AddRetryHooks(func(_ *Response, _ error) {})
+	assertEqual(t, 1, len(c.RetryHooks()))
+
+	decompressers := c.ContentDecompressers()
+	decompressers["bogus"] = nil
+	_, found := c.ContentDecompressers()["bogus"]
+	assertEqual(t, false, found)
+}
+
+// Mutating a client while requests are in flight is documented as safe. It used
+// to race against the middleware that merges client values into each request.
+func TestClientMutationDuringRequestsIsRaceFree(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	c := dcnl().SetBaseURL(ts.URL)
+	defer c.Close()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() { // e.g. a token-refresh goroutine
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			c.SetHeader("Authorization", fmt.Sprintf("Bearer %d", i))
+			c.SetQueryParam("v", strconv.Itoa(i))
+			c.SetPathParam("p", strconv.Itoa(i))
+			c.SetFormData(map[string]string{"f": strconv.Itoa(i)})
+		}
+	}()
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 25; j++ {
+				res, err := c.R().Get("/")
+				if err == nil {
+					_ = res.StatusCode()
+				}
+			}
+		}()
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+// Client had no multi-value setters, so Header().Add() on the live map was the
+// only way to reach them. The accessors now return snapshots, so these exist.
+func TestClientMultiValueSetters(t *testing.T) {
+	c := dcnl()
+	defer c.Close()
+
+	c.AddHeader("X-Multi", "one").AddHeader("X-Multi", "two")
+	assertEqual(t, 2, len(c.Header()["X-Multi"]))
+
+	c.SetHeaderMultiValues(map[string][]string{
+		"Accept": {"text/html", "application/json"},
+	})
+	assertEqual(t, "text/html, application/json", c.Header().Get("Accept"))
+
+	c.AddQueryParam("status", "pending").AddQueryParam("status", "approved")
+	assertEqual(t, 2, len(c.QueryParams()["status"]))
+
+	c.SetQueryParamsFromValues(url.Values{"tag": {"a", "b", "c"}})
+	assertEqual(t, 3, len(c.QueryParams()["tag"]))
+
+	c.SetFormDataFromValues(url.Values{"criteria": {"book", "glass"}})
+	assertEqual(t, 2, len(c.FormData()["criteria"]))
+}

--- a/middleware.go
+++ b/middleware.go
@@ -18,7 +18,6 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
-	"slices"
 	"strings"
 )
 
@@ -61,15 +60,9 @@ func MiddlewareRequestCreate(c *Client, r *Request) (err error) {
 }
 
 func parseRequestURL(c *Client, r *Request) error {
-	if len(c.PathParams())+len(r.PathParams) > 0 {
-		// GitHub #103 Path Params, #663 Raw Path Params
-		for p, v := range c.PathParams() {
-			if _, ok := r.PathParams[p]; ok {
-				continue
-			}
-			r.PathParams[p] = v
-		}
-
+	// GitHub #103 Path Params, #663 Raw Path Params
+	c.mergePathParamsInto(r.PathParams)
+	if len(r.PathParams) > 0 {
 		var prev int
 		buf := acquireBuffer()
 		defer releaseBuffer(buf)
@@ -158,14 +151,8 @@ func parseRequestURL(c *Client, r *Request) error {
 	}
 
 	// Adding Query Param
-	if len(c.QueryParams())+len(r.QueryParams) > 0 {
-		for k, v := range c.QueryParams() {
-			if _, ok := r.QueryParams[k]; ok {
-				continue
-			}
-			r.QueryParams[k] = slices.Clone(v)
-		}
-
+	c.mergeQueryParamsInto(r.QueryParams)
+	if len(r.QueryParams) > 0 {
 		// GitHub #123 Preserve query string order partially.
 		// Since not feasible in `SetQuery*` resty methods, because
 		// standard package `url.Encode(...)` sorts the query params
@@ -192,12 +179,7 @@ func parseRequestURL(c *Client, r *Request) error {
 }
 
 func parseRequestHeader(c *Client, r *Request) {
-	for k, v := range c.Header() {
-		if _, ok := r.Header[k]; ok {
-			continue
-		}
-		r.Header[k] = slices.Clone(v)
-	}
+	c.mergeHeaderInto(r.Header)
 
 	if !r.isHeaderExists(hdrUserAgentKey) {
 		r.Header.Set(hdrUserAgentKey, hdrUserAgentValue)
@@ -350,12 +332,7 @@ func handleMultipartFormData(r *Request) error {
 }
 
 func handleMultipart(c *Client, r *Request) error {
-	for k, v := range c.FormData() {
-		if _, ok := r.FormData[k]; ok {
-			continue
-		}
-		r.FormData[k] = slices.Clone(v)
-	}
+	c.mergeFormDataInto(r.FormData)
 
 	if len(r.multipartFields) == 0 {
 		return handleMultipartFormData(r)
@@ -448,12 +425,7 @@ func handleMultipart(c *Client, r *Request) error {
 }
 
 func handleFormData(c *Client, r *Request) {
-	for k, v := range c.FormData() {
-		if _, ok := r.FormData[k]; ok {
-			continue
-		}
-		r.FormData[k] = slices.Clone(v)
-	}
+	c.mergeFormDataInto(r.FormData)
 
 	r.bodyBuf = acquireBuffer()
 	r.bodyBuf.WriteString(r.FormData.Encode())
@@ -590,6 +562,17 @@ func MiddlewareResponseAutoParse(c *Client, res *Response) (err error) {
 		}
 	}
 
+	// A decoder exists, but no result object was registered for this status code,
+	// so nothing above consumed the body. Read it here: leaving it open holds the
+	// connection out of the keep-alive pool for the life of the process, and it
+	// keeps [Response.String] and [Response.Bytes] working on this path.
+	//
+	// The exception is a save-to-file response, whose body belongs to
+	// [MiddlewareResponseSaveToFile] further down the chain; buffering it here
+	// would hold the whole download in memory.
+	if !res.Request.IsResponseSaveToFile {
+		err = res.readAll()
+	}
 	return
 }
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -12,7 +12,9 @@ import (
 	"io"
 	"mime"
 	"mime/multipart"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/textproto"
 	"net/url"
 	"os"
@@ -20,6 +22,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -1417,11 +1420,11 @@ func TestClientValuesAreNotAliasedIntoRequests(t *testing.T) {
 	// Set then two Adds leaves len 3 in a cap 4 array: one spare slot, which is
 	// where a request's own Add would write.
 	c.SetHeader("X-Multi", "one")
-	c.Header().Add("X-Multi", "two")
-	c.Header().Add("X-Multi", "three")
+	c.AddHeader("X-Multi", "two")
+	c.AddHeader("X-Multi", "three")
 	c.SetQueryParam("tag", "a")
-	c.QueryParams().Add("tag", "b")
-	c.QueryParams().Add("tag", "c")
+	c.AddQueryParam("tag", "b")
+	c.AddQueryParam("tag", "c")
 
 	newRequest := func(path, marker string) *Request {
 		r := c.R()
@@ -1445,4 +1448,89 @@ func TestClientValuesAreNotAliasedIntoRequests(t *testing.T) {
 	// and the client itself must be untouched
 	assertEqual(t, 3, len(c.Header()["X-Multi"]))
 	assertEqual(t, 3, len(c.QueryParams()["tag"]))
+}
+
+// MiddlewareResponseAutoParse used to return without reading or closing the body
+// when a content-type decoder matched but the caller registered no Result (2xx)
+// or ResultError (4xx/5xx). The connection was then never returned to the
+// keep-alive pool, so every such request opened a fresh one.
+func TestAutoParseReleasesBodyWithoutResult(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		contentType string
+		body        string
+		statusCode  int
+		setResult   bool
+		setErr      bool
+	}{
+		{"json 200 without result", "application/json", `{"a":1}`, http.StatusOK, false, false},
+		{"json 200 with result", "application/json", `{"a":1}`, http.StatusOK, true, false},
+		{"json 500 without result error", "application/json", `{"a":1}`, http.StatusInternalServerError, false, false},
+		{"xml 200 without result", "application/xml", `<r><a>1</a></r>`, http.StatusOK, false, false},
+		{"no decoder for content type", "text/plain", `hello`, http.StatusOK, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var conns int32
+			ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set(hdrContentTypeKey, tc.contentType)
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			ts.Config.ConnState = func(_ net.Conn, s http.ConnState) {
+				if s == http.StateNew {
+					atomic.AddInt32(&conns, 1)
+				}
+			}
+			ts.Start()
+			defer ts.Close()
+
+			c := dcnl().SetBaseURL(ts.URL)
+			defer c.Close()
+
+			for i := 0; i < 5; i++ {
+				req := c.R()
+				if tc.setResult {
+					req.SetResult(&map[string]any{})
+				}
+				if tc.setErr {
+					req.SetResultError(&map[string]any{})
+				}
+				res, err := req.Get("/")
+				assertError(t, err)
+				assertEqual(t, tc.statusCode, res.StatusCode())
+				if !tc.setResult && !tc.setErr {
+					// nothing decoded it, so the body must still reach the caller
+					assertEqual(t, tc.body, res.String())
+				}
+			}
+
+			// one connection, reused for all five requests
+			assertEqual(t, int32(1), atomic.LoadInt32(&conns))
+		})
+	}
+}
+
+// A save-to-file response body belongs to MiddlewareResponseSaveToFile, so
+// AutoParse must not buffer it even though a decoder matches its content type.
+func TestAutoParseDoesNotBufferSaveToFileBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(hdrContentTypeKey, "application/json")
+		_, _ = w.Write([]byte(`{"a":1}`))
+	}))
+	defer ts.Close()
+
+	outputFile := filepath.Join(getTestDataPath(), "auto-parse-save.json")
+	defer cleanupFiles(outputFile)
+
+	c := dcnl().SetBaseURL(ts.URL)
+	defer c.Close()
+
+	res, err := c.R().SetResponseSaveFileName(outputFile).Get("/")
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, res.StatusCode())
+	assertEqual(t, false, res.IsRead)
+
+	b, err := os.ReadFile(outputFile)
+	assertError(t, err)
+	assertEqual(t, `{"a":1}`, string(b))
 }


### PR DESCRIPTION
Two defects that hit ordinary usage on the default code path. Both were found by an audit of the v3 branch and are reproduced below against `v3` at 60029bb.

## 1. The response body is never released when no result object is registered

`MiddlewareResponseAutoParse` has four exits and only three release the body. The fourth — a content-type decoder matched, but the caller registered no `Result` (2xx) or `ResultError` (4xx/5xx) — returns with the body neither read nor closed.

Nothing downstream rescues it. `Client.execute` only reads when `ResponseBodyUnlimitedReads` or `Debug` is on (`client.go`), and `Request.Execute` only drains when it is about to retry.

RFC 9112 §9.3: the connection returns to the idle pool only after the body is drained and closed. It never was. Ten sequential requests against one `httptest` server, counting `http.StateNew`:

| scenario | before | after |
|---|---|---|
| `200 application/json`, no `SetResult` | **10** | 1 |
| `200 application/json`, `SetResult` | 1 | 1 |
| `500 application/json`, no `SetResultError` | **10** | 1 |
| `200 application/xml`, no `SetResult` | **10** | 1 |
| `200 text/plain` (no decoder) | 1 | 1 |

That first row is the shape of `res, err := c.R().Get(url)` against a JSON API, which is how most callers use the library — every call burned a socket, an fd and a TLS handshake, and silently defeated `MaxIdleConnsPerHost`. The 5xx row is the path taken during an outage.

The fall-through now calls `res.readAll()`, matching what the no-decoder branch already did, so the connection is released and `Response.String`/`Response.Bytes` keep working. Save-to-file responses are excluded: their body belongs to `MiddlewareResponseSaveToFile` further down the chain, and buffering it here would hold the whole download in memory.

## 2. Client accessors returned live maps, so middleware iterated them unlocked

`Header`, `QueryParams`, `FormData`, `PathParams`, `Cookies`, `RetryConditions`, `RetryHooks` and `ContentDecompressers` took the read lock, returned the live map or slice, and released the lock. Request middleware then iterated those maps with no lock held, so the lock ordered the accessor call and not the use.

Rotating a bearer token on a shared client — documented as safe — raced against every in-flight request:

```
WARNING: DATA RACE
Write at 0x00c000336d50 by goroutine 18:
  resty.dev/v3.(*Client).SetPathParam()
Previous read at 0x00c000336d50 by goroutine 20:
  runtime.mapIterStart()
  resty.dev/v3.parseRequestURL()
  resty.dev/v3.MiddlewareRequestCreate()
  resty.dev/v3.(*Client).execute()
```

Concurrent map iteration and write is not only a race: the runtime can raise `fatal error: concurrent map read and map write`, which `recover` cannot catch, so the process dies.

The accessors now return snapshots, and the middleware merge paths use new unexported helpers that hold the read lock across the whole copy.

### One API consequence, please review

Because the accessors no longer hand out the live map, `Header().Add(...)` is no longer a way to reach multi-value client headers — and `Client` had no setter for them. This adds the ones `Request` already has:

- `AddHeader`, `SetHeaderMultiValues`
- `AddQueryParam`, `SetQueryParamsFromValues`
- `SetFormDataFromValues`

One existing test (`TestClientValuesAreNotAliasedIntoRequests`) built its fixture through `c.Header().Add(...)`; it now uses `AddHeader`/`AddQueryParam`. That is the only behavioural break, and it is deliberate — the alternative is keeping a documented data race.

## Verification

`go test ./... -race -count=1 -shuffle=on` green, 0 data races. `gofmt`, `go vet` clean. Statement coverage unchanged at 99.9%.

First of five stacked PRs from an audit of the v3 branch; this one has no dependencies.
