### PR TITLE
fix: stop redirects and digest auth from handing credentials to other origins

### DIFF
--- a/client.go
+++ b/client.go
@@ -147,6 +147,13 @@ type (
 		TLSClientConfig() *tls.Config
 		SetTLSClientConfig(*tls.Config) error
 	}
+
+	// transportWrapper is implemented by the transports Resty layers over the
+	// client's own, so settings that need the underlying [http.Transport] can
+	// still reach it. See [httpTransportOf].
+	transportWrapper interface {
+		unwrap() http.RoundTripper
+	}
 )
 
 // TransportSettings struct is used to define custom dialer and transport
@@ -1765,10 +1772,10 @@ func (c *Client) SetTLSClientConfig(tlsConfig *tls.Config) *Client {
 		return c
 	}
 
-	// default standard transport handling
-	transport, ok := c.httpClient.Transport.(*http.Transport)
-	if !ok {
-		c.log.Errorf("SetTLSClientConfig: %v", ErrNotHttpTransportType)
+	// default standard transport handling, reached through any Resty wrapper
+	transport, err := httpTransportOf(c.httpClient.Transport)
+	if err != nil {
+		c.log.Errorf("SetTLSClientConfig: %v", err)
 		return c
 	}
 	transport.TLSClientConfig = tlsConfig
@@ -2132,8 +2139,27 @@ func (c *Client) SetResponseSaveToFile(save bool) *Client {
 func (c *Client) HTTPTransport() (*http.Transport, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	if transport, ok := c.httpClient.Transport.(*http.Transport); ok {
-		return transport, nil
+	return httpTransportOf(c.httpClient.Transport)
+}
+
+// maxTransportUnwrap bounds the wrapper chain httpTransportOf will walk, so a
+// custom [http.RoundTripper] that returns itself cannot spin forever.
+const maxTransportUnwrap = 8
+
+// httpTransportOf reaches the [http.Transport] underneath Resty's own transport
+// wrappers. [Client.SetDigestAuth] and [Client.SetHedging] replace the client
+// transport with a wrapper; without unwrapping here, every TLS, certificate and
+// proxy setter called afterwards would silently do nothing.
+func httpTransportOf(rt http.RoundTripper) (*http.Transport, error) {
+	for i := 0; rt != nil && i < maxTransportUnwrap; i++ {
+		if transport, ok := rt.(*http.Transport); ok {
+			return transport, nil
+		}
+		w, ok := rt.(transportWrapper)
+		if !ok {
+			break
+		}
+		rt = w.unwrap()
 	}
 	return nil, ErrNotHttpTransportType
 }
@@ -2738,9 +2764,9 @@ func (c *Client) tlsConfig() (*tls.Config, error) {
 		return tc.TLSClientConfig(), nil
 	}
 
-	transport, ok := c.httpClient.Transport.(*http.Transport)
-	if !ok {
-		return nil, ErrNotHttpTransportType
+	transport, err := httpTransportOf(c.httpClient.Transport)
+	if err != nil {
+		return nil, err
 	}
 
 	if transport.TLSClientConfig == nil {

--- a/client.go
+++ b/client.go
@@ -323,10 +323,27 @@ func (c *Client) SetLoadBalancer(b LoadBalancer) *Client {
 }
 
 // Header method returns the headers from the client instance.
+//
+// The returned value is a snapshot; mutating it does not affect the client, and
+// the client may be modified concurrently without disturbing it.
 func (c *Client) Header() http.Header {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.header
+	return c.header.Clone()
+}
+
+// mergeHeaderInto copies the client headers into dst, skipping keys dst already
+// carries. The lock is held across the whole copy; [Client.Header] cannot be used
+// for this because the caller would iterate the snapshot after releasing it.
+func (c *Client) mergeHeaderInto(dst http.Header) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for k, v := range c.header {
+		if _, ok := dst[k]; ok {
+			continue
+		}
+		dst[k] = slices.Clone(v)
+	}
 }
 
 // SetHeader method sets a single header and its value in the client instance.
@@ -383,6 +400,36 @@ func (c *Client) SetHeaders(headers map[string]string) *Client {
 	defer c.lock.Unlock()
 	for h, v := range headers {
 		c.header.Set(h, v)
+	}
+	return c
+}
+
+// AddHeader method adds a single header and its value to the client instance,
+// keeping any values already present for that key.
+//
+// See [Client.SetHeader] to replace the existing values instead.
+//
+//	client.
+//		AddHeader("Accept", "text/html").
+//		AddHeader("Accept", "application/json")
+func (c *Client) AddHeader(header, value string) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.header.Add(header, value)
+	return c
+}
+
+// SetHeaderMultiValues method sets multiple headers along with their multiple
+// values from a map in the client instance.
+//
+// See [Request.SetHeaderMultiValues].
+//
+//	client.SetHeaderMultiValues(map[string][]string{
+//		"Accept": []string{"text/html", "application/xhtml+xml", "application/xml;q=0.9"},
+//	})
+func (c *Client) SetHeaderMultiValues(headers map[string][]string) *Client {
+	for key, values := range headers {
+		c.SetHeader(key, strings.Join(values, ", "))
 	}
 	return c
 }
@@ -459,10 +506,13 @@ func (c *Client) SetCookieJar(jar http.CookieJar) *Client {
 }
 
 // Cookies method returns all cookies registered in the client instance.
+//
+// The returned slice is a snapshot; appending to it does not affect the client.
+// The [http.Cookie] values themselves are shared and must not be mutated.
 func (c *Client) Cookies() []*http.Cookie {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.cookies
+	return slices.Clone(c.cookies)
 }
 
 // SetCookie method appends a single cookie to the client instance.
@@ -503,10 +553,27 @@ func (c *Client) SetCookies(cs []*http.Cookie) *Client {
 }
 
 // QueryParams method returns all query parameters and their values from the client instance.
+//
+// The returned value is a snapshot; mutating it does not affect the client, and
+// the client may be modified concurrently without disturbing it.
 func (c *Client) QueryParams() url.Values {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.queryParams
+	return cloneURLValues(c.queryParams)
+}
+
+// mergeQueryParamsInto copies the client query parameters into dst, skipping keys
+// dst already carries. See [Client.mergeHeaderInto] for why this is not built on
+// the public accessor.
+func (c *Client) mergeQueryParamsInto(dst url.Values) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for k, v := range c.queryParams {
+		if _, ok := dst[k]; ok {
+			continue
+		}
+		dst[k] = slices.Clone(v)
+	}
 }
 
 // SetQueryParam method sets a single parameter and its value in the client instance.
@@ -573,10 +640,61 @@ func (c *Client) SetQueryParams(params map[string]string) *Client {
 }
 
 // FormData method returns the form parameters and their values from the client instance.
+//
+// The returned value is a snapshot; mutating it does not affect the client, and
+// the client may be modified concurrently without disturbing it.
 func (c *Client) FormData() url.Values {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.formData
+	return cloneURLValues(c.formData)
+}
+
+// mergeFormDataInto copies the client form data into dst, skipping keys dst
+// already carries. See [Client.mergeHeaderInto] for why this is not built on the
+// public accessor.
+func (c *Client) mergeFormDataInto(dst url.Values) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for k, v := range c.formData {
+		if _, ok := dst[k]; ok {
+			continue
+		}
+		dst[k] = slices.Clone(v)
+	}
+}
+
+// AddQueryParam method adds a single query parameter and its value to the client
+// instance, keeping any values already present for that key.
+//
+// See [Client.SetQueryParam] to replace the existing values instead.
+//
+//	client.
+//		AddQueryParam("status", "pending").
+//		AddQueryParam("status", "approved")
+func (c *Client) AddQueryParam(param, value string) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.queryParams.Add(param, value)
+	return c
+}
+
+// SetQueryParamsFromValues method sets multiple query parameters with multiple
+// values from [url.Values] in the client instance.
+//
+// See [Request.SetQueryParamsFromValues].
+//
+//	client.SetQueryParamsFromValues(url.Values{
+//		"status": []string{"pending", "approved", "open"},
+//	})
+func (c *Client) SetQueryParamsFromValues(params url.Values) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for p, v := range params {
+		for _, pv := range v {
+			c.queryParams.Add(p, pv)
+		}
+	}
+	return c
 }
 
 // SetFormData method sets Form parameters and their values in the client instance.
@@ -595,6 +713,25 @@ func (c *Client) SetFormData(data map[string]string) *Client {
 	defer c.lock.Unlock()
 	for k, v := range data {
 		c.formData.Set(k, v)
+	}
+	return c
+}
+
+// SetFormDataFromValues method sets multiple form parameters with multiple values
+// from [url.Values] in the client instance.
+//
+// See [Request.SetFormDataFromValues].
+//
+//	client.SetFormDataFromValues(url.Values{
+//		"search_criteria": []string{"book", "glass", "pencil"},
+//	})
+func (c *Client) SetFormDataFromValues(data url.Values) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for k, v := range data {
+		for _, kv := range v {
+			c.formData.Add(k, kv)
+		}
 	}
 	return c
 }
@@ -1039,7 +1176,7 @@ func (c *Client) inferContentTypeDecoder(ct ...string) (ContentTypeDecoder, bool
 func (c *Client) ContentDecompressers() map[string]ContentDecompresser {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.contentDecompressers
+	return maps.Clone(c.contentDecompressers)
 }
 
 // AddContentDecompresser method adds a Content-Encoding ([RFC 9110]) decompresser
@@ -1491,7 +1628,7 @@ func (c *Client) SetRetryAllowNonIdempotent(b bool) *Client {
 func (c *Client) RetryConditions() []RetryConditionFunc {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.retryConditions
+	return slices.Clone(c.retryConditions)
 }
 
 // AddRetryConditions method adds one or more retry condition functions to the client.
@@ -1517,7 +1654,7 @@ func (c *Client) AddRetryConditions(conditions ...RetryConditionFunc) *Client {
 func (c *Client) RetryHooks() []RetryHookFunc {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.retryHooks
+	return slices.Clone(c.retryHooks)
 }
 
 // AddRetryHooks method appends one or more retry hook functions to the client;
@@ -2079,10 +2216,27 @@ func (c *Client) SetResponseDoNotParse(notParse bool) *Client {
 }
 
 // PathParams method returns the path parameters set on the client.
+//
+// The returned value is a snapshot; mutating it does not affect the client, and
+// the client may be modified concurrently without disturbing it.
 func (c *Client) PathParams() map[string]string {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.pathParams
+	return maps.Clone(c.pathParams)
+}
+
+// mergePathParamsInto copies the client path parameters into dst, skipping keys
+// dst already carries. See [Client.mergeHeaderInto] for why this is not built on
+// the public accessor.
+func (c *Client) mergePathParamsInto(dst map[string]string) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for k, v := range c.pathParams {
+		if _, ok := dst[k]; ok {
+			continue
+		}
+		dst[k] = v
+	}
 }
 
 // SetPathParam method sets a single URL path key-value pair in the

--- a/client_test.go
+++ b/client_test.go
@@ -1794,3 +1794,123 @@ func TestClientHedgingMutualExclusionWithRetry(t *testing.T) {
 	assertEqual(t, false, c.isHedgingEnabled())
 	assertEqual(t, 1, c.RetryCount()) // Retry count should remain
 }
+
+// Client.Header, QueryParams, FormData, PathParams and Cookies used to return the
+// live maps and slices, so request middleware iterated them after the read lock
+// had been released. Mutating the client concurrently was then a data race that
+// could escalate to an uncatchable "concurrent map read and map write".
+func TestClientAccessorsReturnSnapshots(t *testing.T) {
+	c := dcnl()
+	defer c.Close()
+
+	c.SetHeader("X-Snap", "one")
+	c.SetQueryParam("q", "one")
+	c.SetFormData(map[string]string{"f": "one"})
+	c.SetPathParam("p", "one")
+	c.SetCookie(&http.Cookie{Name: "c", Value: "one"})
+
+	// mutating what the accessors hand back must not reach the client
+	c.Header().Set("X-Snap", "mutated")
+	c.Header().Set("X-Added", "nope")
+	c.QueryParams().Set("q", "mutated")
+	c.FormData().Set("f", "mutated")
+	c.PathParams()["p"] = "mutated"
+	cookies := c.Cookies()
+	cookies = append(cookies, &http.Cookie{Name: "extra", Value: "nope"})
+	_ = cookies
+
+	assertEqual(t, "one", c.Header().Get("X-Snap"))
+	assertEqual(t, "", c.Header().Get("X-Added"))
+	assertEqual(t, "one", c.QueryParams().Get("q"))
+	assertEqual(t, "one", c.FormData().Get("f"))
+	assertEqual(t, "one", c.PathParams()["p"])
+	assertEqual(t, 1, len(c.Cookies()))
+
+	// the slice-returning accessors are snapshots too
+	assertEqual(t, 0, len(c.RetryConditions()))
+	c.AddRetryConditions(func(_ *Response, _ error) bool { return false })
+	rc := c.RetryConditions()
+	assertEqual(t, 1, len(rc))
+	rc = append(rc, func(_ *Response, _ error) bool { return true })
+	assertEqual(t, 2, len(rc))
+	assertEqual(t, 1, len(c.RetryConditions()))
+
+	assertEqual(t, 0, len(c.RetryHooks()))
+	c.AddRetryHooks(func(_ *Response, _ error) {})
+	assertEqual(t, 1, len(c.RetryHooks()))
+
+	decompressers := c.ContentDecompressers()
+	decompressers["bogus"] = nil
+	_, found := c.ContentDecompressers()["bogus"]
+	assertEqual(t, false, found)
+}
+
+// Mutating a client while requests are in flight is documented as safe. It used
+// to race against the middleware that merges client values into each request.
+func TestClientMutationDuringRequestsIsRaceFree(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	c := dcnl().SetBaseURL(ts.URL)
+	defer c.Close()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() { // e.g. a token-refresh goroutine
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			c.SetHeader("Authorization", fmt.Sprintf("Bearer %d", i))
+			c.SetQueryParam("v", strconv.Itoa(i))
+			c.SetPathParam("p", strconv.Itoa(i))
+			c.SetFormData(map[string]string{"f": strconv.Itoa(i)})
+		}
+	}()
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 25; j++ {
+				res, err := c.R().Get("/")
+				if err == nil {
+					_ = res.StatusCode()
+				}
+			}
+		}()
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+// Client had no multi-value setters, so Header().Add() on the live map was the
+// only way to reach them. The accessors now return snapshots, so these exist.
+func TestClientMultiValueSetters(t *testing.T) {
+	c := dcnl()
+	defer c.Close()
+
+	c.AddHeader("X-Multi", "one").AddHeader("X-Multi", "two")
+	assertEqual(t, 2, len(c.Header()["X-Multi"]))
+
+	c.SetHeaderMultiValues(map[string][]string{
+		"Accept": {"text/html", "application/json"},
+	})
+	assertEqual(t, "text/html, application/json", c.Header().Get("Accept"))
+
+	c.AddQueryParam("status", "pending").AddQueryParam("status", "approved")
+	assertEqual(t, 2, len(c.QueryParams()["status"]))
+
+	c.SetQueryParamsFromValues(url.Values{"tag": {"a", "b", "c"}})
+	assertEqual(t, 3, len(c.QueryParams()["tag"]))
+
+	c.SetFormDataFromValues(url.Values{"criteria": {"book", "glass"}})
+	assertEqual(t, 2, len(c.FormData()["criteria"]))
+}

--- a/client_test.go
+++ b/client_test.go
@@ -237,7 +237,7 @@ func TestCheckHostAndAddHeadersCrossDomainStrip(t *testing.T) {
 
 		cur, _ := http.NewRequest(http.MethodGet, "https://example.com/other", nil)
 
-		checkHostAndAddHeaders(cur, pre)
+		checkHostAndAddHeaders(cur, []*http.Request{pre})
 
 		assertEqual(t, "Bearer secret", cur.Header.Get("Authorization"))
 		assertEqual(t, "my-api-key", cur.Header.Get("X-Api-Key"))
@@ -259,7 +259,7 @@ func TestCheckHostAndAddHeadersCrossDomainStrip(t *testing.T) {
 		cur.Header.Set("X-My-Secret", "secret-value")
 		cur.Header.Set("X-Safe-Header", "safe")
 
-		checkHostAndAddHeaders(cur, pre)
+		checkHostAndAddHeaders(cur, []*http.Request{pre})
 
 		// Sensitive headers must be stripped
 		assertEqual(t, "", cur.Header.Get("X-Api-Key"))
@@ -283,7 +283,7 @@ func TestCheckHostAndAddHeadersCrossDomainStrip(t *testing.T) {
 		cur.Header.Set("X-Corp-Access-Token", "Bearer CORP_SECRET_123")
 		cur.Header.Set("Content-Type", "application/json")
 
-		checkHostAndAddHeaders(cur, pre)
+		checkHostAndAddHeaders(cur, []*http.Request{pre})
 
 		// Custom auth header must be stripped (contains "token")
 		assertEqual(t, "", cur.Header.Get("X-Corp-Access-Token"))
@@ -297,7 +297,7 @@ func TestCheckHostAndAddHeadersCrossDomainStrip(t *testing.T) {
 
 		cur, _ := http.NewRequest(http.MethodGet, "https://example.com/other", nil)
 
-		checkHostAndAddHeaders(cur, pre)
+		checkHostAndAddHeaders(cur, []*http.Request{pre})
 
 		// Same host (case insensitive) → headers copied, not stripped
 		assertEqual(t, "key", cur.Header.Get("X-Api-Key"))
@@ -1913,4 +1913,59 @@ func TestClientMultiValueSetters(t *testing.T) {
 
 	c.SetFormDataFromValues(url.Values{"criteria": {"book", "glass"}})
 	assertEqual(t, 2, len(c.FormData()["criteria"]))
+}
+
+// SetDigestAuth and SetHedging replace the client transport with a wrapper.
+// Every TLS, certificate and proxy setter called afterwards used to log an error
+// and silently do nothing, so an application that believed it had pinned a CA or
+// required TLS 1.3 got neither.
+func TestTransportSettersReachThroughWrappers(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		wrap func(*Client)
+	}{
+		{"no wrapper", func(c *Client) {}},
+		{"digest transport", func(c *Client) { c.SetDigestAuth("u", "p") }},
+		{"hedging transport", func(c *Client) { c.SetHedging(NewHedging()) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := dcnl()
+			defer c.Close()
+			tc.wrap(c)
+
+			c.SetTLSClientConfig(&tls.Config{MinVersion: tls.VersionTLS13})
+			c.SetProxy("http://127.0.0.1:9999")
+
+			transport, err := c.HTTPTransport()
+			assertNil(t, err)
+			assertNotNil(t, transport.TLSClientConfig)
+			assertEqual(t, uint16(tls.VersionTLS13), transport.TLSClientConfig.MinVersion)
+			assertNotNil(t, transport.Proxy)
+			assertEqual(t, "http://127.0.0.1:9999", c.ProxyURL().String())
+
+			cfg, err := c.tlsConfig()
+			assertNil(t, err)
+			assertEqual(t, uint16(tls.VersionTLS13), cfg.MinVersion)
+		})
+	}
+}
+
+type selfWrappingTransport struct{}
+
+func (s *selfWrappingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, nil
+}
+func (s *selfWrappingTransport) unwrap() http.RoundTripper { return s }
+
+func TestHTTPTransportOfBoundsWrapperChain(t *testing.T) {
+	// a wrapper that returns itself must terminate rather than spin
+	_, err := httpTransportOf(&selfWrappingTransport{})
+	assertErrorIs(t, ErrNotHttpTransportType, err)
+
+	// a plain non-wrapper round tripper is also an error
+	_, err = httpTransportOf(http.NewFileTransport(http.Dir(".")))
+	assertErrorIs(t, ErrNotHttpTransportType, err)
+
+	_, err = httpTransportOf(nil)
+	assertErrorIs(t, ErrNotHttpTransportType, err)
 }

--- a/digest.go
+++ b/digest.go
@@ -19,6 +19,7 @@ import (
 	"hash"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -67,6 +68,21 @@ type digestTransport struct {
 	transport http.RoundTripper
 }
 
+// unwrap implements [transportWrapper] so Resty's TLS, certificate and proxy
+// setters still reach the real transport after [Client.SetDigestAuth].
+func (dt *digestTransport) unwrap() http.RoundTripper { return dt.transport }
+
+// originatingURL walks back to the URL the caller actually requested. net/http
+// sets Request.Response on a redirected request, and that response's Request is
+// the previous hop.
+func originatingURL(req *http.Request) *url.URL {
+	u := req.URL
+	for res := req.Response; res != nil && res.Request != nil; res = res.Request.Response {
+		u = res.Request.URL
+	}
+	return u
+}
+
 func (dt *digestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// first request without body for all HTTP verbs
 	req1 := dt.cloneReq(req, true)
@@ -77,6 +93,13 @@ func (dt *digestTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		return nil, err
 	}
 	if res.StatusCode != http.StatusUnauthorized {
+		return res, nil
+	}
+	// Never answer a challenge from an origin the caller did not address. The
+	// transport runs on every redirect hop, so without this a redirect to an
+	// attacker-controlled host yields the username in cleartext plus a digest
+	// over a realm and nonce that host chose (compare curl CVE-2022-27774).
+	if !sameOrigin(req.URL, originatingURL(req)) {
 		return res, nil
 	}
 	_, _ = ioCopy(io.Discard, res.Body)

--- a/digest_test.go
+++ b/digest_test.go
@@ -426,3 +426,73 @@ func TestClientDigestAuthQopListWithSpaces(t *testing.T) {
 	assertNil(t, err)
 	assertEqual(t, http.StatusOK, res.StatusCode())
 }
+
+// digestTransport runs on every redirect hop, so a redirect to a host the caller
+// never addressed used to be answered with the configured credentials: the
+// username in cleartext plus a digest over a realm and nonce that host chose.
+// Compare curl CVE-2022-27774.
+func TestDigestDoesNotAuthenticateToRedirectTarget(t *testing.T) {
+	var attackerGotAuth string
+	var attackerHits int
+	attacker := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		attackerHits++
+		attackerGotAuth = r.Header.Get("Authorization")
+		w.Header().Set("WWW-Authenticate",
+			`Digest realm="attacker-realm", nonce="attacker-nonce", qop="auth"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	defer attacker.Close()
+
+	origin := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+"/x", http.StatusFound)
+	})
+	defer origin.Close()
+
+	c := dcnl().SetDigestAuth("victim-user", "victim-pass")
+	defer c.Close()
+
+	res, err := c.R().Get(origin.URL + "/start")
+	assertError(t, err)
+
+	// the attacker sees the unauthenticated probe only, and gets no credentials
+	assertEqual(t, 1, attackerHits)
+	assertEqual(t, "", attackerGotAuth)
+	assertEqual(t, http.StatusUnauthorized, res.StatusCode())
+}
+
+// A same-origin challenge must still be answered.
+func TestDigestAuthenticatesOnSameOriginRedirect(t *testing.T) {
+	var authed bool
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/start" {
+			http.Redirect(w, r, "/protected", http.StatusFound)
+			return
+		}
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate",
+				`Digest realm="test", nonce="abc", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		authed = true
+		w.WriteHeader(http.StatusOK)
+	})
+	defer ts.Close()
+
+	c := dcnl().SetDigestAuth("user", "pass")
+	defer c.Close()
+
+	res, err := c.R().Get(ts.URL + "/start")
+	assertError(t, err)
+	assertEqual(t, true, authed)
+	assertEqual(t, http.StatusOK, res.StatusCode())
+}
+
+func TestOriginatingURL(t *testing.T) {
+	first := mustReq(t, http.MethodGet, "https://origin.example/start")
+	second := mustReq(t, http.MethodGet, "https://evil.example/x")
+	second.Response = &http.Response{Request: first}
+
+	assertEqual(t, "https://origin.example/start", originatingURL(second).String())
+	assertEqual(t, "https://origin.example/start", originatingURL(first).String())
+}

--- a/hedging.go
+++ b/hedging.go
@@ -95,6 +95,14 @@ type Hedging struct {
 	isNonReadOnlyAllowed bool
 }
 
+// unwrap implements [transportWrapper] so Resty's TLS, certificate and proxy
+// setters still reach the real transport after [Client.SetHedging].
+func (h *Hedging) unwrap() http.RoundTripper {
+	h.lock.RLock()
+	defer h.lock.RUnlock()
+	return h.underlying
+}
+
 // SetTransport sets the underlying HTTP transport that [Hedging] delegates
 // individual requests to.
 func (h *Hedging) SetTransport(t http.RoundTripper) {

--- a/middleware.go
+++ b/middleware.go
@@ -18,7 +18,6 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
-	"slices"
 	"strings"
 )
 
@@ -61,15 +60,9 @@ func MiddlewareRequestCreate(c *Client, r *Request) (err error) {
 }
 
 func parseRequestURL(c *Client, r *Request) error {
-	if len(c.PathParams())+len(r.PathParams) > 0 {
-		// GitHub #103 Path Params, #663 Raw Path Params
-		for p, v := range c.PathParams() {
-			if _, ok := r.PathParams[p]; ok {
-				continue
-			}
-			r.PathParams[p] = v
-		}
-
+	// GitHub #103 Path Params, #663 Raw Path Params
+	c.mergePathParamsInto(r.PathParams)
+	if len(r.PathParams) > 0 {
 		var prev int
 		buf := acquireBuffer()
 		defer releaseBuffer(buf)
@@ -158,14 +151,8 @@ func parseRequestURL(c *Client, r *Request) error {
 	}
 
 	// Adding Query Param
-	if len(c.QueryParams())+len(r.QueryParams) > 0 {
-		for k, v := range c.QueryParams() {
-			if _, ok := r.QueryParams[k]; ok {
-				continue
-			}
-			r.QueryParams[k] = slices.Clone(v)
-		}
-
+	c.mergeQueryParamsInto(r.QueryParams)
+	if len(r.QueryParams) > 0 {
 		// GitHub #123 Preserve query string order partially.
 		// Since not feasible in `SetQuery*` resty methods, because
 		// standard package `url.Encode(...)` sorts the query params
@@ -192,12 +179,7 @@ func parseRequestURL(c *Client, r *Request) error {
 }
 
 func parseRequestHeader(c *Client, r *Request) {
-	for k, v := range c.Header() {
-		if _, ok := r.Header[k]; ok {
-			continue
-		}
-		r.Header[k] = slices.Clone(v)
-	}
+	c.mergeHeaderInto(r.Header)
 
 	if !r.isHeaderExists(hdrUserAgentKey) {
 		r.Header.Set(hdrUserAgentKey, hdrUserAgentValue)
@@ -350,12 +332,7 @@ func handleMultipartFormData(r *Request) error {
 }
 
 func handleMultipart(c *Client, r *Request) error {
-	for k, v := range c.FormData() {
-		if _, ok := r.FormData[k]; ok {
-			continue
-		}
-		r.FormData[k] = slices.Clone(v)
-	}
+	c.mergeFormDataInto(r.FormData)
 
 	if len(r.multipartFields) == 0 {
 		return handleMultipartFormData(r)
@@ -448,12 +425,7 @@ func handleMultipart(c *Client, r *Request) error {
 }
 
 func handleFormData(c *Client, r *Request) {
-	for k, v := range c.FormData() {
-		if _, ok := r.FormData[k]; ok {
-			continue
-		}
-		r.FormData[k] = slices.Clone(v)
-	}
+	c.mergeFormDataInto(r.FormData)
 
 	r.bodyBuf = acquireBuffer()
 	r.bodyBuf.WriteString(r.FormData.Encode())
@@ -590,6 +562,17 @@ func MiddlewareResponseAutoParse(c *Client, res *Response) (err error) {
 		}
 	}
 
+	// A decoder exists, but no result object was registered for this status code,
+	// so nothing above consumed the body. Read it here: leaving it open holds the
+	// connection out of the keep-alive pool for the life of the process, and it
+	// keeps [Response.String] and [Response.Bytes] working on this path.
+	//
+	// The exception is a save-to-file response, whose body belongs to
+	// [MiddlewareResponseSaveToFile] further down the chain; buffering it here
+	// would hold the whole download in memory.
+	if !res.Request.IsResponseSaveToFile {
+		err = res.readAll()
+	}
 	return
 }
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -12,7 +12,9 @@ import (
 	"io"
 	"mime"
 	"mime/multipart"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/textproto"
 	"net/url"
 	"os"
@@ -20,6 +22,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -1417,11 +1420,11 @@ func TestClientValuesAreNotAliasedIntoRequests(t *testing.T) {
 	// Set then two Adds leaves len 3 in a cap 4 array: one spare slot, which is
 	// where a request's own Add would write.
 	c.SetHeader("X-Multi", "one")
-	c.Header().Add("X-Multi", "two")
-	c.Header().Add("X-Multi", "three")
+	c.AddHeader("X-Multi", "two")
+	c.AddHeader("X-Multi", "three")
 	c.SetQueryParam("tag", "a")
-	c.QueryParams().Add("tag", "b")
-	c.QueryParams().Add("tag", "c")
+	c.AddQueryParam("tag", "b")
+	c.AddQueryParam("tag", "c")
 
 	newRequest := func(path, marker string) *Request {
 		r := c.R()
@@ -1445,4 +1448,89 @@ func TestClientValuesAreNotAliasedIntoRequests(t *testing.T) {
 	// and the client itself must be untouched
 	assertEqual(t, 3, len(c.Header()["X-Multi"]))
 	assertEqual(t, 3, len(c.QueryParams()["tag"]))
+}
+
+// MiddlewareResponseAutoParse used to return without reading or closing the body
+// when a content-type decoder matched but the caller registered no Result (2xx)
+// or ResultError (4xx/5xx). The connection was then never returned to the
+// keep-alive pool, so every such request opened a fresh one.
+func TestAutoParseReleasesBodyWithoutResult(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		contentType string
+		body        string
+		statusCode  int
+		setResult   bool
+		setErr      bool
+	}{
+		{"json 200 without result", "application/json", `{"a":1}`, http.StatusOK, false, false},
+		{"json 200 with result", "application/json", `{"a":1}`, http.StatusOK, true, false},
+		{"json 500 without result error", "application/json", `{"a":1}`, http.StatusInternalServerError, false, false},
+		{"xml 200 without result", "application/xml", `<r><a>1</a></r>`, http.StatusOK, false, false},
+		{"no decoder for content type", "text/plain", `hello`, http.StatusOK, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var conns int32
+			ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set(hdrContentTypeKey, tc.contentType)
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			ts.Config.ConnState = func(_ net.Conn, s http.ConnState) {
+				if s == http.StateNew {
+					atomic.AddInt32(&conns, 1)
+				}
+			}
+			ts.Start()
+			defer ts.Close()
+
+			c := dcnl().SetBaseURL(ts.URL)
+			defer c.Close()
+
+			for i := 0; i < 5; i++ {
+				req := c.R()
+				if tc.setResult {
+					req.SetResult(&map[string]any{})
+				}
+				if tc.setErr {
+					req.SetResultError(&map[string]any{})
+				}
+				res, err := req.Get("/")
+				assertError(t, err)
+				assertEqual(t, tc.statusCode, res.StatusCode())
+				if !tc.setResult && !tc.setErr {
+					// nothing decoded it, so the body must still reach the caller
+					assertEqual(t, tc.body, res.String())
+				}
+			}
+
+			// one connection, reused for all five requests
+			assertEqual(t, int32(1), atomic.LoadInt32(&conns))
+		})
+	}
+}
+
+// A save-to-file response body belongs to MiddlewareResponseSaveToFile, so
+// AutoParse must not buffer it even though a decoder matches its content type.
+func TestAutoParseDoesNotBufferSaveToFileBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(hdrContentTypeKey, "application/json")
+		_, _ = w.Write([]byte(`{"a":1}`))
+	}))
+	defer ts.Close()
+
+	outputFile := filepath.Join(getTestDataPath(), "auto-parse-save.json")
+	defer cleanupFiles(outputFile)
+
+	c := dcnl().SetBaseURL(ts.URL)
+	defer c.Close()
+
+	res, err := c.R().SetResponseSaveFileName(outputFile).Get("/")
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, res.StatusCode())
+	assertEqual(t, false, res.IsRead)
+
+	b, err := os.ReadFile(outputFile)
+	assertError(t, err)
+	assertEqual(t, `{"a":1}`, string(b))
 }

--- a/multipart.go
+++ b/multipart.go
@@ -15,7 +15,11 @@ import (
 	"strings"
 )
 
-var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+// quoteEscaper matches mime/multipart's own escaper. CR and LF must be
+// percent-encoded: multipart part headers are written verbatim, so a newline in
+// a field name, filename or content type would otherwise inject headers or
+// terminate the part early.
+var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"", "\r", "%0D", "\n", "%0A")
 
 func escapeQuotes(s string) string {
 	return quoteEscaper.Replace(s)
@@ -61,6 +65,11 @@ type MultipartField struct {
 	// tempBuf is used to preserve the byte(s) read from the file to detect the content type.
 	// Or any possible read error early.
 	tempBuf []byte
+
+	// openedByResty records that Resty opened Reader itself from FilePath, so it
+	// owns the handle and may close and reopen it between retry attempts. A
+	// caller-supplied Reader is never reopened, only rewound.
+	openedByResty bool
 }
 
 // Clone returns a copy of m, except [MultipartField.Reader] which is shared.
@@ -71,6 +80,16 @@ func (mf *MultipartField) Clone() *MultipartField {
 }
 
 func (mf *MultipartField) resetReader() error {
+	// tempBuf holds the head sniffed for content-type detection on the previous
+	// attempt. The rewound reader supplies those bytes again, so drop it rather
+	// than writing them a second time.
+	mf.tempBuf = nil
+
+	// A file Resty opened is closed after every attempt, so seeking it would
+	// fail with "file already closed". Reopen it instead.
+	if mf.openedByResty && mf.Reader == nil {
+		return mf.openFile()
+	}
 	if rs, ok := mf.Reader.(io.ReadSeeker); ok {
 		_, err := rs.Seek(0, io.SeekStart)
 		return err
@@ -84,6 +103,11 @@ func (mf *MultipartField) isValues() bool {
 
 func (mf *MultipartField) close() {
 	closeq(mf.Reader)
+	if mf.openedByResty {
+		// Drop the closed handle so a retry reopens FilePath rather than
+		// seeking a file that is already closed.
+		mf.Reader = nil
+	}
 }
 
 func (mf *MultipartField) createHeader() textproto.MIMEHeader {
@@ -121,6 +145,7 @@ func (mf *MultipartField) openFile() error {
 
 	mf.Reader = file
 	mf.FileSize = fileStat.Size()
+	mf.openedByResty = true
 
 	return nil
 }

--- a/multipart_test.go
+++ b/multipart_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"io/fs"
 	"mime/multipart"
 	"net/http"
@@ -754,4 +755,114 @@ func TestRetryNonSeekableReaderWithoutFactoryReturnsError(t *testing.T) {
 
 	assertErrorIs(t, ErrReaderNotSeekable, err)
 	assertEqual(t, 1, attemptCount)
+}
+
+// Resty opens files named by SetFile itself and closes them after every attempt,
+// so a retry used to seek an already-closed handle and abandon the request. The
+// sniffed content-type head must also be sent exactly once per attempt.
+func TestMultipartRetryResendsIdenticalFile(t *testing.T) {
+	var mu sync.Mutex
+	var bodies []string
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, string(body))
+		mu.Unlock()
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	defer ts.Close()
+
+	c := dcnl()
+	defer c.Close()
+
+	_, err := c.R().
+		SetRetryCount(1).
+		SetRetryWaitTime(time.Millisecond).
+		SetRetryMaxWaitTime(2*time.Millisecond).
+		SetRetryAllowNonIdempotent(true).
+		AddRetryConditions(func(res *Response, _ error) bool { return true }).
+		SetFile("file", filepath.Join(getTestDataPath(), "text-file.txt")).
+		Post(ts.URL)
+	assertNil(t, err)
+
+	const payload = "THIS IS TEXT FILE FOR MULTIPART UPLOAD TEST :)"
+
+	mu.Lock()
+	defer mu.Unlock()
+	assertEqual(t, 2, len(bodies))
+	for _, body := range bodies {
+		// exactly once: the sniffed head is neither dropped nor re-sent
+		assertEqual(t, 1, strings.Count(body, payload))
+		assertEqual(t, 1, strings.Count(body, "text-file.txt"))
+	}
+}
+
+// mime/multipart writes part headers verbatim, so CR and LF in a field name,
+// filename or content type must be percent-encoded. Resty's escaper was a fork
+// of the stdlib one with those two replacements dropped, which let an
+// attacker-controlled filename inject headers or forge an entire extra part.
+func TestEscapeQuotesEncodesCRLF(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		in     string
+		expect string
+	}{
+		{"carriage return", "a\rb", "a%0Db"},
+		{"line feed", "a\nb", "a%0Ab"},
+		{"crlf pair", "a\r\nb", "a%0D%0Ab"},
+		{"quote still escaped", `a"b`, `a\"b`},
+		{"backslash still escaped", `a\b`, `a\\b`},
+		{"plain text untouched", "report.pdf", "report.pdf"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assertEqual(t, tc.expect, escapeQuotes(tc.in))
+		})
+	}
+}
+
+func TestMultipartFileNameCannotInjectParts(t *testing.T) {
+	var gotRole string
+	var partCount int
+	var parseErr error
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		mr, err := r.MultipartReader()
+		if err != nil {
+			parseErr = err
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		for {
+			p, err := mr.NextPart()
+			if err != nil {
+				break
+			}
+			partCount++
+			if p.FormName() == "role" {
+				b, _ := io.ReadAll(p)
+				gotRole = string(b)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	defer ts.Close()
+
+	c := dcnl()
+	defer c.Close()
+
+	// A filename carrying a forged part boundary and an extra form field.
+	evil := "x.txt\"\r\n\r\nnot-a-part\r\n--BOUND\r\n" +
+		"Content-Disposition: form-data; name=\"role\"\r\n\r\nadmin\r\n--BOUND--\r\n"
+
+	res, err := c.R().
+		SetMultipartBoundary("BOUND").
+		SetFileReader("file", evil, strings.NewReader("real content")).
+		Post(ts.URL)
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, res.StatusCode())
+
+	// A real multipart parser must see exactly the one part Resty intended,
+	// and no injected "role" field.
+	assertNil(t, parseErr)
+	assertEqual(t, 1, partCount)
+	assertEqual(t, "", gotRole)
 }

--- a/redirect.go
+++ b/redirect.go
@@ -8,8 +8,9 @@ package resty
 import (
 	"errors"
 	"fmt"
-	"maps"
 	"net/http"
+	"net/url"
+	"slices"
 	"strings"
 )
 
@@ -60,7 +61,7 @@ func RedirectFlexiblePolicy(noOfRedirect int) RedirectPolicy {
 		if len(via) >= noOfRedirect {
 			return fmt.Errorf("resty: stopped after %d redirects", noOfRedirect)
 		}
-		checkHostAndAddHeaders(req, via[0])
+		checkHostAndAddHeaders(req, via)
 		return nil
 	})
 }
@@ -79,7 +80,7 @@ func RedirectDomainCheckPolicy(hostnames ...string) RedirectPolicy {
 		if ok := hosts[strings.ToLower(req.URL.Host)]; !ok {
 			return errors.New("resty: redirect is not allowed as per DomainCheckRedirectPolicy")
 		}
-		checkHostAndAddHeaders(req, via[0])
+		checkHostAndAddHeaders(req, via)
 		return nil
 	})
 }
@@ -123,29 +124,89 @@ func RedirectHeaderStripSensitivePolicy(applyDefault bool, headers ...string) Re
 	})
 }
 
+// redirectBodyHeaders describe the enclosed representation. RFC 9110 section 8.3
+// ties them to a request body, and net/http deliberately withholds them when a
+// 301, 302 or 303 turns a request with a body into a body-less GET, so they must
+// not be restored on a method change either.
+var redirectBodyHeaders = []string{
+	"Content-Type",
+	"Content-Encoding",
+	"Content-Language",
+	"Content-Location",
+}
+
+// sameOrigin reports whether two URLs share a scheme and a host. Host alone is
+// not enough: the default port is elided, so an https to http downgrade of the
+// same hostname compares equal on Host and would look like a same-origin hop.
+func sameOrigin(a, b *url.URL) bool {
+	return strings.EqualFold(a.Scheme, b.Scheme) && strings.EqualFold(a.Host, b.Host)
+}
+
+// leftOrigin reports whether any hop so far targeted an origin other than the
+// one the chain started at.
+func leftOrigin(via []*http.Request) bool {
+	for _, r := range via[1:] {
+		if !sameOrigin(r.URL, via[0].URL) {
+			return true
+		}
+	}
+	return false
+}
+
 // By default, Golang will not redirect request headers.
 // After reading through the various discussion comments from the thread -
 // https://github.com/golang/go/issues/4800
 // Resty will add all the headers during a redirect for the same host and
 // adds library user-agent if the Host is different.
 //
-// For cross-domain redirects, sensitive headers (matching [isSanitizeHeader])
+// For cross-origin redirects, sensitive headers (matching [isSanitizeHeader])
 // are stripped from the redirected request. Go's net/http only strips standard
 // headers such as Authorization and Cookie; custom authentication headers
 // (e.g. those set via [Client.SetHeaderAuthorizationKey]) are forwarded
 // verbatim unless explicitly removed. See https://github.com/go-resty/resty/issues/1128.
-func checkHostAndAddHeaders(cur *http.Request, pre *http.Request) {
-	curHostname := strings.ToLower(cur.URL.Host)
-	preHostname := strings.ToLower(pre.URL.Host)
-	if strings.EqualFold(curHostname, preHostname) {
-		maps.Copy(cur.Header, pre.Header)
-	} else {
-		// Cross-domain redirect: strip sensitive headers that Go's
+//
+// Headers already present on the redirected request are never overwritten, and
+// three kinds are never restored from the original request:
+//
+//   - anything sensitive, once any hop in the chain has left the original
+//     origin. net/http sets its own strip flag once and never clears it, so a
+//     credential dropped at a foreign hop must stay dropped even if the chain
+//     returns to the original host.
+//   - [redirectBodyHeaders], when the redirect changed the method and therefore
+//     dropped the body.
+//   - anything on a hop whose scheme or host differs from the original.
+func checkHostAndAddHeaders(cur *http.Request, via []*http.Request) {
+	orig := via[0]
+
+	if !sameOrigin(cur.URL, orig.URL) {
+		// Cross-origin redirect: strip sensitive headers that Go's
 		// net/http does not know about (custom auth, token, api-key, etc.).
 		for key := range cur.Header {
 			if isSanitizeHeader(key) {
 				cur.Header.Del(key)
 			}
 		}
+		return
+	}
+
+	credentialsSpent := leftOrigin(via)
+	methodChanged := cur.Method != orig.Method
+
+	for key, value := range orig.Header {
+		// Never clobber what net/http or an earlier hop already set; that is how
+		// a Set-Cookie delivered with the redirect supersedes the original
+		// Cookie header (RFC 6265 section 5.3).
+		if _, ok := cur.Header[key]; ok {
+			continue
+		}
+		if credentialsSpent && isSanitizeHeader(key) {
+			continue
+		}
+		if methodChanged && slices.ContainsFunc(redirectBodyHeaders, func(h string) bool {
+			return strings.EqualFold(h, key)
+		}) {
+			continue
+		}
+		cur.Header[key] = slices.Clone(value)
 	}
 }

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2015-present Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
+// resty source code and usage is governed by a MIT style
+// license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package resty
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func mustReq(t *testing.T, method, rawURL string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(method, rawURL, nil)
+	assertNil(t, err)
+	return req
+}
+
+func TestSameOrigin(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		a, b   string
+		expect bool
+	}{
+		{"identical", "https://a.com/x", "https://a.com/y", true},
+		{"case-insensitive host", "https://A.com/x", "https://a.com/y", true},
+		{"scheme downgrade", "http://a.com/x", "https://a.com/y", false},
+		{"different host", "https://a.com/x", "https://b.com/y", false},
+		{"explicit port differs", "https://a.com:8443/x", "https://a.com/y", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			au, _ := url.Parse(tc.a)
+			bu, _ := url.Parse(tc.b)
+			assertEqual(t, tc.expect, sameOrigin(au, bu))
+		})
+	}
+}
+
+// An https -> http redirect keeps the same URL.Host, because the default port is
+// elided, so a host-only comparison treated the downgrade as same-origin and put
+// the caller's credentials on the wire in cleartext.
+func TestCheckHostAndAddHeadersSchemeDowngrade(t *testing.T) {
+	orig := mustReq(t, http.MethodGet, "https://example.com/api")
+	orig.Header.Set("Authorization", "Bearer secret")
+	orig.Header.Set("Cookie", "sid=secret")
+
+	cur := mustReq(t, http.MethodGet, "http://example.com/api")
+	checkHostAndAddHeaders(cur, []*http.Request{orig})
+
+	assertEqual(t, "", cur.Header.Get("Authorization"))
+	assertEqual(t, "", cur.Header.Get("Cookie"))
+}
+
+// net/http sets its strip flag once and never clears it, so a credential dropped
+// at a foreign hop must stay dropped even when the chain returns to the original
+// host. Resty compared only against via[0] and copied the originals back.
+func TestCheckHostAndAddHeadersDoesNotResurrectCredentials(t *testing.T) {
+	orig := mustReq(t, http.MethodGet, "https://example.com/api")
+	orig.Header.Set("Authorization", "Bearer secret")
+	orig.Header.Set("X-Api-Key", "key")
+	orig.Header.Set("X-Safe", "safe")
+
+	attacker := mustReq(t, http.MethodGet, "https://evil.example.net/x")
+	cur := mustReq(t, http.MethodGet, "https://example.com/back")
+
+	checkHostAndAddHeaders(cur, []*http.Request{orig, attacker})
+
+	assertEqual(t, "", cur.Header.Get("Authorization"))
+	assertEqual(t, "", cur.Header.Get("X-Api-Key"))
+	// non-sensitive headers are still restored
+	assertEqual(t, "safe", cur.Header.Get("X-Safe"))
+}
+
+// A chain that never leaves the origin still gets its headers restored.
+func TestCheckHostAndAddHeadersSameOriginChain(t *testing.T) {
+	orig := mustReq(t, http.MethodGet, "https://example.com/api")
+	orig.Header.Set("Authorization", "Bearer secret")
+
+	hop := mustReq(t, http.MethodGet, "https://example.com/hop")
+	cur := mustReq(t, http.MethodGet, "https://example.com/final")
+
+	checkHostAndAddHeaders(cur, []*http.Request{orig, hop})
+	assertEqual(t, "Bearer secret", cur.Header.Get("Authorization"))
+}
+
+// RFC 9110 section 8.3: Content-Type describes the enclosed representation, and
+// a 301/302/303 that rewrites POST to GET drops the body. net/http withholds the
+// body headers accordingly; Resty copied them back.
+func TestCheckHostAndAddHeadersDropsBodyHeadersOnMethodChange(t *testing.T) {
+	orig := mustReq(t, http.MethodPost, "https://example.com/api")
+	orig.Header.Set("Content-Type", "application/json")
+	orig.Header.Set("Content-Language", "en")
+	orig.Header.Set("X-Trace", "abc")
+
+	cur := mustReq(t, http.MethodGet, "https://example.com/api")
+	checkHostAndAddHeaders(cur, []*http.Request{orig})
+
+	assertEqual(t, "", cur.Header.Get("Content-Type"))
+	assertEqual(t, "", cur.Header.Get("Content-Language"))
+	assertEqual(t, "abc", cur.Header.Get("X-Trace"))
+
+	// same method keeps them
+	cur2 := mustReq(t, http.MethodPost, "https://example.com/api")
+	checkHostAndAddHeaders(cur2, []*http.Request{orig})
+	assertEqual(t, "application/json", cur2.Header.Get("Content-Type"))
+}
+
+// RFC 6265 section 5.3: a cookie received with the redirect supersedes the one
+// the caller sent. maps.Copy overwrote the corrected header with the stale one,
+// so the request carried "sid=old; sid=new" and servers took the first match.
+func TestCheckHostAndAddHeadersDoesNotClobberExistingHeaders(t *testing.T) {
+	orig := mustReq(t, http.MethodGet, "https://example.com/api")
+	orig.Header.Set("Cookie", "sid=old")
+	orig.Header.Set("X-Only-On-Original", "yes")
+
+	cur := mustReq(t, http.MethodGet, "https://example.com/next")
+	cur.Header.Set("Cookie", "sid=new")
+
+	checkHostAndAddHeaders(cur, []*http.Request{orig})
+
+	assertEqual(t, "sid=new", cur.Header.Get("Cookie"))
+	assertEqual(t, 1, len(cur.Header["Cookie"]))
+	assertEqual(t, "yes", cur.Header.Get("X-Only-On-Original"))
+}

--- a/stream.go
+++ b/stream.go
@@ -6,9 +6,11 @@
 package resty
 
 import (
+	"bufio"
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"context"
 	"encoding/json"
 	"encoding/xml"
@@ -229,11 +231,16 @@ type deflateReaderWrapper struct {
 	mu *sync.Mutex
 	r  io.ReadCloser
 	fr io.ReadCloser
+	// fromPool marks fr as a flate reader that may go back to flateReaderPool.
+	// A zlib reader must never be pooled there: zlib.Resetter and flate.Resetter
+	// have the same method set, so a type assertion cannot tell them apart, and a
+	// pooled zlib reader would fail every later raw-deflate stream.
+	fromPool bool
 }
 
 // acquireDeflateReader gets a flate.Reader from the pool or creates one.
 // It resets the reader for the new stream using the provided io.ReadCloser.
-func acquireDeflateReader(r io.ReadCloser) (*deflateReaderWrapper, error) {
+func acquireDeflateReader(r io.ReadCloser, src io.Reader) (*deflateReaderWrapper, error) {
 	w := &deflateReaderWrapper{
 		mu: new(sync.Mutex),
 		r:  r,
@@ -242,14 +249,16 @@ func acquireDeflateReader(r io.ReadCloser) (*deflateReaderWrapper, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
+	w.fromPool = true
+
 	// Try to get a cached reader from the pool
 	if cached := flateReaderPool.Get(); cached != nil {
 		w.fr = cached.(io.ReadCloser)
 		// Reset the pooled reader for the new stream; flate.Resetter.Reset never errors
-		w.fr.(flate.Resetter).Reset(r, nil)
+		w.fr.(flate.Resetter).Reset(src, nil)
 	} else {
 		// Pool is empty, create a new reader
-		w.fr = flate.NewReader(r)
+		w.fr = flate.NewReader(src)
 	}
 
 	return w, nil
@@ -262,8 +271,12 @@ func releaseDeflateReader(w *deflateReaderWrapper) {
 	defer w.mu.Unlock()
 
 	if w.fr != nil {
-		w.fr.(flate.Resetter).Reset(nopReader{}, nil)
-		flateReaderPool.Put(w.fr)
+		if w.fromPool {
+			w.fr.(flate.Resetter).Reset(nopReader{}, nil)
+			flateReaderPool.Put(w.fr)
+		} else {
+			closeq(w.fr)
+		}
 		w.fr = nil
 	}
 	if w.r != nil {
@@ -272,8 +285,30 @@ func releaseDeflateReader(w *deflateReaderWrapper) {
 	}
 }
 
+// isZlibWrapped reports whether the next two bytes of br are an RFC 1950 zlib
+// header. RFC 9110 section 8.4.1.2 defines the "deflate" content coding as a
+// zlib stream, but plenty of servers send a bare RFC 1951 stream under the same
+// name, so both are accepted.
+func isZlibWrapped(br *bufio.Reader) bool {
+	h, err := br.Peek(2)
+	if err != nil {
+		return false
+	}
+	// The low nibble of CMF is the compression method; 8 is deflate. The two
+	// header bytes read big-endian must also be a multiple of 31.
+	return h[0]&0x0f == 8 && (uint16(h[0])<<8|uint16(h[1]))%31 == 0
+}
+
 func decompressDeflate(r io.ReadCloser) (io.ReadCloser, error) {
-	return acquireDeflateReader(r)
+	br := bufio.NewReader(r)
+	if isZlibWrapped(br) {
+		zr, err := zlib.NewReader(br)
+		if err != nil {
+			return nil, err
+		}
+		return &deflateReaderWrapper{mu: new(sync.Mutex), r: r, fr: zr}, nil
+	}
+	return acquireDeflateReader(r, br)
 }
 
 // Implement io.ReadCloser for deflateReaderWrapper

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,9 +1,11 @@
 package resty
 
 import (
+	"bufio"
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"errors"
 	"io"
 	"net/http"
@@ -475,7 +477,7 @@ func TestDeflateReaderPanicOnConcurrentCorruptedBody(t *testing.T) {
 func TestDeflateReaderPoolAcquireAndRead(t *testing.T) {
 	// Test successful creation and read with valid deflate data
 	validData := io.NopCloser(bytes.NewReader(createDeflateValidData()))
-	wrapper, err := acquireDeflateReader(validData)
+	wrapper, err := acquireDeflateReader(validData, validData)
 	assertNil(t, err)
 	assertNotNil(t, wrapper)
 
@@ -507,7 +509,7 @@ func TestDeflateReaderPoolConcurrentAccess(t *testing.T) {
 			for range numOperations {
 				// Create fresh data for each operation
 				validData := io.NopCloser(bytes.NewReader(createDeflateValidData()))
-				wrapper, err := acquireDeflateReader(validData)
+				wrapper, err := acquireDeflateReader(validData, validData)
 				assertNil(t, err)
 				assertNotNil(t, wrapper)
 
@@ -657,4 +659,68 @@ func TestStreamMisc(t *testing.T) {
 		assertEqual(t, 0, n)
 
 	})
+}
+
+// RFC 9110 section 8.4.1.2 defines the "deflate" content coding as a zlib
+// stream (RFC 1950) wrapping deflate-compressed data (RFC 1951). Resty
+// advertises deflate but decoded with compress/flate, so a conforming server's
+// response failed to decode -- and readAll mapped the resulting
+// io.ErrUnexpectedEOF to nil, surfacing a 200 with an empty body.
+func TestDecompressDeflateAcceptsZlibAndRawStreams(t *testing.T) {
+	const payload = `{"hello":"world"}`
+
+	var zlibFramed bytes.Buffer
+	zw := zlib.NewWriter(&zlibFramed)
+	_, _ = zw.Write([]byte(payload))
+	assertNil(t, zw.Close())
+
+	var rawFramed bytes.Buffer
+	fw, err := flate.NewWriter(&rawFramed, flate.DefaultCompression)
+	assertNil(t, err)
+	_, _ = fw.Write([]byte(payload))
+	assertNil(t, fw.Close())
+
+	for _, tc := range []struct {
+		name string
+		body []byte
+	}{
+		{"zlib framed, per RFC 9110", zlibFramed.Bytes()},
+		{"raw deflate, as many servers send", rawFramed.Bytes()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Encoding", "deflate")
+				w.Header().Set(hdrContentTypeKey, "application/json")
+				_, _ = w.Write(tc.body)
+			}))
+			defer ts.Close()
+
+			c := dcnl().SetBaseURL(ts.URL)
+			defer c.Close()
+
+			res, err := c.R().Get("/")
+			assertError(t, err)
+			assertEqual(t, http.StatusOK, res.StatusCode())
+			assertEqual(t, payload, res.String())
+		})
+	}
+}
+
+func TestIsZlibWrapped(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		in     []byte
+		expect bool
+	}{
+		{"zlib default compression", []byte{0x78, 0x9c}, true},
+		{"zlib best compression", []byte{0x78, 0xda}, true},
+		{"raw deflate block", []byte{0x00, 0x01}, false},
+		{"wrong compression method", []byte{0x71, 0x9c}, false},
+		{"too short to tell", []byte{0x78}, false},
+		{"empty", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assertEqual(t, tc.expect, isZlibWrapped(bufio.NewReader(bytes.NewReader(tc.in))))
+		})
+	}
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -724,3 +724,15 @@ func TestIsZlibWrapped(t *testing.T) {
 		})
 	}
 }
+
+// A header that passes the zlib sniff but that zlib.NewReader rejects (FDICT set,
+// so the stream needs a preset dictionary) must surface as an error rather than
+// an empty body.
+func TestDecompressDeflateZlibHeaderError(t *testing.T) {
+	// 0x78 0x20: CM=deflate, FDICT set, and (0x7820 % 31) == 0
+	body := []byte{0x78, 0x20, 0x00, 0x00, 0x00, 0x00}
+	assertEqual(t, true, isZlibWrapped(bufio.NewReader(bytes.NewReader(body))))
+
+	_, err := decompressDeflate(io.NopCloser(bytes.NewReader(body)))
+	assertNotNil(t, err)
+}


### PR DESCRIPTION
> **Depends on #1208 and #1209.** Stacked on them; until they merge this PR shows their commits too.

Three places where Resty hands credentials to an origin the caller never addressed, plus the transport-wrapper bug that silently disables TLS configuration.

## 1. Redirect policies restored credentials `net/http` had deliberately dropped

`checkHostAndAddHeaders` compared only `URL.Host` against `via[0]` and then `maps.Copy`'d the original request's entire header map over the redirected one. Three separate problems come out of that single line.

**Scheme was never compared.** The default port is elided from `URL.Host`, so an `https` → `http` downgrade of the same hostname compares equal, and `Authorization` and `Cookie` were copied onto a plaintext hop.

**`net/http`'s strip flag is sticky.** Once a redirect leaves the original origin it never re-sends `Authorization` or `Cookie`, even if the chain comes back. Resty compared each hop against `via[0]` alone, so a chain of `origin → attacker → origin` put the caller's bearer token and session cookie back on the wire:

```
go default (no resty policy):  Authorization=""              Cookie=""
RedirectFlexiblePolicy:        Authorization="Bearer SECRET" Cookie="sid=SECRET-COOKIE"
```

The chain is now checked end to end, and nothing sensitive is restored once any hop has left the origin.

**`maps.Copy` overwrote headers the redirected request already carried.** That undid two things `net/http` does on purpose:

- withholding `Content-Type` and the other body headers when a 301/302/303 rewrites the method and drops the body (RFC 9110 §8.3);
- superseding the caller's `Cookie` with one delivered alongside the redirect (RFC 6265 §5.3). The request went out as `Cookie: sid=old; sid=new`, and essentially every server-side parser takes the first match — i.e. the invalidated session.

Existing headers are now left alone, and body headers are not restored across a method change.

## 2. Digest auth answered challenges from any host

`digestTransport` is an `http.RoundTripper`, so `http.Client` invokes it on **every redirect hop**. It answered any `401 Digest` with the configured credentials, with no check that the challenging host was the one they were configured for, and with realm and nonce chosen by whoever responded:

```
attacker host received:
Digest username="victim-user", realm="victim-realm", nonce="attacker-chosen-nonce",
       uri="/x", qop=auth, nc=00000001, cnonce="3f035d...", response="940254e3..."
```

That is the username in cleartext plus a digest over attacker-chosen parameters — a chosen-parameter cracking oracle, and precomputable with a fixed realm. Same shape as curl's CVE-2022-27774.

The transport now walks back through `Request.Response` to the URL the caller actually requested and declines to authenticate when the challenge comes from a different origin, returning the 401 instead. A same-origin redirect still authenticates normally (covered by a test).

## 3. TLS, certificate and proxy setters silently did nothing after `SetDigestAuth` or `SetHedging`

Both replace the client transport with a wrapper, and neither implements `TLSClientConfiger`, so every later `SetTLSClientConfig`, `SetCertificates`, `SetRootCertificates` and `SetProxy` hit the not-an-`http.Transport` branch, logged an error and returned the client unchanged:

```go
c.SetDigestAuth("u", "p")
c.SetTLSClientConfig(&tls.Config{MinVersion: tls.VersionTLS13, RootCAs: pool})
c.SetCertificates(clientCert)
c.SetProxy("http://127.0.0.1:9999")
```
```
inner transport TLSClientConfig = <nil>
inner transport Proxy unchanged = true
client.ProxyURL() reports       = <nil>
ERROR RESTY SetTLSClientConfig: resty: not a http.Transport type   (x4)
```

An application that believed it had pinned a CA, required TLS 1.3 and attached a client certificate for mTLS got none of them, and traffic intended for an inspecting egress proxy went direct. Only a log line distinguished this from success. The reverse call order works, and nothing documented the requirement.

Rather than implementing `TLSClientConfiger` on each wrapper, the wrappers now expose the transport they wrap and `Client.HTTPTransport` unwraps to find the real `http.Transport` — which fixes every one of those setters at once. The walk is bounded so a round tripper that returns itself cannot spin.

## Not addressed here

The digest probe still sends the first request with the body stripped, so a server that never challenges receives an empty request while the caller sees success. Fixing that means either sending the body twice or issuing an extra request, and the existing tests pin the current design (prefer `qop=auth` when `GetBody` is unusable). I did not want to make that trade-off silently — happy to follow up if you have a preference.

## Verification

`go test ./... -race -count=1 -shuffle=on` green. `gofmt`, `go vet` clean. Coverage unchanged at 99.9%.

Third of five stacked PRs from an audit of the v3 branch.
