### PR TITLE
fix: decode zlib-framed deflate, escape CRLF in multipart headers, reopen files on retry

### DIFF
--- a/client.go
+++ b/client.go
@@ -323,10 +323,27 @@ func (c *Client) SetLoadBalancer(b LoadBalancer) *Client {
 }
 
 // Header method returns the headers from the client instance.
+//
+// The returned value is a snapshot; mutating it does not affect the client, and
+// the client may be modified concurrently without disturbing it.
 func (c *Client) Header() http.Header {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.header
+	return c.header.Clone()
+}
+
+// mergeHeaderInto copies the client headers into dst, skipping keys dst already
+// carries. The lock is held across the whole copy; [Client.Header] cannot be used
+// for this because the caller would iterate the snapshot after releasing it.
+func (c *Client) mergeHeaderInto(dst http.Header) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for k, v := range c.header {
+		if _, ok := dst[k]; ok {
+			continue
+		}
+		dst[k] = slices.Clone(v)
+	}
 }
 
 // SetHeader method sets a single header and its value in the client instance.
@@ -383,6 +400,36 @@ func (c *Client) SetHeaders(headers map[string]string) *Client {
 	defer c.lock.Unlock()
 	for h, v := range headers {
 		c.header.Set(h, v)
+	}
+	return c
+}
+
+// AddHeader method adds a single header and its value to the client instance,
+// keeping any values already present for that key.
+//
+// See [Client.SetHeader] to replace the existing values instead.
+//
+//	client.
+//		AddHeader("Accept", "text/html").
+//		AddHeader("Accept", "application/json")
+func (c *Client) AddHeader(header, value string) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.header.Add(header, value)
+	return c
+}
+
+// SetHeaderMultiValues method sets multiple headers along with their multiple
+// values from a map in the client instance.
+//
+// See [Request.SetHeaderMultiValues].
+//
+//	client.SetHeaderMultiValues(map[string][]string{
+//		"Accept": []string{"text/html", "application/xhtml+xml", "application/xml;q=0.9"},
+//	})
+func (c *Client) SetHeaderMultiValues(headers map[string][]string) *Client {
+	for key, values := range headers {
+		c.SetHeader(key, strings.Join(values, ", "))
 	}
 	return c
 }
@@ -459,10 +506,13 @@ func (c *Client) SetCookieJar(jar http.CookieJar) *Client {
 }
 
 // Cookies method returns all cookies registered in the client instance.
+//
+// The returned slice is a snapshot; appending to it does not affect the client.
+// The [http.Cookie] values themselves are shared and must not be mutated.
 func (c *Client) Cookies() []*http.Cookie {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.cookies
+	return slices.Clone(c.cookies)
 }
 
 // SetCookie method appends a single cookie to the client instance.
@@ -503,10 +553,27 @@ func (c *Client) SetCookies(cs []*http.Cookie) *Client {
 }
 
 // QueryParams method returns all query parameters and their values from the client instance.
+//
+// The returned value is a snapshot; mutating it does not affect the client, and
+// the client may be modified concurrently without disturbing it.
 func (c *Client) QueryParams() url.Values {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.queryParams
+	return cloneURLValues(c.queryParams)
+}
+
+// mergeQueryParamsInto copies the client query parameters into dst, skipping keys
+// dst already carries. See [Client.mergeHeaderInto] for why this is not built on
+// the public accessor.
+func (c *Client) mergeQueryParamsInto(dst url.Values) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for k, v := range c.queryParams {
+		if _, ok := dst[k]; ok {
+			continue
+		}
+		dst[k] = slices.Clone(v)
+	}
 }
 
 // SetQueryParam method sets a single parameter and its value in the client instance.
@@ -573,10 +640,61 @@ func (c *Client) SetQueryParams(params map[string]string) *Client {
 }
 
 // FormData method returns the form parameters and their values from the client instance.
+//
+// The returned value is a snapshot; mutating it does not affect the client, and
+// the client may be modified concurrently without disturbing it.
 func (c *Client) FormData() url.Values {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.formData
+	return cloneURLValues(c.formData)
+}
+
+// mergeFormDataInto copies the client form data into dst, skipping keys dst
+// already carries. See [Client.mergeHeaderInto] for why this is not built on the
+// public accessor.
+func (c *Client) mergeFormDataInto(dst url.Values) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for k, v := range c.formData {
+		if _, ok := dst[k]; ok {
+			continue
+		}
+		dst[k] = slices.Clone(v)
+	}
+}
+
+// AddQueryParam method adds a single query parameter and its value to the client
+// instance, keeping any values already present for that key.
+//
+// See [Client.SetQueryParam] to replace the existing values instead.
+//
+//	client.
+//		AddQueryParam("status", "pending").
+//		AddQueryParam("status", "approved")
+func (c *Client) AddQueryParam(param, value string) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.queryParams.Add(param, value)
+	return c
+}
+
+// SetQueryParamsFromValues method sets multiple query parameters with multiple
+// values from [url.Values] in the client instance.
+//
+// See [Request.SetQueryParamsFromValues].
+//
+//	client.SetQueryParamsFromValues(url.Values{
+//		"status": []string{"pending", "approved", "open"},
+//	})
+func (c *Client) SetQueryParamsFromValues(params url.Values) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for p, v := range params {
+		for _, pv := range v {
+			c.queryParams.Add(p, pv)
+		}
+	}
+	return c
 }
 
 // SetFormData method sets Form parameters and their values in the client instance.
@@ -595,6 +713,25 @@ func (c *Client) SetFormData(data map[string]string) *Client {
 	defer c.lock.Unlock()
 	for k, v := range data {
 		c.formData.Set(k, v)
+	}
+	return c
+}
+
+// SetFormDataFromValues method sets multiple form parameters with multiple values
+// from [url.Values] in the client instance.
+//
+// See [Request.SetFormDataFromValues].
+//
+//	client.SetFormDataFromValues(url.Values{
+//		"search_criteria": []string{"book", "glass", "pencil"},
+//	})
+func (c *Client) SetFormDataFromValues(data url.Values) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for k, v := range data {
+		for _, kv := range v {
+			c.formData.Add(k, kv)
+		}
 	}
 	return c
 }
@@ -1039,7 +1176,7 @@ func (c *Client) inferContentTypeDecoder(ct ...string) (ContentTypeDecoder, bool
 func (c *Client) ContentDecompressers() map[string]ContentDecompresser {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.contentDecompressers
+	return maps.Clone(c.contentDecompressers)
 }
 
 // AddContentDecompresser method adds a Content-Encoding ([RFC 9110]) decompresser
@@ -1491,7 +1628,7 @@ func (c *Client) SetRetryAllowNonIdempotent(b bool) *Client {
 func (c *Client) RetryConditions() []RetryConditionFunc {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.retryConditions
+	return slices.Clone(c.retryConditions)
 }
 
 // AddRetryConditions method adds one or more retry condition functions to the client.
@@ -1517,7 +1654,7 @@ func (c *Client) AddRetryConditions(conditions ...RetryConditionFunc) *Client {
 func (c *Client) RetryHooks() []RetryHookFunc {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.retryHooks
+	return slices.Clone(c.retryHooks)
 }
 
 // AddRetryHooks method appends one or more retry hook functions to the client;
@@ -2079,10 +2216,27 @@ func (c *Client) SetResponseDoNotParse(notParse bool) *Client {
 }
 
 // PathParams method returns the path parameters set on the client.
+//
+// The returned value is a snapshot; mutating it does not affect the client, and
+// the client may be modified concurrently without disturbing it.
 func (c *Client) PathParams() map[string]string {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.pathParams
+	return maps.Clone(c.pathParams)
+}
+
+// mergePathParamsInto copies the client path parameters into dst, skipping keys
+// dst already carries. See [Client.mergeHeaderInto] for why this is not built on
+// the public accessor.
+func (c *Client) mergePathParamsInto(dst map[string]string) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for k, v := range c.pathParams {
+		if _, ok := dst[k]; ok {
+			continue
+		}
+		dst[k] = v
+	}
 }
 
 // SetPathParam method sets a single URL path key-value pair in the

--- a/client_test.go
+++ b/client_test.go
@@ -1794,3 +1794,123 @@ func TestClientHedgingMutualExclusionWithRetry(t *testing.T) {
 	assertEqual(t, false, c.isHedgingEnabled())
 	assertEqual(t, 1, c.RetryCount()) // Retry count should remain
 }
+
+// Client.Header, QueryParams, FormData, PathParams and Cookies used to return the
+// live maps and slices, so request middleware iterated them after the read lock
+// had been released. Mutating the client concurrently was then a data race that
+// could escalate to an uncatchable "concurrent map read and map write".
+func TestClientAccessorsReturnSnapshots(t *testing.T) {
+	c := dcnl()
+	defer c.Close()
+
+	c.SetHeader("X-Snap", "one")
+	c.SetQueryParam("q", "one")
+	c.SetFormData(map[string]string{"f": "one"})
+	c.SetPathParam("p", "one")
+	c.SetCookie(&http.Cookie{Name: "c", Value: "one"})
+
+	// mutating what the accessors hand back must not reach the client
+	c.Header().Set("X-Snap", "mutated")
+	c.Header().Set("X-Added", "nope")
+	c.QueryParams().Set("q", "mutated")
+	c.FormData().Set("f", "mutated")
+	c.PathParams()["p"] = "mutated"
+	cookies := c.Cookies()
+	cookies = append(cookies, &http.Cookie{Name: "extra", Value: "nope"})
+	_ = cookies
+
+	assertEqual(t, "one", c.Header().Get("X-Snap"))
+	assertEqual(t, "", c.Header().Get("X-Added"))
+	assertEqual(t, "one", c.QueryParams().Get("q"))
+	assertEqual(t, "one", c.FormData().Get("f"))
+	assertEqual(t, "one", c.PathParams()["p"])
+	assertEqual(t, 1, len(c.Cookies()))
+
+	// the slice-returning accessors are snapshots too
+	assertEqual(t, 0, len(c.RetryConditions()))
+	c.AddRetryConditions(func(_ *Response, _ error) bool { return false })
+	rc := c.RetryConditions()
+	assertEqual(t, 1, len(rc))
+	rc = append(rc, func(_ *Response, _ error) bool { return true })
+	assertEqual(t, 2, len(rc))
+	assertEqual(t, 1, len(c.RetryConditions()))
+
+	assertEqual(t, 0, len(c.RetryHooks()))
+	c.AddRetryHooks(func(_ *Response, _ error) {})
+	assertEqual(t, 1, len(c.RetryHooks()))
+
+	decompressers := c.ContentDecompressers()
+	decompressers["bogus"] = nil
+	_, found := c.ContentDecompressers()["bogus"]
+	assertEqual(t, false, found)
+}
+
+// Mutating a client while requests are in flight is documented as safe. It used
+// to race against the middleware that merges client values into each request.
+func TestClientMutationDuringRequestsIsRaceFree(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	c := dcnl().SetBaseURL(ts.URL)
+	defer c.Close()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() { // e.g. a token-refresh goroutine
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			c.SetHeader("Authorization", fmt.Sprintf("Bearer %d", i))
+			c.SetQueryParam("v", strconv.Itoa(i))
+			c.SetPathParam("p", strconv.Itoa(i))
+			c.SetFormData(map[string]string{"f": strconv.Itoa(i)})
+		}
+	}()
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 25; j++ {
+				res, err := c.R().Get("/")
+				if err == nil {
+					_ = res.StatusCode()
+				}
+			}
+		}()
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+// Client had no multi-value setters, so Header().Add() on the live map was the
+// only way to reach them. The accessors now return snapshots, so these exist.
+func TestClientMultiValueSetters(t *testing.T) {
+	c := dcnl()
+	defer c.Close()
+
+	c.AddHeader("X-Multi", "one").AddHeader("X-Multi", "two")
+	assertEqual(t, 2, len(c.Header()["X-Multi"]))
+
+	c.SetHeaderMultiValues(map[string][]string{
+		"Accept": {"text/html", "application/json"},
+	})
+	assertEqual(t, "text/html, application/json", c.Header().Get("Accept"))
+
+	c.AddQueryParam("status", "pending").AddQueryParam("status", "approved")
+	assertEqual(t, 2, len(c.QueryParams()["status"]))
+
+	c.SetQueryParamsFromValues(url.Values{"tag": {"a", "b", "c"}})
+	assertEqual(t, 3, len(c.QueryParams()["tag"]))
+
+	c.SetFormDataFromValues(url.Values{"criteria": {"book", "glass"}})
+	assertEqual(t, 2, len(c.FormData()["criteria"]))
+}

--- a/middleware.go
+++ b/middleware.go
@@ -18,7 +18,6 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
-	"slices"
 	"strings"
 )
 
@@ -61,15 +60,9 @@ func MiddlewareRequestCreate(c *Client, r *Request) (err error) {
 }
 
 func parseRequestURL(c *Client, r *Request) error {
-	if len(c.PathParams())+len(r.PathParams) > 0 {
-		// GitHub #103 Path Params, #663 Raw Path Params
-		for p, v := range c.PathParams() {
-			if _, ok := r.PathParams[p]; ok {
-				continue
-			}
-			r.PathParams[p] = v
-		}
-
+	// GitHub #103 Path Params, #663 Raw Path Params
+	c.mergePathParamsInto(r.PathParams)
+	if len(r.PathParams) > 0 {
 		var prev int
 		buf := acquireBuffer()
 		defer releaseBuffer(buf)
@@ -158,14 +151,8 @@ func parseRequestURL(c *Client, r *Request) error {
 	}
 
 	// Adding Query Param
-	if len(c.QueryParams())+len(r.QueryParams) > 0 {
-		for k, v := range c.QueryParams() {
-			if _, ok := r.QueryParams[k]; ok {
-				continue
-			}
-			r.QueryParams[k] = slices.Clone(v)
-		}
-
+	c.mergeQueryParamsInto(r.QueryParams)
+	if len(r.QueryParams) > 0 {
 		// GitHub #123 Preserve query string order partially.
 		// Since not feasible in `SetQuery*` resty methods, because
 		// standard package `url.Encode(...)` sorts the query params
@@ -192,12 +179,7 @@ func parseRequestURL(c *Client, r *Request) error {
 }
 
 func parseRequestHeader(c *Client, r *Request) {
-	for k, v := range c.Header() {
-		if _, ok := r.Header[k]; ok {
-			continue
-		}
-		r.Header[k] = slices.Clone(v)
-	}
+	c.mergeHeaderInto(r.Header)
 
 	if !r.isHeaderExists(hdrUserAgentKey) {
 		r.Header.Set(hdrUserAgentKey, hdrUserAgentValue)
@@ -350,12 +332,7 @@ func handleMultipartFormData(r *Request) error {
 }
 
 func handleMultipart(c *Client, r *Request) error {
-	for k, v := range c.FormData() {
-		if _, ok := r.FormData[k]; ok {
-			continue
-		}
-		r.FormData[k] = slices.Clone(v)
-	}
+	c.mergeFormDataInto(r.FormData)
 
 	if len(r.multipartFields) == 0 {
 		return handleMultipartFormData(r)
@@ -448,12 +425,7 @@ func handleMultipart(c *Client, r *Request) error {
 }
 
 func handleFormData(c *Client, r *Request) {
-	for k, v := range c.FormData() {
-		if _, ok := r.FormData[k]; ok {
-			continue
-		}
-		r.FormData[k] = slices.Clone(v)
-	}
+	c.mergeFormDataInto(r.FormData)
 
 	r.bodyBuf = acquireBuffer()
 	r.bodyBuf.WriteString(r.FormData.Encode())
@@ -590,6 +562,17 @@ func MiddlewareResponseAutoParse(c *Client, res *Response) (err error) {
 		}
 	}
 
+	// A decoder exists, but no result object was registered for this status code,
+	// so nothing above consumed the body. Read it here: leaving it open holds the
+	// connection out of the keep-alive pool for the life of the process, and it
+	// keeps [Response.String] and [Response.Bytes] working on this path.
+	//
+	// The exception is a save-to-file response, whose body belongs to
+	// [MiddlewareResponseSaveToFile] further down the chain; buffering it here
+	// would hold the whole download in memory.
+	if !res.Request.IsResponseSaveToFile {
+		err = res.readAll()
+	}
 	return
 }
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -12,7 +12,9 @@ import (
 	"io"
 	"mime"
 	"mime/multipart"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/textproto"
 	"net/url"
 	"os"
@@ -20,6 +22,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -1417,11 +1420,11 @@ func TestClientValuesAreNotAliasedIntoRequests(t *testing.T) {
 	// Set then two Adds leaves len 3 in a cap 4 array: one spare slot, which is
 	// where a request's own Add would write.
 	c.SetHeader("X-Multi", "one")
-	c.Header().Add("X-Multi", "two")
-	c.Header().Add("X-Multi", "three")
+	c.AddHeader("X-Multi", "two")
+	c.AddHeader("X-Multi", "three")
 	c.SetQueryParam("tag", "a")
-	c.QueryParams().Add("tag", "b")
-	c.QueryParams().Add("tag", "c")
+	c.AddQueryParam("tag", "b")
+	c.AddQueryParam("tag", "c")
 
 	newRequest := func(path, marker string) *Request {
 		r := c.R()
@@ -1445,4 +1448,89 @@ func TestClientValuesAreNotAliasedIntoRequests(t *testing.T) {
 	// and the client itself must be untouched
 	assertEqual(t, 3, len(c.Header()["X-Multi"]))
 	assertEqual(t, 3, len(c.QueryParams()["tag"]))
+}
+
+// MiddlewareResponseAutoParse used to return without reading or closing the body
+// when a content-type decoder matched but the caller registered no Result (2xx)
+// or ResultError (4xx/5xx). The connection was then never returned to the
+// keep-alive pool, so every such request opened a fresh one.
+func TestAutoParseReleasesBodyWithoutResult(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		contentType string
+		body        string
+		statusCode  int
+		setResult   bool
+		setErr      bool
+	}{
+		{"json 200 without result", "application/json", `{"a":1}`, http.StatusOK, false, false},
+		{"json 200 with result", "application/json", `{"a":1}`, http.StatusOK, true, false},
+		{"json 500 without result error", "application/json", `{"a":1}`, http.StatusInternalServerError, false, false},
+		{"xml 200 without result", "application/xml", `<r><a>1</a></r>`, http.StatusOK, false, false},
+		{"no decoder for content type", "text/plain", `hello`, http.StatusOK, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var conns int32
+			ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set(hdrContentTypeKey, tc.contentType)
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			ts.Config.ConnState = func(_ net.Conn, s http.ConnState) {
+				if s == http.StateNew {
+					atomic.AddInt32(&conns, 1)
+				}
+			}
+			ts.Start()
+			defer ts.Close()
+
+			c := dcnl().SetBaseURL(ts.URL)
+			defer c.Close()
+
+			for i := 0; i < 5; i++ {
+				req := c.R()
+				if tc.setResult {
+					req.SetResult(&map[string]any{})
+				}
+				if tc.setErr {
+					req.SetResultError(&map[string]any{})
+				}
+				res, err := req.Get("/")
+				assertError(t, err)
+				assertEqual(t, tc.statusCode, res.StatusCode())
+				if !tc.setResult && !tc.setErr {
+					// nothing decoded it, so the body must still reach the caller
+					assertEqual(t, tc.body, res.String())
+				}
+			}
+
+			// one connection, reused for all five requests
+			assertEqual(t, int32(1), atomic.LoadInt32(&conns))
+		})
+	}
+}
+
+// A save-to-file response body belongs to MiddlewareResponseSaveToFile, so
+// AutoParse must not buffer it even though a decoder matches its content type.
+func TestAutoParseDoesNotBufferSaveToFileBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(hdrContentTypeKey, "application/json")
+		_, _ = w.Write([]byte(`{"a":1}`))
+	}))
+	defer ts.Close()
+
+	outputFile := filepath.Join(getTestDataPath(), "auto-parse-save.json")
+	defer cleanupFiles(outputFile)
+
+	c := dcnl().SetBaseURL(ts.URL)
+	defer c.Close()
+
+	res, err := c.R().SetResponseSaveFileName(outputFile).Get("/")
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, res.StatusCode())
+	assertEqual(t, false, res.IsRead)
+
+	b, err := os.ReadFile(outputFile)
+	assertError(t, err)
+	assertEqual(t, `{"a":1}`, string(b))
 }

--- a/multipart.go
+++ b/multipart.go
@@ -15,7 +15,11 @@ import (
 	"strings"
 )
 
-var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+// quoteEscaper matches mime/multipart's own escaper. CR and LF must be
+// percent-encoded: multipart part headers are written verbatim, so a newline in
+// a field name, filename or content type would otherwise inject headers or
+// terminate the part early.
+var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"", "\r", "%0D", "\n", "%0A")
 
 func escapeQuotes(s string) string {
 	return quoteEscaper.Replace(s)
@@ -61,6 +65,11 @@ type MultipartField struct {
 	// tempBuf is used to preserve the byte(s) read from the file to detect the content type.
 	// Or any possible read error early.
 	tempBuf []byte
+
+	// openedByResty records that Resty opened Reader itself from FilePath, so it
+	// owns the handle and may close and reopen it between retry attempts. A
+	// caller-supplied Reader is never reopened, only rewound.
+	openedByResty bool
 }
 
 // Clone returns a copy of m, except [MultipartField.Reader] which is shared.
@@ -71,6 +80,16 @@ func (mf *MultipartField) Clone() *MultipartField {
 }
 
 func (mf *MultipartField) resetReader() error {
+	// tempBuf holds the head sniffed for content-type detection on the previous
+	// attempt. The rewound reader supplies those bytes again, so drop it rather
+	// than writing them a second time.
+	mf.tempBuf = nil
+
+	// A file Resty opened is closed after every attempt, so seeking it would
+	// fail with "file already closed". Reopen it instead.
+	if mf.openedByResty && mf.Reader == nil {
+		return mf.openFile()
+	}
 	if rs, ok := mf.Reader.(io.ReadSeeker); ok {
 		_, err := rs.Seek(0, io.SeekStart)
 		return err
@@ -84,6 +103,11 @@ func (mf *MultipartField) isValues() bool {
 
 func (mf *MultipartField) close() {
 	closeq(mf.Reader)
+	if mf.openedByResty {
+		// Drop the closed handle so a retry reopens FilePath rather than
+		// seeking a file that is already closed.
+		mf.Reader = nil
+	}
 }
 
 func (mf *MultipartField) createHeader() textproto.MIMEHeader {
@@ -121,6 +145,7 @@ func (mf *MultipartField) openFile() error {
 
 	mf.Reader = file
 	mf.FileSize = fileStat.Size()
+	mf.openedByResty = true
 
 	return nil
 }

--- a/multipart_test.go
+++ b/multipart_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"io/fs"
 	"mime/multipart"
 	"net/http"
@@ -754,4 +755,114 @@ func TestRetryNonSeekableReaderWithoutFactoryReturnsError(t *testing.T) {
 
 	assertErrorIs(t, ErrReaderNotSeekable, err)
 	assertEqual(t, 1, attemptCount)
+}
+
+// Resty opens files named by SetFile itself and closes them after every attempt,
+// so a retry used to seek an already-closed handle and abandon the request. The
+// sniffed content-type head must also be sent exactly once per attempt.
+func TestMultipartRetryResendsIdenticalFile(t *testing.T) {
+	var mu sync.Mutex
+	var bodies []string
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, string(body))
+		mu.Unlock()
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	defer ts.Close()
+
+	c := dcnl()
+	defer c.Close()
+
+	_, err := c.R().
+		SetRetryCount(1).
+		SetRetryWaitTime(time.Millisecond).
+		SetRetryMaxWaitTime(2*time.Millisecond).
+		SetRetryAllowNonIdempotent(true).
+		AddRetryConditions(func(res *Response, _ error) bool { return true }).
+		SetFile("file", filepath.Join(getTestDataPath(), "text-file.txt")).
+		Post(ts.URL)
+	assertNil(t, err)
+
+	const payload = "THIS IS TEXT FILE FOR MULTIPART UPLOAD TEST :)"
+
+	mu.Lock()
+	defer mu.Unlock()
+	assertEqual(t, 2, len(bodies))
+	for _, body := range bodies {
+		// exactly once: the sniffed head is neither dropped nor re-sent
+		assertEqual(t, 1, strings.Count(body, payload))
+		assertEqual(t, 1, strings.Count(body, "text-file.txt"))
+	}
+}
+
+// mime/multipart writes part headers verbatim, so CR and LF in a field name,
+// filename or content type must be percent-encoded. Resty's escaper was a fork
+// of the stdlib one with those two replacements dropped, which let an
+// attacker-controlled filename inject headers or forge an entire extra part.
+func TestEscapeQuotesEncodesCRLF(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		in     string
+		expect string
+	}{
+		{"carriage return", "a\rb", "a%0Db"},
+		{"line feed", "a\nb", "a%0Ab"},
+		{"crlf pair", "a\r\nb", "a%0D%0Ab"},
+		{"quote still escaped", `a"b`, `a\"b`},
+		{"backslash still escaped", `a\b`, `a\\b`},
+		{"plain text untouched", "report.pdf", "report.pdf"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assertEqual(t, tc.expect, escapeQuotes(tc.in))
+		})
+	}
+}
+
+func TestMultipartFileNameCannotInjectParts(t *testing.T) {
+	var gotRole string
+	var partCount int
+	var parseErr error
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		mr, err := r.MultipartReader()
+		if err != nil {
+			parseErr = err
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		for {
+			p, err := mr.NextPart()
+			if err != nil {
+				break
+			}
+			partCount++
+			if p.FormName() == "role" {
+				b, _ := io.ReadAll(p)
+				gotRole = string(b)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	defer ts.Close()
+
+	c := dcnl()
+	defer c.Close()
+
+	// A filename carrying a forged part boundary and an extra form field.
+	evil := "x.txt\"\r\n\r\nnot-a-part\r\n--BOUND\r\n" +
+		"Content-Disposition: form-data; name=\"role\"\r\n\r\nadmin\r\n--BOUND--\r\n"
+
+	res, err := c.R().
+		SetMultipartBoundary("BOUND").
+		SetFileReader("file", evil, strings.NewReader("real content")).
+		Post(ts.URL)
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, res.StatusCode())
+
+	// A real multipart parser must see exactly the one part Resty intended,
+	// and no injected "role" field.
+	assertNil(t, parseErr)
+	assertEqual(t, 1, partCount)
+	assertEqual(t, "", gotRole)
 }

--- a/stream.go
+++ b/stream.go
@@ -6,9 +6,11 @@
 package resty
 
 import (
+	"bufio"
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"context"
 	"encoding/json"
 	"encoding/xml"
@@ -229,11 +231,16 @@ type deflateReaderWrapper struct {
 	mu *sync.Mutex
 	r  io.ReadCloser
 	fr io.ReadCloser
+	// fromPool marks fr as a flate reader that may go back to flateReaderPool.
+	// A zlib reader must never be pooled there: zlib.Resetter and flate.Resetter
+	// have the same method set, so a type assertion cannot tell them apart, and a
+	// pooled zlib reader would fail every later raw-deflate stream.
+	fromPool bool
 }
 
 // acquireDeflateReader gets a flate.Reader from the pool or creates one.
 // It resets the reader for the new stream using the provided io.ReadCloser.
-func acquireDeflateReader(r io.ReadCloser) (*deflateReaderWrapper, error) {
+func acquireDeflateReader(r io.ReadCloser, src io.Reader) (*deflateReaderWrapper, error) {
 	w := &deflateReaderWrapper{
 		mu: new(sync.Mutex),
 		r:  r,
@@ -242,14 +249,16 @@ func acquireDeflateReader(r io.ReadCloser) (*deflateReaderWrapper, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
+	w.fromPool = true
+
 	// Try to get a cached reader from the pool
 	if cached := flateReaderPool.Get(); cached != nil {
 		w.fr = cached.(io.ReadCloser)
 		// Reset the pooled reader for the new stream; flate.Resetter.Reset never errors
-		w.fr.(flate.Resetter).Reset(r, nil)
+		w.fr.(flate.Resetter).Reset(src, nil)
 	} else {
 		// Pool is empty, create a new reader
-		w.fr = flate.NewReader(r)
+		w.fr = flate.NewReader(src)
 	}
 
 	return w, nil
@@ -262,8 +271,12 @@ func releaseDeflateReader(w *deflateReaderWrapper) {
 	defer w.mu.Unlock()
 
 	if w.fr != nil {
-		w.fr.(flate.Resetter).Reset(nopReader{}, nil)
-		flateReaderPool.Put(w.fr)
+		if w.fromPool {
+			w.fr.(flate.Resetter).Reset(nopReader{}, nil)
+			flateReaderPool.Put(w.fr)
+		} else {
+			closeq(w.fr)
+		}
 		w.fr = nil
 	}
 	if w.r != nil {
@@ -272,8 +285,30 @@ func releaseDeflateReader(w *deflateReaderWrapper) {
 	}
 }
 
+// isZlibWrapped reports whether the next two bytes of br are an RFC 1950 zlib
+// header. RFC 9110 section 8.4.1.2 defines the "deflate" content coding as a
+// zlib stream, but plenty of servers send a bare RFC 1951 stream under the same
+// name, so both are accepted.
+func isZlibWrapped(br *bufio.Reader) bool {
+	h, err := br.Peek(2)
+	if err != nil {
+		return false
+	}
+	// The low nibble of CMF is the compression method; 8 is deflate. The two
+	// header bytes read big-endian must also be a multiple of 31.
+	return h[0]&0x0f == 8 && (uint16(h[0])<<8|uint16(h[1]))%31 == 0
+}
+
 func decompressDeflate(r io.ReadCloser) (io.ReadCloser, error) {
-	return acquireDeflateReader(r)
+	br := bufio.NewReader(r)
+	if isZlibWrapped(br) {
+		zr, err := zlib.NewReader(br)
+		if err != nil {
+			return nil, err
+		}
+		return &deflateReaderWrapper{mu: new(sync.Mutex), r: r, fr: zr}, nil
+	}
+	return acquireDeflateReader(r, br)
 }
 
 // Implement io.ReadCloser for deflateReaderWrapper

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,9 +1,11 @@
 package resty
 
 import (
+	"bufio"
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"errors"
 	"io"
 	"net/http"
@@ -475,7 +477,7 @@ func TestDeflateReaderPanicOnConcurrentCorruptedBody(t *testing.T) {
 func TestDeflateReaderPoolAcquireAndRead(t *testing.T) {
 	// Test successful creation and read with valid deflate data
 	validData := io.NopCloser(bytes.NewReader(createDeflateValidData()))
-	wrapper, err := acquireDeflateReader(validData)
+	wrapper, err := acquireDeflateReader(validData, validData)
 	assertNil(t, err)
 	assertNotNil(t, wrapper)
 
@@ -507,7 +509,7 @@ func TestDeflateReaderPoolConcurrentAccess(t *testing.T) {
 			for range numOperations {
 				// Create fresh data for each operation
 				validData := io.NopCloser(bytes.NewReader(createDeflateValidData()))
-				wrapper, err := acquireDeflateReader(validData)
+				wrapper, err := acquireDeflateReader(validData, validData)
 				assertNil(t, err)
 				assertNotNil(t, wrapper)
 
@@ -657,4 +659,68 @@ func TestStreamMisc(t *testing.T) {
 		assertEqual(t, 0, n)
 
 	})
+}
+
+// RFC 9110 section 8.4.1.2 defines the "deflate" content coding as a zlib
+// stream (RFC 1950) wrapping deflate-compressed data (RFC 1951). Resty
+// advertises deflate but decoded with compress/flate, so a conforming server's
+// response failed to decode -- and readAll mapped the resulting
+// io.ErrUnexpectedEOF to nil, surfacing a 200 with an empty body.
+func TestDecompressDeflateAcceptsZlibAndRawStreams(t *testing.T) {
+	const payload = `{"hello":"world"}`
+
+	var zlibFramed bytes.Buffer
+	zw := zlib.NewWriter(&zlibFramed)
+	_, _ = zw.Write([]byte(payload))
+	assertNil(t, zw.Close())
+
+	var rawFramed bytes.Buffer
+	fw, err := flate.NewWriter(&rawFramed, flate.DefaultCompression)
+	assertNil(t, err)
+	_, _ = fw.Write([]byte(payload))
+	assertNil(t, fw.Close())
+
+	for _, tc := range []struct {
+		name string
+		body []byte
+	}{
+		{"zlib framed, per RFC 9110", zlibFramed.Bytes()},
+		{"raw deflate, as many servers send", rawFramed.Bytes()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Encoding", "deflate")
+				w.Header().Set(hdrContentTypeKey, "application/json")
+				_, _ = w.Write(tc.body)
+			}))
+			defer ts.Close()
+
+			c := dcnl().SetBaseURL(ts.URL)
+			defer c.Close()
+
+			res, err := c.R().Get("/")
+			assertError(t, err)
+			assertEqual(t, http.StatusOK, res.StatusCode())
+			assertEqual(t, payload, res.String())
+		})
+	}
+}
+
+func TestIsZlibWrapped(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		in     []byte
+		expect bool
+	}{
+		{"zlib default compression", []byte{0x78, 0x9c}, true},
+		{"zlib best compression", []byte{0x78, 0xda}, true},
+		{"raw deflate block", []byte{0x00, 0x01}, false},
+		{"wrong compression method", []byte{0x71, 0x9c}, false},
+		{"too short to tell", []byte{0x78}, false},
+		{"empty", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assertEqual(t, tc.expect, isZlibWrapped(bufio.NewReader(bytes.NewReader(tc.in))))
+		})
+	}
 }


### PR DESCRIPTION
> **Depends on #1208.** Stacked on it because both touch `middleware.go`/`stream.go` and their tests. Until #1208 merges this PR shows both commits; afterwards the diff collapses to just this one. Happy to reorder.

Three independent defects, each with a regression test.

## 1. `Content-Encoding: deflate` was decoded as a raw DEFLATE stream

RFC 9110 §8.4.1.2 defines the `deflate` content coding as **a zlib stream (RFC 1950) wrapping deflate-compressed data (RFC 1951)**. Resty advertises `deflate` in every request (`Accept-Encoding: gzip, deflate`) but decoded with `compress/flate`, which expects a bare RFC 1951 stream with no zlib header. A conforming server's response could not be read.

The failure was silent, which is what makes it serious: `Response.readAll` maps `io.ErrUnexpectedEOF` to nil, so the caller saw a successful 200 with an empty body rather than an error.

```
client advertised Accept-Encoding: "gzip, deflate"
original payload : {"hello":"world"}
err              : <nil>
status           : 200
body received    : ""              <- before
body received    : {"hello":"world"} <- after
```

`decompressDeflate` now sniffs the two-byte zlib header and picks `compress/zlib` or `compress/flate` accordingly, so both framings work. `net/http` never hits this because it only ever advertises `gzip`.

One subtlety worth flagging for review: `zlib.Resetter` and `flate.Resetter` have identical method sets, so a type assertion cannot tell the two readers apart. The wrapper tracks provenance with an explicit field instead — pooling a zlib reader in `flateReaderPool` breaks every later raw-deflate stream, which showed up as an order-dependent failure under `-shuffle=on`.

## 2. Multipart part headers dropped the standard library's CR/LF escaping

`mime/multipart` writes part headers with `fmt.Fprintf` and no validation, which is exactly why its escaper percent-encodes CR and LF. Resty's `escapeQuotes` is a fork of that escaper with those two replacements removed:

```go
resty:  strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
stdlib: strings.NewReplacer("\\", "\\\\", `"`, "\\\"", "\r", "%0D", "\n", "%0A")
```

So an attacker-controlled `MultipartField.Name`, `FileName` or `ContentType` — set via `SetMultipartField`, `SetFileReader` or `SetMultipartFields` — could inject part headers, terminate the part early, or forge an additional part when the boundary is predictable (i.e. the application calls `SetMultipartBoundary`). Header injection into the existing part works regardless of boundary secrecy.

Restored to match the standard library. The added test drives a real `multipart.Reader` on the server side and asserts it sees exactly one part and no injected field.

## 3. Files named by `SetFile` were not reopened on retry

Resty opens `FilePath` itself and closes the handle after every attempt via `stopMultipart`, but left `MultipartField.Reader` pointing at the closed file. The retry then seeked it:

```
seek .testdata/text-file.txt: file already closed
```

so **any retry of a request built with `SetFile` was abandoned instead of retried**. The field now records that Resty owns the handle, drops it on close, and reopens it on reset.

`resetReader` also clears `tempBuf` — the head sniffed for content-type detection on the previous attempt — since the rewound reader supplies those bytes again and they would otherwise be sent twice. The test asserts each attempt's body contains the payload exactly once.

## Verification

`go test ./... -race -count=1 -shuffle=on` green. `gofmt`, `go vet` clean. Coverage unchanged at 99.9%.

Second of five stacked PRs from an audit of the v3 branch.
