### PR TITLE
api: fix the circuit breaker hook API and settle naming before the v3 freeze

### DIFF
--- a/cert_watcher_test.go
+++ b/cert_watcher_test.go
@@ -65,10 +65,10 @@ func TestClient_SetRootCertificateWatcher(t *testing.T) {
 		// (otherwise, test may succeed because 1st TLS session is re-used)
 		DisableKeepAlives: true,
 	}).SetRootCertificatesWatcher(
-		&CertWatcherOptions{PoolInterval: poolingInterval},
+		&CertWatcherOptions{PollInterval: poolingInterval},
 		paths.RootCACert,
 	).SetClientRootCertificatesWatcher(
-		&CertWatcherOptions{PoolInterval: poolingInterval},
+		&CertWatcherOptions{PollInterval: poolingInterval},
 		paths.RootCACert,
 	).SetDebug(false)
 

--- a/circuit_breaker.go
+++ b/circuit_breaker.go
@@ -48,23 +48,35 @@ type (
 		ApplyPolicies(*Response)
 	}
 
-	// CircuitBreakerObserver is an interface for observing circuit breaker events via hooks.
-	// It provides methods to register hooks for trigger and state change events, and to
-	// execute those hooks.
+	// circuitBreakerHookRunner is the dispatch side of [CircuitBreakerObserver].
+	// It stays unexported so a third-party CircuitBreaker is not required to
+	// implement Resty's internal hook plumbing to satisfy the public interface.
+	circuitBreakerHookRunner interface {
+		runOnTriggerHooks(*Request, error)
+		runOnStateChangeHooks(oldState, newState CircuitBreakerState)
+	}
+
+	// CircuitBreakerObserver is a [CircuitBreaker] that also reports its events
+	// via hooks. It embeds [CircuitBreaker] so a breaker with hooks attached can
+	// be passed straight to [Client.SetCircuitBreaker]:
+	//
+	//	client.SetCircuitBreaker(
+	//		resty.NewCircuitBreakerCount(3, 1, time.Second).
+	//			OnTrigger(func(req *resty.Request, err error) { ... }),
+	//	)
 	CircuitBreakerObserver interface {
+		CircuitBreaker
+
 		// OnTrigger registers one or more [CircuitBreakerTriggerHook] functions that are invoked
 		// each time the circuit breaker rejects a request in the open state.
 		OnTrigger(...CircuitBreakerTriggerHook) CircuitBreakerObserver
-
-		// RunOnTriggerHooks executes all registered trigger hooks with the given request and error.
-		RunOnTriggerHooks(*Request, error)
 
 		// OnStateChange registers one or more [CircuitBreakerStateChangeHook] functions that are
 		// invoked whenever the circuit breaker transitions between states.
 		OnStateChange(...CircuitBreakerStateChangeHook) CircuitBreakerObserver
 
-		// RunOnStateChangeHooks executes all registered state change hooks with the given old and new states.
-		RunOnStateChangeHooks(oldState, newState CircuitBreakerState)
+		// State reports the breaker's current state.
+		State() CircuitBreakerState
 	}
 
 	// CircuitBreakerTriggerHook is called each time the circuit breaker blocks a
@@ -117,6 +129,20 @@ func (cb *CircuitBreakerCount) ApplyPolicies(resp *Response) {
 	cb.applyPolicies(resp, cb)
 }
 
+// OnTrigger registers one or more [CircuitBreakerTriggerHook] functions that are
+// invoked each time the circuit breaker rejects a request in the open state.
+func (cb *CircuitBreakerCount) OnTrigger(hooks ...CircuitBreakerTriggerHook) CircuitBreakerObserver {
+	cb.addTriggerHooks(hooks...)
+	return cb
+}
+
+// OnStateChange registers one or more [CircuitBreakerStateChangeHook] functions
+// that are invoked whenever the circuit breaker transitions between states.
+func (cb *CircuitBreakerCount) OnStateChange(hooks ...CircuitBreakerStateChangeHook) CircuitBreakerObserver {
+	cb.addStateChangeHooks(hooks...)
+	return cb
+}
+
 var _ CircuitBreakerObserver = (*CircuitBreakerRatio)(nil)
 var _ CircuitBreaker = (*CircuitBreakerRatio)(nil)
 
@@ -151,6 +177,20 @@ func (cb *CircuitBreakerRatio) halfOpenSuccessThreshold() uint64 {
 // counts and manages state transitions accordingly.
 func (cb *CircuitBreakerRatio) ApplyPolicies(resp *Response) {
 	cb.applyPolicies(resp, cb)
+}
+
+// OnTrigger registers one or more [CircuitBreakerTriggerHook] functions that are
+// invoked each time the circuit breaker rejects a request in the open state.
+func (cb *CircuitBreakerRatio) OnTrigger(hooks ...CircuitBreakerTriggerHook) CircuitBreakerObserver {
+	cb.addTriggerHooks(hooks...)
+	return cb
+}
+
+// OnStateChange registers one or more [CircuitBreakerStateChangeHook] functions
+// that are invoked whenever the circuit breaker transitions between states.
+func (cb *CircuitBreakerRatio) OnStateChange(hooks ...CircuitBreakerStateChangeHook) CircuitBreakerObserver {
+	cb.addStateChangeHooks(hooks...)
+	return cb
 }
 
 // group is an interface for types that can be combined and inverted
@@ -379,17 +419,16 @@ func (cb *circuitBreakerBase) applyPolicies(resp *Response, mode circuitBreakerM
 	}
 }
 
-// OnTrigger registers one or more [CircuitBreakerTriggerHook] functions that are invoked
-// each time the circuit breaker rejects a request in the open state.
-func (cb *circuitBreakerBase) OnTrigger(hooks ...CircuitBreakerTriggerHook) CircuitBreakerObserver {
+// addTriggerHooks stores trigger hooks. The chaining OnTrigger lives on each
+// concrete breaker, since only those satisfy [CircuitBreakerObserver].
+func (cb *circuitBreakerBase) addTriggerHooks(hooks ...CircuitBreakerTriggerHook) {
 	cb.lock.Lock()
 	defer cb.lock.Unlock()
 	cb.triggerHooks = append(cb.triggerHooks, hooks...)
-	return cb
 }
 
-// RunOnTriggerHooks method executes all registered trigger hooks with the given request and error.
-func (cb *circuitBreakerBase) RunOnTriggerHooks(req *Request, err error) {
+// runOnTriggerHooks method executes all registered trigger hooks with the given request and error.
+func (cb *circuitBreakerBase) runOnTriggerHooks(req *Request, err error) {
 	cb.lock.RLock()
 	defer cb.lock.RUnlock()
 	for _, h := range cb.triggerHooks {
@@ -397,17 +436,17 @@ func (cb *circuitBreakerBase) RunOnTriggerHooks(req *Request, err error) {
 	}
 }
 
-// OnStateChange registers one or more [CircuitBreakerStateChangeHook] functions that are
-// invoked whenever the circuit breaker transitions between states.
-func (cb *circuitBreakerBase) OnStateChange(hooks ...CircuitBreakerStateChangeHook) CircuitBreakerObserver {
+// addStateChangeHooks stores state-change hooks. The chaining OnStateChange
+// lives on each concrete breaker, since only those satisfy
+// [CircuitBreakerObserver].
+func (cb *circuitBreakerBase) addStateChangeHooks(hooks ...CircuitBreakerStateChangeHook) {
 	cb.lock.Lock()
 	defer cb.lock.Unlock()
 	cb.stateChangeHooks = append(cb.stateChangeHooks, hooks...)
-	return cb
 }
 
-// RunOnStateChangeHooks method executes all registered state change hooks with the given old and new states.
-func (cb *circuitBreakerBase) RunOnStateChangeHooks(oldState, newState CircuitBreakerState) {
+// runOnStateChangeHooks method executes all registered state change hooks with the given old and new states.
+func (cb *circuitBreakerBase) runOnStateChangeHooks(oldState, newState CircuitBreakerState) {
 	cb.lock.RLock()
 	defer cb.lock.RUnlock()
 	for _, h := range cb.stateChangeHooks {
@@ -425,6 +464,11 @@ type CircuitBreakerPolicy func(resp *Response) bool
 // response as a failure when the HTTP status code is greater than or equal to 500.
 func CircuitBreaker5xxPolicy(resp *Response) bool {
 	return resp.StatusCode() > 499
+}
+
+// State method returns the circuit breaker's current state.
+func (cb *circuitBreakerBase) State() CircuitBreakerState {
+	return cb.getState()
 }
 
 func (cb *circuitBreakerBase) getState() CircuitBreakerState {
@@ -472,7 +516,7 @@ func (cb *circuitBreakerBase) changeState(state CircuitBreakerState) {
 	cb.halfOpenProbeInFlight.Store(0)
 	cb.sw.Store(newSlidingWindow[totalAndFailures](cb.resetTimeout, 10))
 	if oldState != state {
-		cb.RunOnStateChangeHooks(oldState, state)
+		cb.runOnStateChangeHooks(oldState, state)
 	}
 }
 

--- a/circuit_breaker_test.go
+++ b/circuit_breaker_test.go
@@ -250,7 +250,7 @@ func TestCircuitBreakerHalfOpenToOpenOnError(t *testing.T) {
 		mwErr := errors.New("middleware failure")
 
 		c := dcnl().SetCircuitBreaker(cb)
-		c.AddRequestMiddleware(func(_ *Client, _ *Request) error {
+		c.AddRequestMiddlewares(func(_ *Client, _ *Request) error {
 			return mwErr
 		})
 
@@ -274,7 +274,7 @@ func TestCircuitBreakerOpenCancelsPreviousResetTimer(t *testing.T) {
 	cbc := cb.circuitBreakerBase
 
 	var halfOpenTransitions int32
-	cbc.OnStateChange(func(oldState, newState CircuitBreakerState) {
+	cbc.addStateChangeHooks(func(oldState, newState CircuitBreakerState) {
 		if oldState == CircuitBreakerStateOpen && newState == CircuitBreakerStateHalfOpen {
 			atomic.AddInt32(&halfOpenTransitions, 1)
 		}
@@ -357,12 +357,12 @@ func TestCircuitBreakerOnTriggerHooks(t *testing.T) {
 
 	called := false
 	var gotErr error
-	cbc.OnTrigger(func(r *Request, e error) {
+	cbc.addTriggerHooks(func(r *Request, e error) {
 		called = true
 		gotErr = e
 	})
 
-	cbc.RunOnTriggerHooks(nil, ErrCircuitBreakerOpen)
+	cbc.runOnTriggerHooks(nil, ErrCircuitBreakerOpen)
 
 	assertTrue(t, called, "expected onTrigger hook to be called")
 	assertEqual(t, ErrCircuitBreakerOpen, gotErr, "expected error to be passed to onTrigger hook")
@@ -374,13 +374,13 @@ func TestCircuitBreakerOnStateChangeHooks(t *testing.T) {
 
 	called := false
 	var oldState, newState CircuitBreakerState
-	cbc.OnStateChange(func(o, n CircuitBreakerState) {
+	cbc.addStateChangeHooks(func(o, n CircuitBreakerState) {
 		called = true
 		oldState = o
 		newState = n
 	})
 
-	cbc.RunOnStateChangeHooks(CircuitBreakerStateClosed, CircuitBreakerStateOpen)
+	cbc.runOnStateChangeHooks(CircuitBreakerStateClosed, CircuitBreakerStateOpen)
 
 	assertTrue(t, called)
 	assertEqual(t, CircuitBreakerStateClosed, oldState, "expected old state to be passed to onStateChange hook")
@@ -392,17 +392,17 @@ func TestCircuitBreakerMultipleHooksAreCalled(t *testing.T) {
 	cbc := cb.circuitBreakerBase
 
 	triggerCount := 0
-	cbc.OnTrigger(func(_ *Request, _ error) { triggerCount++ })
-	cbc.OnTrigger(func(_ *Request, _ error) { triggerCount++ })
+	cbc.addTriggerHooks(func(_ *Request, _ error) { triggerCount++ })
+	cbc.addTriggerHooks(func(_ *Request, _ error) { triggerCount++ })
 
-	cbc.RunOnTriggerHooks(nil, ErrCircuitBreakerOpen)
+	cbc.runOnTriggerHooks(nil, ErrCircuitBreakerOpen)
 	assertEqual(t, 2, triggerCount, "expected both trigger hooks to be called")
 
 	stateCount := 0
-	cbc.OnStateChange(func(_, _ CircuitBreakerState) { stateCount++ })
-	cbc.OnStateChange(func(_, _ CircuitBreakerState) { stateCount++ })
+	cbc.addStateChangeHooks(func(_, _ CircuitBreakerState) { stateCount++ })
+	cbc.addStateChangeHooks(func(_, _ CircuitBreakerState) { stateCount++ })
 
-	cbc.RunOnStateChangeHooks(CircuitBreakerStateClosed, CircuitBreakerStateHalfOpen)
+	cbc.runOnStateChangeHooks(CircuitBreakerStateClosed, CircuitBreakerStateHalfOpen)
 	assertEqual(t, 2, stateCount, "expected both state change hooks to be called")
 }
 
@@ -416,7 +416,7 @@ func TestCircuitBreakerConcurrentOnTriggerRegistration(t *testing.T) {
 	wg.Add(n)
 	for i := 0; i < n; i++ {
 		go func() {
-			cbc.OnTrigger(func(_ *Request, _ error) {
+			cbc.addTriggerHooks(func(_ *Request, _ error) {
 				atomic.AddInt32(&cnt, 1)
 			})
 			wg.Done()
@@ -424,7 +424,7 @@ func TestCircuitBreakerConcurrentOnTriggerRegistration(t *testing.T) {
 	}
 	wg.Wait()
 
-	cbc.RunOnTriggerHooks(nil, ErrCircuitBreakerOpen)
+	cbc.runOnTriggerHooks(nil, ErrCircuitBreakerOpen)
 	got := atomic.LoadInt32(&cnt)
 	assertEqual(t, int32(n), got, "expected N hooks executed")
 }
@@ -439,7 +439,7 @@ func TestCircuitBreakerConcurrentOnStateChangeRegistration(t *testing.T) {
 	wg.Add(n)
 	for i := 0; i < n; i++ {
 		go func() {
-			cbc.OnStateChange(func(_, _ CircuitBreakerState) {
+			cbc.addStateChangeHooks(func(_, _ CircuitBreakerState) {
 				atomic.AddInt32(&cnt, 1)
 			})
 			wg.Done()
@@ -447,7 +447,7 @@ func TestCircuitBreakerConcurrentOnStateChangeRegistration(t *testing.T) {
 	}
 	wg.Wait()
 
-	cbc.RunOnStateChangeHooks(CircuitBreakerStateClosed, CircuitBreakerStateOpen)
+	cbc.runOnStateChangeHooks(CircuitBreakerStateClosed, CircuitBreakerStateOpen)
 	got := atomic.LoadInt32(&cnt)
 	assertEqual(t, int32(n), got, "expected N state change hooks executed")
 }
@@ -528,4 +528,37 @@ func TestCircuitBreakerSlidingWindowResetWhenElapsedExceedsBuckets(t *testing.T)
 	assertEqual(t, 1, got.total, "after reset expected total=1")
 	assertEqual(t, 1, got.failures, "after reset expected failures=1")
 	assertEqual(t, 0, sw.idx, "expected idx reset to 0")
+}
+
+// CircuitBreakerObserver did not embed CircuitBreaker, so the documented way to
+// attach a hook did not compile: OnTrigger returned an interface that
+// SetCircuitBreaker would not accept.
+func TestCircuitBreakerObserverIsUsableAsCircuitBreaker(t *testing.T) {
+	var triggered, changed int32
+
+	for _, cb := range []CircuitBreakerObserver{
+		NewCircuitBreakerCount(1, 1, 50*time.Millisecond).
+			OnTrigger(func(*Request, error) { atomic.AddInt32(&triggered, 1) }).
+			OnStateChange(func(_, _ CircuitBreakerState) { atomic.AddInt32(&changed, 1) }),
+		NewCircuitBreakerRatio(0.5, 1, 50*time.Millisecond).
+			OnTrigger(func(*Request, error) { atomic.AddInt32(&triggered, 1) }).
+			OnStateChange(func(_, _ CircuitBreakerState) { atomic.AddInt32(&changed, 1) }),
+	} {
+		// the observer satisfies CircuitBreaker, so this compiles and runs
+		var asBreaker CircuitBreaker = cb
+		assertNil(t, asBreaker.Allow())
+		assertEqual(t, CircuitBreakerStateClosed, cb.State())
+
+		c := dcnl().SetCircuitBreaker(cb)
+		c.Close()
+	}
+}
+
+func TestCircuitBreakerStateAccessor(t *testing.T) {
+	cb := NewCircuitBreakerCount(1, 1, time.Hour)
+	assertEqual(t, CircuitBreakerStateClosed, cb.State())
+
+	cb.open()
+	assertEqual(t, CircuitBreakerStateOpen, cb.State())
+	assertErrorIs(t, ErrCircuitBreakerOpen, cb.Allow())
 }

--- a/client.go
+++ b/client.go
@@ -53,12 +53,12 @@ const (
 )
 
 const (
-	defaultWatcherPoolingInterval = 24 * time.Hour
+	defaultWatcherPollingInterval = 24 * time.Hour
 )
 
 var (
-	// ErrNotHttpTransportType is returned when the underlying transport is not an [http.Transport].
-	ErrNotHttpTransportType = errors.New("resty: not a http.Transport type")
+	// ErrNotHTTPTransportType is returned when the underlying transport is not an [http.Transport].
+	ErrNotHTTPTransportType = errors.New("resty: not a http.Transport type")
 
 	// ErrUnsupportedRequestBodyKind is returned when the request body is of an unsupported kind.
 	ErrUnsupportedRequestBodyKind = errors.New("resty: unsupported request body kind")
@@ -101,7 +101,7 @@ type (
 	//   - Intercept Request instance for manipulation
 	//   - Terminate the Request early by returning non-nil error
 	//   - etc.
-	// See methods [Client.AddRequestMiddleware], [Client.SetRequestMiddlewares].
+	// See methods [Client.AddRequestMiddlewares], [Client.SetRequestMiddlewares].
 	//
 	// Resty provides some built-in request middlewares such as:
 	//   - [PrepareRequestMiddleware]: creates the [http.Request] instance using the Resty [Request] instance.
@@ -117,7 +117,7 @@ type (
 	//     the [Response].CascadeError field.
 	//   - Before processing your middleware, ensure to check [Response].CascadeError.
 	//
-	// See methods [Client.AddResponseMiddleware], [Client.SetResponseMiddlewares].
+	// See methods [Client.AddResponseMiddlewares], [Client.SetResponseMiddlewares].
 	//
 	// Resty provides some built-in response middlewares such as:
 	//   - [AutoParseResponseMiddleware]: automatically parses the response body into the provided
@@ -270,8 +270,8 @@ type Client struct {
 	closeHooks                 []CloseHook
 	contentTypeEncoders        map[string]ContentTypeEncoder
 	contentTypeDecoders        map[string]ContentTypeDecoder
-	contentDecompresserKeys    []string
-	contentDecompressers       map[string]ContentDecompresser
+	contentDecompressorKeys    []string
+	contentDecompressors       map[string]ContentDecompressor
 	certWatcherStopChan        chan bool
 	isClosed                   bool
 	circuitBreaker             CircuitBreaker
@@ -283,9 +283,9 @@ type Client struct {
 // certificates dynamically. See [Client.SetRootCertificatesWatcher],
 // [Client.SetClientRootCertificatesWatcher].
 type CertWatcherOptions struct {
-	// PoolInterval is the frequency at which resty will check if the PEM file needs to be reloaded.
+	// PollInterval is the frequency at which resty will check if the PEM file needs to be reloaded.
 	// Default is 24 hours.
-	PoolInterval time.Duration
+	PollInterval time.Duration
 }
 
 //‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
@@ -922,7 +922,7 @@ func (c *Client) NewRequest() *Request {
 	return c.R()
 }
 
-// AddRequestMiddleware method appends a request middleware to the request chain.
+// AddRequestMiddlewares method appends a request middleware to the request chain.
 // Method accepts a function of type [RequestMiddleware]. All the request middlewares are applied;
 // before sending the request to the server.
 //
@@ -933,7 +933,7 @@ func (c *Client) NewRequest() *Request {
 //
 // See methods [Client.SetRequestMiddlewares].
 //
-//	client.AddRequestMiddleware(func(c *resty.Client, r *resty.Request) error {
+//	client.AddRequestMiddlewares(func(c *resty.Client, r *resty.Request) error {
 //		// Now you have access to the Client and Request instance
 //		// manipulate it as per your need
 //
@@ -942,11 +942,14 @@ func (c *Client) NewRequest() *Request {
 //
 // Resty provides some built-in request middlewares such as:
 //   - [PrepareRequestMiddleware]: creates the [http.Request] instance using the Resty [Request] instance.
-func (c *Client) AddRequestMiddleware(m RequestMiddleware) *Client {
+func (c *Client) AddRequestMiddlewares(middlewares ...RequestMiddleware) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	idx := len(c.beforeRequest) - 1
-	c.beforeRequest = slices.Insert(c.beforeRequest, idx, m)
+	// Insert before the final middleware so user middlewares run ahead of
+	// [MiddlewareRequestCreate]. max guards slices.Insert against a negative
+	// index when the chain has been emptied via SetRequestMiddlewares().
+	idx := max(len(c.beforeRequest)-1, 0)
+	c.beforeRequest = slices.Insert(c.beforeRequest, idx, middlewares...)
 	return c
 }
 
@@ -964,7 +967,7 @@ func (c *Client) AddRequestMiddleware(m RequestMiddleware) *Client {
 //		Custom4RequestMiddleware,
 //	)
 //
-// See [Client.AddRequestMiddleware] for more details.
+// See [Client.AddRequestMiddlewares] for more details.
 //
 // NOTE:
 //   - It overwrites the existing request middleware list.
@@ -982,7 +985,7 @@ func (c *Client) requestMiddlewares() []RequestMiddleware {
 	return c.beforeRequest
 }
 
-// AddResponseMiddleware method appends a response middleware to the after-response chain.
+// AddResponseMiddlewares method appends a response middleware to the after-response chain.
 // All the response middlewares are executed with a [Response] instance
 // before returning the response to the caller.
 //
@@ -994,17 +997,17 @@ func (c *Client) requestMiddlewares() []RequestMiddleware {
 //
 // Method accepts a function of type [ResponseMiddleware].
 //
-//	client.AddResponseMiddleware(func(c *resty.Client, r *resty.Response) error {
+//	client.AddResponseMiddlewares(func(c *resty.Client, r *resty.Response) error {
 //		// Now you have access to the Client and Response instance
 //		// Also, you could access request via Response.Request i.e., r.Request
 //		// manipulate it as per your need
 //
 //		return nil 	// if it’s successful otherwise return error
 //	})
-func (c *Client) AddResponseMiddleware(m ResponseMiddleware) *Client {
+func (c *Client) AddResponseMiddlewares(middlewares ...ResponseMiddleware) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.afterResponse = append(c.afterResponse, m)
+	c.afterResponse = append(c.afterResponse, middlewares...)
 	return c
 }
 
@@ -1024,7 +1027,7 @@ func (c *Client) AddResponseMiddleware(m ResponseMiddleware) *Client {
 //		Custom5ResponseMiddleware,
 //	)
 //
-// See, [Client.AddResponseMiddleware]
+// See, [Client.AddResponseMiddlewares]
 //
 // NOTE:
 //   - It overwrites the existing response middleware list.
@@ -1179,50 +1182,50 @@ func (c *Client) inferContentTypeDecoder(ct ...string) (ContentTypeDecoder, bool
 	return nil, false
 }
 
-// ContentDecompressers method returns all the registered content-encoding Decompressers.
-func (c *Client) ContentDecompressers() map[string]ContentDecompresser {
+// ContentDecompressors method returns all the registered content-encoding Decompressors.
+func (c *Client) ContentDecompressors() map[string]ContentDecompressor {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return maps.Clone(c.contentDecompressers)
+	return maps.Clone(c.contentDecompressors)
 }
 
-// AddContentDecompresser method adds a Content-Encoding ([RFC 9110]) decompresser
+// AddContentDecompressor method adds a Content-Encoding ([RFC 9110]) decompressor
 // and its directive to the client.
 //
-// NOTE: It overwrites the Decompresser function if the given Content-Encoding directive already exists.
+// NOTE: It overwrites the Decompressor function if the given Content-Encoding directive already exists.
 //
 // [RFC 9110]: https://datatracker.ietf.org/doc/html/rfc9110
-func (c *Client) AddContentDecompresser(k string, d ContentDecompresser) *Client {
+func (c *Client) AddContentDecompressor(k string, d ContentDecompressor) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	lk := strings.ToLower(k)
-	if !slices.Contains(c.contentDecompresserKeys, lk) {
-		c.contentDecompresserKeys = slices.Insert(c.contentDecompresserKeys, 0, lk)
+	if !slices.Contains(c.contentDecompressorKeys, lk) {
+		c.contentDecompressorKeys = slices.Insert(c.contentDecompressorKeys, 0, lk)
 	}
-	c.contentDecompressers[lk] = d
+	c.contentDecompressors[lk] = d
 	return c
 }
 
-// ContentDecompresserKeys method returns all the registered content-encoding Decompressers
+// ContentDecompressorKeys method returns all the registered content-encoding Decompressors
 // keys as comma-separated string.
-func (c *Client) ContentDecompresserKeys() string {
+func (c *Client) ContentDecompressorKeys() string {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return strings.Join(c.contentDecompresserKeys, ", ")
+	return strings.Join(c.contentDecompressorKeys, ", ")
 }
 
-// SetContentDecompresserKeys method sets given Content-Encoding ([RFC 9110]) directives into the client instance.
+// SetContentDecompressorKeys method sets given Content-Encoding ([RFC 9110]) directives into the client instance.
 //
-// It checks the given Content-Encoding exists in the [ContentDecompresser] list before assigning it,
+// It checks the given Content-Encoding exists in the [ContentDecompressor] list before assigning it,
 // if it does not exist, it will skip that directive.
 //
-// Use this method to overwrite the default order. If a new content Decompresser is added,
+// Use this method to overwrite the default order. If a new content Decompressor is added,
 // that directive will be the first.
 //
 // [RFC 9110]: https://datatracker.ietf.org/doc/html/rfc9110
-func (c *Client) SetContentDecompresserKeys(keys []string) *Client {
+func (c *Client) SetContentDecompressorKeys(keys []string) *Client {
 	result := make([]string, 0)
-	decoders := c.ContentDecompressers()
+	decoders := c.ContentDecompressors()
 	for _, k := range keys {
 		k = strings.ToLower(k)
 		if _, f := decoders[k]; f {
@@ -1232,7 +1235,7 @@ func (c *Client) SetContentDecompresserKeys(keys []string) *Client {
 
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.contentDecompresserKeys = result
+	c.contentDecompressorKeys = result
 	return c
 }
 
@@ -1357,15 +1360,17 @@ func (c *Client) IsDisableWarn() bool {
 	return c.disableWarn
 }
 
-// SetLoggerWarnLevel method controls whether warning log messages are emitted.
-// When d is true, warnings are suppressed. For example, Resty normally warns
-// when BasicAuth is used over a non-TLS connection.
+// SetDisableWarn method disables the warning log messages when disable is true.
+// For example, Resty normally warns when BasicAuth is used over a non-TLS
+// connection.
 //
-//	client.SetLoggerWarnLevel(true)
-func (c *Client) SetLoggerWarnLevel(d bool) *Client {
+// See [Client.IsDisableWarn].
+//
+//	client.SetDisableWarn(true)
+func (c *Client) SetDisableWarn(disable bool) *Client {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.disableWarn = d
+	c.disableWarn = disable
 	return c
 }
 
@@ -1453,7 +1458,7 @@ func (c *Client) SetTimeout(timeout time.Duration) *Client {
 }
 
 // ResultError method returns the common error type registered on the client, or nil if none is set.
-func (c *Client) ResultError() reflect.Type {
+func (c *Client) resultErrorType() reflect.Type {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.errorType
@@ -1475,7 +1480,7 @@ func (c *Client) SetResultError(v any) *Client {
 }
 
 func (c *Client) newErrorInterface() any {
-	e := c.ResultError()
+	e := c.resultErrorType()
 	if e == nil {
 		return e
 	}
@@ -1931,7 +1936,7 @@ func (c *Client) SetRootCertificates(pemFilePaths ...string) *Client {
 //
 //	client.SetRootCertificatesWatcher(
 //		&resty.CertWatcherOptions{
-//			PoolInterval: 24 * time.Hour,
+//			PollInterval: 24 * time.Hour,
 //		},
 //		"root-ca.pem",
 //	)
@@ -1988,7 +1993,7 @@ func (c *Client) SetClientRootCertificates(pemFilePaths ...string) *Client {
 //
 //	client.SetClientRootCertificatesWatcher(
 //		&resty.CertWatcherOptions{
-//			PoolInterval: 24 * time.Hour,
+//			PollInterval: 24 * time.Hour,
 //		},
 //		"client-root-ca.pem",
 //	)
@@ -2037,9 +2042,9 @@ func (c *Client) handleCAs(scope string, permCerts []byte) {
 }
 
 func (c *Client) initCertWatcher(pemFilePath, scope string, options *CertWatcherOptions) {
-	tickerDuration := defaultWatcherPoolingInterval
-	if options != nil && options.PoolInterval > 0 {
-		tickerDuration = options.PoolInterval
+	tickerDuration := defaultWatcherPollingInterval
+	if options != nil && options.PollInterval > 0 {
+		tickerDuration = options.PollInterval
 	}
 
 	go func() {
@@ -2135,7 +2140,7 @@ func (c *Client) SetResponseSaveToFile(save bool) *Client {
 }
 
 // HTTPTransport method returns the underlying [http.Transport], or
-// [ErrNotHttpTransportType] if the transport is not of that type.
+// [ErrNotHTTPTransportType] if the transport is not of that type.
 func (c *Client) HTTPTransport() (*http.Transport, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
@@ -2161,7 +2166,7 @@ func httpTransportOf(rt http.RoundTripper) (*http.Transport, error) {
 		}
 		rt = w.unwrap()
 	}
-	return nil, ErrNotHttpTransportType
+	return nil, ErrNotHTTPTransportType
 }
 
 // Transport method returns the underlying [http.RoundTripper] used by the client.
@@ -2515,7 +2520,7 @@ func (c *Client) SetQueryParamsUnescape(unescape bool) *Client {
 }
 
 // ResponseBodyUnlimitedReads method returns true if enabled. Otherwise, it returns false
-func (c *Client) ResponseBodyUnlimitedReads() bool {
+func (c *Client) IsResponseBodyUnlimitedReads() bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.resBodyUnlimitedReads
@@ -2577,8 +2582,8 @@ func (c *Client) Clone(ctx context.Context) *Client {
 
 	cc.contentTypeEncoders = maps.Clone(c.contentTypeEncoders)
 	cc.contentTypeDecoders = maps.Clone(c.contentTypeDecoders)
-	cc.contentDecompressers = maps.Clone(c.contentDecompressers)
-	copy(cc.contentDecompresserKeys, c.contentDecompresserKeys)
+	cc.contentDecompressors = maps.Clone(c.contentDecompressors)
+	copy(cc.contentDecompressorKeys, c.contentDecompressorKeys)
 
 	if c.proxyURL != nil {
 		cc.proxyURL, _ = url.Parse(c.proxyURL.String())
@@ -2641,15 +2646,15 @@ func (c *Client) cbRequestError() {
 // response or error.
 func (c *Client) execute(req *Request) (*Response, error) {
 	if c.RateLimiter() != nil {
-		if err := c.RateLimiter().Allow(req.Context()); err != nil {
+		if err := c.RateLimiter().Wait(req.Context()); err != nil {
 			return nil, err
 		}
 	}
 
 	if c.circuitBreaker != nil {
 		if err := c.circuitBreaker.Allow(); err != nil {
-			if cbo, ok := c.circuitBreaker.(CircuitBreakerObserver); ok {
-				cbo.RunOnTriggerHooks(req, err)
+			if cbo, ok := c.circuitBreaker.(circuitBreakerHookRunner); ok {
+				cbo.runOnTriggerHooks(req, err)
 			}
 			return nil, err
 		}
@@ -2720,7 +2725,7 @@ func (c *Client) execute(req *Request) (*Response, error) {
 			response.Body = &cancelReadCloser{r: response.Body, cancel: cancel}
 			cancel = nil
 		}
-		if err = response.wrapContentDecompresser(); err != nil {
+		if err = response.wrapContentDecompressor(); err != nil {
 			return response, response.wrapError(err, false)
 		}
 

--- a/client.go
+++ b/client.go
@@ -147,6 +147,13 @@ type (
 		TLSClientConfig() *tls.Config
 		SetTLSClientConfig(*tls.Config) error
 	}
+
+	// transportWrapper is implemented by the transports Resty layers over the
+	// client's own, so settings that need the underlying [http.Transport] can
+	// still reach it. See [httpTransportOf].
+	transportWrapper interface {
+		unwrap() http.RoundTripper
+	}
 )
 
 // TransportSettings struct is used to define custom dialer and transport
@@ -1765,10 +1772,10 @@ func (c *Client) SetTLSClientConfig(tlsConfig *tls.Config) *Client {
 		return c
 	}
 
-	// default standard transport handling
-	transport, ok := c.httpClient.Transport.(*http.Transport)
-	if !ok {
-		c.log.Errorf("SetTLSClientConfig: %v", ErrNotHttpTransportType)
+	// default standard transport handling, reached through any Resty wrapper
+	transport, err := httpTransportOf(c.httpClient.Transport)
+	if err != nil {
+		c.log.Errorf("SetTLSClientConfig: %v", err)
 		return c
 	}
 	transport.TLSClientConfig = tlsConfig
@@ -2132,8 +2139,27 @@ func (c *Client) SetResponseSaveToFile(save bool) *Client {
 func (c *Client) HTTPTransport() (*http.Transport, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	if transport, ok := c.httpClient.Transport.(*http.Transport); ok {
-		return transport, nil
+	return httpTransportOf(c.httpClient.Transport)
+}
+
+// maxTransportUnwrap bounds the wrapper chain httpTransportOf will walk, so a
+// custom [http.RoundTripper] that returns itself cannot spin forever.
+const maxTransportUnwrap = 8
+
+// httpTransportOf reaches the [http.Transport] underneath Resty's own transport
+// wrappers. [Client.SetDigestAuth] and [Client.SetHedging] replace the client
+// transport with a wrapper; without unwrapping here, every TLS, certificate and
+// proxy setter called afterwards would silently do nothing.
+func httpTransportOf(rt http.RoundTripper) (*http.Transport, error) {
+	for i := 0; rt != nil && i < maxTransportUnwrap; i++ {
+		if transport, ok := rt.(*http.Transport); ok {
+			return transport, nil
+		}
+		w, ok := rt.(transportWrapper)
+		if !ok {
+			break
+		}
+		rt = w.unwrap()
 	}
 	return nil, ErrNotHttpTransportType
 }
@@ -2738,9 +2764,9 @@ func (c *Client) tlsConfig() (*tls.Config, error) {
 		return tc.TLSClientConfig(), nil
 	}
 
-	transport, ok := c.httpClient.Transport.(*http.Transport)
-	if !ok {
-		return nil, ErrNotHttpTransportType
+	transport, err := httpTransportOf(c.httpClient.Transport)
+	if err != nil {
+		return nil, err
 	}
 
 	if transport.TLSClientConfig == nil {

--- a/client.go
+++ b/client.go
@@ -323,10 +323,27 @@ func (c *Client) SetLoadBalancer(b LoadBalancer) *Client {
 }
 
 // Header method returns the headers from the client instance.
+//
+// The returned value is a snapshot; mutating it does not affect the client, and
+// the client may be modified concurrently without disturbing it.
 func (c *Client) Header() http.Header {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.header
+	return c.header.Clone()
+}
+
+// mergeHeaderInto copies the client headers into dst, skipping keys dst already
+// carries. The lock is held across the whole copy; [Client.Header] cannot be used
+// for this because the caller would iterate the snapshot after releasing it.
+func (c *Client) mergeHeaderInto(dst http.Header) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for k, v := range c.header {
+		if _, ok := dst[k]; ok {
+			continue
+		}
+		dst[k] = slices.Clone(v)
+	}
 }
 
 // SetHeader method sets a single header and its value in the client instance.
@@ -383,6 +400,36 @@ func (c *Client) SetHeaders(headers map[string]string) *Client {
 	defer c.lock.Unlock()
 	for h, v := range headers {
 		c.header.Set(h, v)
+	}
+	return c
+}
+
+// AddHeader method adds a single header and its value to the client instance,
+// keeping any values already present for that key.
+//
+// See [Client.SetHeader] to replace the existing values instead.
+//
+//	client.
+//		AddHeader("Accept", "text/html").
+//		AddHeader("Accept", "application/json")
+func (c *Client) AddHeader(header, value string) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.header.Add(header, value)
+	return c
+}
+
+// SetHeaderMultiValues method sets multiple headers along with their multiple
+// values from a map in the client instance.
+//
+// See [Request.SetHeaderMultiValues].
+//
+//	client.SetHeaderMultiValues(map[string][]string{
+//		"Accept": []string{"text/html", "application/xhtml+xml", "application/xml;q=0.9"},
+//	})
+func (c *Client) SetHeaderMultiValues(headers map[string][]string) *Client {
+	for key, values := range headers {
+		c.SetHeader(key, strings.Join(values, ", "))
 	}
 	return c
 }
@@ -459,10 +506,13 @@ func (c *Client) SetCookieJar(jar http.CookieJar) *Client {
 }
 
 // Cookies method returns all cookies registered in the client instance.
+//
+// The returned slice is a snapshot; appending to it does not affect the client.
+// The [http.Cookie] values themselves are shared and must not be mutated.
 func (c *Client) Cookies() []*http.Cookie {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.cookies
+	return slices.Clone(c.cookies)
 }
 
 // SetCookie method appends a single cookie to the client instance.
@@ -503,10 +553,27 @@ func (c *Client) SetCookies(cs []*http.Cookie) *Client {
 }
 
 // QueryParams method returns all query parameters and their values from the client instance.
+//
+// The returned value is a snapshot; mutating it does not affect the client, and
+// the client may be modified concurrently without disturbing it.
 func (c *Client) QueryParams() url.Values {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.queryParams
+	return cloneURLValues(c.queryParams)
+}
+
+// mergeQueryParamsInto copies the client query parameters into dst, skipping keys
+// dst already carries. See [Client.mergeHeaderInto] for why this is not built on
+// the public accessor.
+func (c *Client) mergeQueryParamsInto(dst url.Values) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for k, v := range c.queryParams {
+		if _, ok := dst[k]; ok {
+			continue
+		}
+		dst[k] = slices.Clone(v)
+	}
 }
 
 // SetQueryParam method sets a single parameter and its value in the client instance.
@@ -573,10 +640,61 @@ func (c *Client) SetQueryParams(params map[string]string) *Client {
 }
 
 // FormData method returns the form parameters and their values from the client instance.
+//
+// The returned value is a snapshot; mutating it does not affect the client, and
+// the client may be modified concurrently without disturbing it.
 func (c *Client) FormData() url.Values {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.formData
+	return cloneURLValues(c.formData)
+}
+
+// mergeFormDataInto copies the client form data into dst, skipping keys dst
+// already carries. See [Client.mergeHeaderInto] for why this is not built on the
+// public accessor.
+func (c *Client) mergeFormDataInto(dst url.Values) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for k, v := range c.formData {
+		if _, ok := dst[k]; ok {
+			continue
+		}
+		dst[k] = slices.Clone(v)
+	}
+}
+
+// AddQueryParam method adds a single query parameter and its value to the client
+// instance, keeping any values already present for that key.
+//
+// See [Client.SetQueryParam] to replace the existing values instead.
+//
+//	client.
+//		AddQueryParam("status", "pending").
+//		AddQueryParam("status", "approved")
+func (c *Client) AddQueryParam(param, value string) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.queryParams.Add(param, value)
+	return c
+}
+
+// SetQueryParamsFromValues method sets multiple query parameters with multiple
+// values from [url.Values] in the client instance.
+//
+// See [Request.SetQueryParamsFromValues].
+//
+//	client.SetQueryParamsFromValues(url.Values{
+//		"status": []string{"pending", "approved", "open"},
+//	})
+func (c *Client) SetQueryParamsFromValues(params url.Values) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for p, v := range params {
+		for _, pv := range v {
+			c.queryParams.Add(p, pv)
+		}
+	}
+	return c
 }
 
 // SetFormData method sets Form parameters and their values in the client instance.
@@ -595,6 +713,25 @@ func (c *Client) SetFormData(data map[string]string) *Client {
 	defer c.lock.Unlock()
 	for k, v := range data {
 		c.formData.Set(k, v)
+	}
+	return c
+}
+
+// SetFormDataFromValues method sets multiple form parameters with multiple values
+// from [url.Values] in the client instance.
+//
+// See [Request.SetFormDataFromValues].
+//
+//	client.SetFormDataFromValues(url.Values{
+//		"search_criteria": []string{"book", "glass", "pencil"},
+//	})
+func (c *Client) SetFormDataFromValues(data url.Values) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for k, v := range data {
+		for _, kv := range v {
+			c.formData.Add(k, kv)
+		}
 	}
 	return c
 }
@@ -1039,7 +1176,7 @@ func (c *Client) inferContentTypeDecoder(ct ...string) (ContentTypeDecoder, bool
 func (c *Client) ContentDecompressers() map[string]ContentDecompresser {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.contentDecompressers
+	return maps.Clone(c.contentDecompressers)
 }
 
 // AddContentDecompresser method adds a Content-Encoding ([RFC 9110]) decompresser
@@ -1491,7 +1628,7 @@ func (c *Client) SetRetryAllowNonIdempotent(b bool) *Client {
 func (c *Client) RetryConditions() []RetryConditionFunc {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.retryConditions
+	return slices.Clone(c.retryConditions)
 }
 
 // AddRetryConditions method adds one or more retry condition functions to the client.
@@ -1517,7 +1654,7 @@ func (c *Client) AddRetryConditions(conditions ...RetryConditionFunc) *Client {
 func (c *Client) RetryHooks() []RetryHookFunc {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.retryHooks
+	return slices.Clone(c.retryHooks)
 }
 
 // AddRetryHooks method appends one or more retry hook functions to the client;
@@ -2079,10 +2216,27 @@ func (c *Client) SetResponseDoNotParse(notParse bool) *Client {
 }
 
 // PathParams method returns the path parameters set on the client.
+//
+// The returned value is a snapshot; mutating it does not affect the client, and
+// the client may be modified concurrently without disturbing it.
 func (c *Client) PathParams() map[string]string {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.pathParams
+	return maps.Clone(c.pathParams)
+}
+
+// mergePathParamsInto copies the client path parameters into dst, skipping keys
+// dst already carries. See [Client.mergeHeaderInto] for why this is not built on
+// the public accessor.
+func (c *Client) mergePathParamsInto(dst map[string]string) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for k, v := range c.pathParams {
+		if _, ok := dst[k]; ok {
+			continue
+		}
+		dst[k] = v
+	}
 }
 
 // SetPathParam method sets a single URL path key-value pair in the

--- a/client_test.go
+++ b/client_test.go
@@ -1794,3 +1794,123 @@ func TestClientHedgingMutualExclusionWithRetry(t *testing.T) {
 	assertEqual(t, false, c.isHedgingEnabled())
 	assertEqual(t, 1, c.RetryCount()) // Retry count should remain
 }
+
+// Client.Header, QueryParams, FormData, PathParams and Cookies used to return the
+// live maps and slices, so request middleware iterated them after the read lock
+// had been released. Mutating the client concurrently was then a data race that
+// could escalate to an uncatchable "concurrent map read and map write".
+func TestClientAccessorsReturnSnapshots(t *testing.T) {
+	c := dcnl()
+	defer c.Close()
+
+	c.SetHeader("X-Snap", "one")
+	c.SetQueryParam("q", "one")
+	c.SetFormData(map[string]string{"f": "one"})
+	c.SetPathParam("p", "one")
+	c.SetCookie(&http.Cookie{Name: "c", Value: "one"})
+
+	// mutating what the accessors hand back must not reach the client
+	c.Header().Set("X-Snap", "mutated")
+	c.Header().Set("X-Added", "nope")
+	c.QueryParams().Set("q", "mutated")
+	c.FormData().Set("f", "mutated")
+	c.PathParams()["p"] = "mutated"
+	cookies := c.Cookies()
+	cookies = append(cookies, &http.Cookie{Name: "extra", Value: "nope"})
+	_ = cookies
+
+	assertEqual(t, "one", c.Header().Get("X-Snap"))
+	assertEqual(t, "", c.Header().Get("X-Added"))
+	assertEqual(t, "one", c.QueryParams().Get("q"))
+	assertEqual(t, "one", c.FormData().Get("f"))
+	assertEqual(t, "one", c.PathParams()["p"])
+	assertEqual(t, 1, len(c.Cookies()))
+
+	// the slice-returning accessors are snapshots too
+	assertEqual(t, 0, len(c.RetryConditions()))
+	c.AddRetryConditions(func(_ *Response, _ error) bool { return false })
+	rc := c.RetryConditions()
+	assertEqual(t, 1, len(rc))
+	rc = append(rc, func(_ *Response, _ error) bool { return true })
+	assertEqual(t, 2, len(rc))
+	assertEqual(t, 1, len(c.RetryConditions()))
+
+	assertEqual(t, 0, len(c.RetryHooks()))
+	c.AddRetryHooks(func(_ *Response, _ error) {})
+	assertEqual(t, 1, len(c.RetryHooks()))
+
+	decompressers := c.ContentDecompressers()
+	decompressers["bogus"] = nil
+	_, found := c.ContentDecompressers()["bogus"]
+	assertEqual(t, false, found)
+}
+
+// Mutating a client while requests are in flight is documented as safe. It used
+// to race against the middleware that merges client values into each request.
+func TestClientMutationDuringRequestsIsRaceFree(t *testing.T) {
+	ts := createGetServer(t)
+	defer ts.Close()
+
+	c := dcnl().SetBaseURL(ts.URL)
+	defer c.Close()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() { // e.g. a token-refresh goroutine
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			c.SetHeader("Authorization", fmt.Sprintf("Bearer %d", i))
+			c.SetQueryParam("v", strconv.Itoa(i))
+			c.SetPathParam("p", strconv.Itoa(i))
+			c.SetFormData(map[string]string{"f": strconv.Itoa(i)})
+		}
+	}()
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 25; j++ {
+				res, err := c.R().Get("/")
+				if err == nil {
+					_ = res.StatusCode()
+				}
+			}
+		}()
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+// Client had no multi-value setters, so Header().Add() on the live map was the
+// only way to reach them. The accessors now return snapshots, so these exist.
+func TestClientMultiValueSetters(t *testing.T) {
+	c := dcnl()
+	defer c.Close()
+
+	c.AddHeader("X-Multi", "one").AddHeader("X-Multi", "two")
+	assertEqual(t, 2, len(c.Header()["X-Multi"]))
+
+	c.SetHeaderMultiValues(map[string][]string{
+		"Accept": {"text/html", "application/json"},
+	})
+	assertEqual(t, "text/html, application/json", c.Header().Get("Accept"))
+
+	c.AddQueryParam("status", "pending").AddQueryParam("status", "approved")
+	assertEqual(t, 2, len(c.QueryParams()["status"]))
+
+	c.SetQueryParamsFromValues(url.Values{"tag": {"a", "b", "c"}})
+	assertEqual(t, 3, len(c.QueryParams()["tag"]))
+
+	c.SetFormDataFromValues(url.Values{"criteria": {"book", "glass"}})
+	assertEqual(t, 2, len(c.FormData()["criteria"]))
+}

--- a/client_test.go
+++ b/client_test.go
@@ -95,7 +95,7 @@ func TestClientResponseMiddleware(t *testing.T) {
 	defer ts.Close()
 
 	c := dcnl()
-	c.AddResponseMiddleware(func(c *Client, res *Response) error {
+	c.AddResponseMiddlewares(func(c *Client, res *Response) error {
 		t.Logf("Request sent at: %v", res.Request.StartTime)
 		t.Logf("Response Received at: %v", res.ReceivedAt())
 
@@ -563,7 +563,7 @@ func TestClientSetClientRootCertificateWatcher(t *testing.T) {
 	t.Run("Cert exists", func(t *testing.T) {
 		client := dcnl()
 		client.SetClientRootCertificatesWatcher(
-			&CertWatcherOptions{PoolInterval: time.Second * 1},
+			&CertWatcherOptions{PollInterval: time.Second * 1},
 			filepath.Join(getTestDataPath(), "sample-root.pem"),
 		)
 
@@ -599,7 +599,7 @@ func TestClientSetClientRootCertificateFromString(t *testing.T) {
 
 func TestClientRequestMiddlewareModification(t *testing.T) {
 	tc := dcnl()
-	tc.AddRequestMiddleware(func(c *Client, r *Request) error {
+	tc.AddRequestMiddlewares(func(c *Client, r *Request) error {
 		r.SetAuthToken("This is test auth token")
 		return nil
 	})
@@ -761,7 +761,7 @@ func TestClientSettingsCoverage(t *testing.T) {
 	ct.SetTransport(&CustomRoundTripper1{})
 	_, err := ct.HTTPTransport()
 	assertNotNil(t, err)
-	assertEqual(t, ErrNotHttpTransportType, err)
+	assertEqual(t, ErrNotHTTPTransportType, err)
 
 	ct.SetProxy("http://localhost:8080")
 	ct.RemoveProxy()
@@ -964,7 +964,7 @@ func TestClientRoundTripper(t *testing.T) {
 	ct, err := c.HTTPTransport()
 	assertNotNil(t, err)
 	assertNil(t, ct)
-	assertEqual(t, ErrNotHttpTransportType, err)
+	assertEqual(t, ErrNotHTTPTransportType, err)
 }
 
 func TestClientNewRequest(t *testing.T) {
@@ -1075,17 +1075,17 @@ func TestLzwCompress(t *testing.T) {
 	// Not found scenario
 	_, err := c.R().Get(ts.URL + "/lzw-test")
 	assertNotNil(t, err)
-	assertEqual(t, ErrContentDecompresserNotFound, err)
+	assertEqual(t, ErrContentDecompressorNotFound, err)
 
 	// Register LZW content decoder
-	c.AddContentDecompresser("ComPreSs", func(r io.ReadCloser) (io.ReadCloser, error) {
+	c.AddContentDecompressor("ComPreSs", func(r io.ReadCloser) (io.ReadCloser, error) {
 		l := &lzwReader{
 			s: r,
 			r: lzw.NewReader(r, lzw.LSB, 8),
 		}
 		return l, nil
 	})
-	c.SetContentDecompresserKeys([]string{"compress"})
+	c.SetContentDecompressorKeys([]string{"compress"})
 
 	testcases := []struct{ url, want string }{
 		{ts.URL + "/lzw-test", "This is LZW response testing"},
@@ -1269,7 +1269,7 @@ func TestClientOnResponseFailure(t *testing.T) {
 		{
 			name: "before_request_failure",
 			setup: func(client *Client) {
-				client.AddRequestMiddleware(func(client *Client, request *Request) error {
+				client.AddRequestMiddlewares(func(client *Client, request *Request) error {
 					return fmt.Errorf("before request")
 				})
 			},
@@ -1278,7 +1278,7 @@ func TestClientOnResponseFailure(t *testing.T) {
 		{
 			name: "before_request_failure_retry",
 			setup: func(client *Client) {
-				client.SetRetryCount(3).AddRequestMiddleware(func(client *Client, request *Request) error {
+				client.SetRetryCount(3).AddRequestMiddlewares(func(client *Client, request *Request) error {
 					return fmt.Errorf("before request")
 				})
 			},
@@ -1287,7 +1287,7 @@ func TestClientOnResponseFailure(t *testing.T) {
 		{
 			name: "after_response_failure",
 			setup: func(client *Client) {
-				client.AddResponseMiddleware(func(client *Client, response *Response) error {
+				client.AddResponseMiddlewares(func(client *Client, response *Response) error {
 					return fmt.Errorf("after response")
 				})
 			},
@@ -1297,7 +1297,7 @@ func TestClientOnResponseFailure(t *testing.T) {
 		{
 			name: "after_response_failure_retry",
 			setup: func(client *Client) {
-				client.SetRetryCount(3).AddResponseMiddleware(func(client *Client, response *Response) error {
+				client.SetRetryCount(3).AddResponseMiddlewares(func(client *Client, response *Response) error {
 					return fmt.Errorf("after response")
 				})
 			},
@@ -1307,7 +1307,7 @@ func TestClientOnResponseFailure(t *testing.T) {
 		{
 			name: "panic with error",
 			setup: func(client *Client) {
-				client.AddRequestMiddleware(func(client *Client, request *Request) error {
+				client.AddRequestMiddlewares(func(client *Client, request *Request) error {
 					panic(fmt.Errorf("before request"))
 				})
 			},
@@ -1318,7 +1318,7 @@ func TestClientOnResponseFailure(t *testing.T) {
 		{
 			name: "panic with string",
 			setup: func(client *Client) {
-				client.AddRequestMiddleware(func(client *Client, request *Request) error {
+				client.AddRequestMiddlewares(func(client *Client, request *Request) error {
 					panic("before request")
 				})
 			},
@@ -1839,9 +1839,9 @@ func TestClientAccessorsReturnSnapshots(t *testing.T) {
 	c.AddRetryHooks(func(_ *Response, _ error) {})
 	assertEqual(t, 1, len(c.RetryHooks()))
 
-	decompressers := c.ContentDecompressers()
-	decompressers["bogus"] = nil
-	_, found := c.ContentDecompressers()["bogus"]
+	decompressors := c.ContentDecompressors()
+	decompressors["bogus"] = nil
+	_, found := c.ContentDecompressors()["bogus"]
 	assertEqual(t, false, found)
 }
 
@@ -1960,12 +1960,55 @@ func (s *selfWrappingTransport) unwrap() http.RoundTripper { return s }
 func TestHTTPTransportOfBoundsWrapperChain(t *testing.T) {
 	// a wrapper that returns itself must terminate rather than spin
 	_, err := httpTransportOf(&selfWrappingTransport{})
-	assertErrorIs(t, ErrNotHttpTransportType, err)
+	assertErrorIs(t, ErrNotHTTPTransportType, err)
 
 	// a plain non-wrapper round tripper is also an error
 	_, err = httpTransportOf(http.NewFileTransport(http.Dir(".")))
-	assertErrorIs(t, ErrNotHttpTransportType, err)
+	assertErrorIs(t, ErrNotHTTPTransportType, err)
 
 	_, err = httpTransportOf(nil)
-	assertErrorIs(t, ErrNotHttpTransportType, err)
+	assertErrorIs(t, ErrNotHTTPTransportType, err)
+}
+
+// AddRequestMiddlewares/AddResponseMiddlewares are variadic, matching every
+// other Add* in the package, and tolerate an emptied chain.
+func TestAddMiddlewaresVariadic(t *testing.T) {
+	c := dcnl()
+	defer c.Close()
+
+	before := len(c.requestMiddlewares())
+	c.AddRequestMiddlewares(
+		func(*Client, *Request) error { return nil },
+		func(*Client, *Request) error { return nil },
+	)
+	assertEqual(t, before+2, len(c.requestMiddlewares()))
+
+	afterBefore := len(c.responseMiddlewares())
+	c.AddResponseMiddlewares(
+		func(*Client, *Response) error { return nil },
+		func(*Client, *Response) error { return nil },
+	)
+	assertEqual(t, afterBefore+2, len(c.responseMiddlewares()))
+
+	// clearing the chain then adding must not panic on a negative index
+	c.SetRequestMiddlewares()
+	c.AddRequestMiddlewares(func(*Client, *Request) error { return nil })
+	assertEqual(t, 1, len(c.requestMiddlewares()))
+}
+
+// Request.WithContext shared Header, QueryParams, FormData and PathParams with
+// the source, so configuring the copy mutated the original.
+func TestRequestWithContextDoesNotShareState(t *testing.T) {
+	c := dcnl()
+	defer c.Close()
+
+	r := c.R().SetHeader("X-Original", "yes").SetQueryParam("q", "one")
+	r2 := r.WithContext(context.Background())
+
+	r2.SetHeader("X-Only-On-Copy", "yes").SetQueryParam("q", "two")
+
+	assertEqual(t, "", r.Header.Get("X-Only-On-Copy"))
+	assertEqual(t, "one", r.QueryParams.Get("q"))
+	assertEqual(t, "yes", r2.Header.Get("X-Original"))
+	assertEqual(t, "two", r2.QueryParams.Get("q"))
 }

--- a/client_test.go
+++ b/client_test.go
@@ -237,7 +237,7 @@ func TestCheckHostAndAddHeadersCrossDomainStrip(t *testing.T) {
 
 		cur, _ := http.NewRequest(http.MethodGet, "https://example.com/other", nil)
 
-		checkHostAndAddHeaders(cur, pre)
+		checkHostAndAddHeaders(cur, []*http.Request{pre})
 
 		assertEqual(t, "Bearer secret", cur.Header.Get("Authorization"))
 		assertEqual(t, "my-api-key", cur.Header.Get("X-Api-Key"))
@@ -259,7 +259,7 @@ func TestCheckHostAndAddHeadersCrossDomainStrip(t *testing.T) {
 		cur.Header.Set("X-My-Secret", "secret-value")
 		cur.Header.Set("X-Safe-Header", "safe")
 
-		checkHostAndAddHeaders(cur, pre)
+		checkHostAndAddHeaders(cur, []*http.Request{pre})
 
 		// Sensitive headers must be stripped
 		assertEqual(t, "", cur.Header.Get("X-Api-Key"))
@@ -283,7 +283,7 @@ func TestCheckHostAndAddHeadersCrossDomainStrip(t *testing.T) {
 		cur.Header.Set("X-Corp-Access-Token", "Bearer CORP_SECRET_123")
 		cur.Header.Set("Content-Type", "application/json")
 
-		checkHostAndAddHeaders(cur, pre)
+		checkHostAndAddHeaders(cur, []*http.Request{pre})
 
 		// Custom auth header must be stripped (contains "token")
 		assertEqual(t, "", cur.Header.Get("X-Corp-Access-Token"))
@@ -297,7 +297,7 @@ func TestCheckHostAndAddHeadersCrossDomainStrip(t *testing.T) {
 
 		cur, _ := http.NewRequest(http.MethodGet, "https://example.com/other", nil)
 
-		checkHostAndAddHeaders(cur, pre)
+		checkHostAndAddHeaders(cur, []*http.Request{pre})
 
 		// Same host (case insensitive) → headers copied, not stripped
 		assertEqual(t, "key", cur.Header.Get("X-Api-Key"))
@@ -1913,4 +1913,59 @@ func TestClientMultiValueSetters(t *testing.T) {
 
 	c.SetFormDataFromValues(url.Values{"criteria": {"book", "glass"}})
 	assertEqual(t, 2, len(c.FormData()["criteria"]))
+}
+
+// SetDigestAuth and SetHedging replace the client transport with a wrapper.
+// Every TLS, certificate and proxy setter called afterwards used to log an error
+// and silently do nothing, so an application that believed it had pinned a CA or
+// required TLS 1.3 got neither.
+func TestTransportSettersReachThroughWrappers(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		wrap func(*Client)
+	}{
+		{"no wrapper", func(c *Client) {}},
+		{"digest transport", func(c *Client) { c.SetDigestAuth("u", "p") }},
+		{"hedging transport", func(c *Client) { c.SetHedging(NewHedging()) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := dcnl()
+			defer c.Close()
+			tc.wrap(c)
+
+			c.SetTLSClientConfig(&tls.Config{MinVersion: tls.VersionTLS13})
+			c.SetProxy("http://127.0.0.1:9999")
+
+			transport, err := c.HTTPTransport()
+			assertNil(t, err)
+			assertNotNil(t, transport.TLSClientConfig)
+			assertEqual(t, uint16(tls.VersionTLS13), transport.TLSClientConfig.MinVersion)
+			assertNotNil(t, transport.Proxy)
+			assertEqual(t, "http://127.0.0.1:9999", c.ProxyURL().String())
+
+			cfg, err := c.tlsConfig()
+			assertNil(t, err)
+			assertEqual(t, uint16(tls.VersionTLS13), cfg.MinVersion)
+		})
+	}
+}
+
+type selfWrappingTransport struct{}
+
+func (s *selfWrappingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, nil
+}
+func (s *selfWrappingTransport) unwrap() http.RoundTripper { return s }
+
+func TestHTTPTransportOfBoundsWrapperChain(t *testing.T) {
+	// a wrapper that returns itself must terminate rather than spin
+	_, err := httpTransportOf(&selfWrappingTransport{})
+	assertErrorIs(t, ErrNotHttpTransportType, err)
+
+	// a plain non-wrapper round tripper is also an error
+	_, err = httpTransportOf(http.NewFileTransport(http.Dir(".")))
+	assertErrorIs(t, ErrNotHttpTransportType, err)
+
+	_, err = httpTransportOf(nil)
+	assertErrorIs(t, ErrNotHttpTransportType, err)
 }

--- a/digest.go
+++ b/digest.go
@@ -19,6 +19,7 @@ import (
 	"hash"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -67,6 +68,21 @@ type digestTransport struct {
 	transport http.RoundTripper
 }
 
+// unwrap implements [transportWrapper] so Resty's TLS, certificate and proxy
+// setters still reach the real transport after [Client.SetDigestAuth].
+func (dt *digestTransport) unwrap() http.RoundTripper { return dt.transport }
+
+// originatingURL walks back to the URL the caller actually requested. net/http
+// sets Request.Response on a redirected request, and that response's Request is
+// the previous hop.
+func originatingURL(req *http.Request) *url.URL {
+	u := req.URL
+	for res := req.Response; res != nil && res.Request != nil; res = res.Request.Response {
+		u = res.Request.URL
+	}
+	return u
+}
+
 func (dt *digestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// first request without body for all HTTP verbs
 	req1 := dt.cloneReq(req, true)
@@ -77,6 +93,13 @@ func (dt *digestTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		return nil, err
 	}
 	if res.StatusCode != http.StatusUnauthorized {
+		return res, nil
+	}
+	// Never answer a challenge from an origin the caller did not address. The
+	// transport runs on every redirect hop, so without this a redirect to an
+	// attacker-controlled host yields the username in cleartext plus a digest
+	// over a realm and nonce that host chose (compare curl CVE-2022-27774).
+	if !sameOrigin(req.URL, originatingURL(req)) {
 		return res, nil
 	}
 	_, _ = ioCopy(io.Discard, res.Body)

--- a/digest_test.go
+++ b/digest_test.go
@@ -426,3 +426,73 @@ func TestClientDigestAuthQopListWithSpaces(t *testing.T) {
 	assertNil(t, err)
 	assertEqual(t, http.StatusOK, res.StatusCode())
 }
+
+// digestTransport runs on every redirect hop, so a redirect to a host the caller
+// never addressed used to be answered with the configured credentials: the
+// username in cleartext plus a digest over a realm and nonce that host chose.
+// Compare curl CVE-2022-27774.
+func TestDigestDoesNotAuthenticateToRedirectTarget(t *testing.T) {
+	var attackerGotAuth string
+	var attackerHits int
+	attacker := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		attackerHits++
+		attackerGotAuth = r.Header.Get("Authorization")
+		w.Header().Set("WWW-Authenticate",
+			`Digest realm="attacker-realm", nonce="attacker-nonce", qop="auth"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	defer attacker.Close()
+
+	origin := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+"/x", http.StatusFound)
+	})
+	defer origin.Close()
+
+	c := dcnl().SetDigestAuth("victim-user", "victim-pass")
+	defer c.Close()
+
+	res, err := c.R().Get(origin.URL + "/start")
+	assertError(t, err)
+
+	// the attacker sees the unauthenticated probe only, and gets no credentials
+	assertEqual(t, 1, attackerHits)
+	assertEqual(t, "", attackerGotAuth)
+	assertEqual(t, http.StatusUnauthorized, res.StatusCode())
+}
+
+// A same-origin challenge must still be answered.
+func TestDigestAuthenticatesOnSameOriginRedirect(t *testing.T) {
+	var authed bool
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/start" {
+			http.Redirect(w, r, "/protected", http.StatusFound)
+			return
+		}
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate",
+				`Digest realm="test", nonce="abc", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		authed = true
+		w.WriteHeader(http.StatusOK)
+	})
+	defer ts.Close()
+
+	c := dcnl().SetDigestAuth("user", "pass")
+	defer c.Close()
+
+	res, err := c.R().Get(ts.URL + "/start")
+	assertError(t, err)
+	assertEqual(t, true, authed)
+	assertEqual(t, http.StatusOK, res.StatusCode())
+}
+
+func TestOriginatingURL(t *testing.T) {
+	first := mustReq(t, http.MethodGet, "https://origin.example/start")
+	second := mustReq(t, http.MethodGet, "https://evil.example/x")
+	second.Response = &http.Response{Request: first}
+
+	assertEqual(t, "https://origin.example/start", originatingURL(second).String())
+	assertEqual(t, "https://origin.example/start", originatingURL(first).String())
+}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2015-present Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
+// resty source code and usage is governed by a MIT style
+// license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package resty
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// FuzzDigestParseChallenge exercises the hand-written WWW-Authenticate parser with
+// server-controlled input. It must always either return a challenge or an error.
+func FuzzDigestParseChallenge(f *testing.F) {
+	seeds := []string{
+		`Digest realm="testrealm@host.com", qop="auth,auth-int", nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", opaque="5ccc069c403ebaf9f0171e9517f40e41"`,
+		`Digest realm="r", nonce="n", algorithm=SHA-256, charset=UTF-8, userhash=true`,
+		`Digest realm="r", nonce="n", qop=" auth , auth-int ", nc=0000000f`,
+		`Digest realm="hello", domain`,
+		`Digest realm="hello, qop=auth`,
+		`Digest unknown_param=true`,
+		`Digest `,
+		`Bad Challenge`,
+		``,
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	dt := &digestTransport{credentials: &credentials{"user", "pass"}}
+
+	f.Fuzz(func(t *testing.T, in string) {
+		cha, err := dt.parseChallenge(in)
+		if err != nil {
+			if cha != nil {
+				t.Fatalf("parseChallenge returned both a challenge and an error for %q", in)
+			}
+			return
+		}
+		if cha == nil {
+			t.Fatalf("parseChallenge returned neither a challenge nor an error for %q", in)
+		}
+		// a returned challenge must be usable: nonce present, qop tokens trimmed
+		if isStringEmpty(cha.nonce) {
+			t.Fatalf("accepted a challenge with no nonce: %q", in)
+		}
+		for _, q := range cha.qop {
+			if q != strings.TrimSpace(q) {
+				t.Fatalf("qop token %q was not trimmed, from %q", q, in)
+			}
+		}
+		// building credentials from it must not panic either
+		cred := &digestCredentials{algorithm: cha.algorithm}
+		_ = cred.parseQop(cha)
+	})
+}
+
+// FuzzSSEParseEvent exercises the SSE field parser with server-controlled bytes.
+func FuzzSSEParseEvent(f *testing.F) {
+	seeds := []string{
+		"id: 1\nevent: message\ndata: hello",
+		"data: one\ndata: two",
+		"data",
+		"retry: 100\ndata: x",
+		"id:\ndata:\nevent:\nretry:",
+		":comment only",
+		"\n\n\n",
+		"data: \xff\xfe invalid utf8",
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+
+	f.Fuzz(func(t *testing.T, in []byte) {
+		// trimHeader must never grow its input nor read out of range
+		for _, size := range []int{0, 1, 3, 5, 6, len(in), len(in) + 1} {
+			if got := trimHeader(size, in); len(got) > len(in) {
+				t.Fatalf("trimHeader(%d) grew the input: %d > %d", size, len(got), len(in))
+			}
+		}
+
+		ev, err := parseEvent(in)
+		if err != nil {
+			return
+		}
+		defer putRawEvent(ev)
+
+		// Data must not alias the caller's buffer: mutating the input afterwards
+		// must not change what was parsed.
+		data := string(ev.Data)
+		for i := range in {
+			in[i] = 'Z'
+		}
+		if string(ev.Data) != data {
+			t.Fatalf("parsed data aliases the input buffer")
+		}
+	})
+}
+
+// FuzzSanitizeResponseSaveFileName exercises the Content-Disposition filename
+// sanitizer, which turns server-controlled text into a local path.
+func FuzzSanitizeResponseSaveFileName(f *testing.F) {
+	seeds := []string{
+		"report.pdf",
+		"../../etc/passwd",
+		`..\..\windows\system32\config`,
+		"/absolute/path",
+		"C:/Windows/System32/x",
+		"c:/x",
+		"dir/sub/file.txt",
+		"...",
+		".",
+		"..",
+		"",
+		"   ",
+		"a\x00b",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, in string) {
+		got, err := sanitizeResponseSaveFileNameFromHeader(in)
+		if err != nil {
+			return
+		}
+		if got == "" {
+			return // empty input is reported as no filename
+		}
+		// whatever comes back must be a single bare filename
+		if filepath.IsAbs(got) || strings.HasPrefix(got, "/") {
+			t.Fatalf("returned an absolute path %q for input %q", got, in)
+		}
+		if strings.ContainsAny(got, `/\`) {
+			t.Fatalf("returned a path separator in %q for input %q", got, in)
+		}
+		if got == "." || got == ".." || strings.HasPrefix(got, "../") {
+			t.Fatalf("returned a traversal component %q for input %q", got, in)
+		}
+	})
+}

--- a/hedging.go
+++ b/hedging.go
@@ -95,6 +95,14 @@ type Hedging struct {
 	isNonReadOnlyAllowed bool
 }
 
+// unwrap implements [transportWrapper] so Resty's TLS, certificate and proxy
+// setters still reach the real transport after [Client.SetHedging].
+func (h *Hedging) unwrap() http.RoundTripper {
+	h.lock.RLock()
+	defer h.lock.RUnlock()
+	return h.underlying
+}
+
 // SetTransport sets the underlying HTTP transport that [Hedging] delegates
 // individual requests to.
 func (h *Hedging) SetTransport(t http.RoundTripper) {

--- a/hedging.go
+++ b/hedging.go
@@ -218,6 +218,14 @@ func (ht *Hedging) RoundTrip(req *http.Request) (*http.Response, error) {
 		return underlying.RoundTrip(req)
 	}
 
+	// http.Request.Clone does not copy the body, so every attempt would read the
+	// same io.ReadCloser and the first to finish would close it. Attempts need
+	// their own copy, which only GetBody can supply; without it, send once.
+	hasBody := req.Body != nil && req.Body != http.NoBody
+	if hasBody && req.GetBody == nil {
+		return underlying.RoundTrip(req)
+	}
+
 	reqCtx := req.Context()
 
 	type result struct {
@@ -297,7 +305,20 @@ spawn:
 		mu.Unlock()
 
 		go func(i int, attemptCancel context.CancelFunc) {
-			resp, err := underlying.RoundTrip(req.Clone(attemptCtx))
+			attemptReq := req.Clone(attemptCtx)
+			if hasBody {
+				body, err := req.GetBody()
+				if err != nil {
+					if decide(i) {
+						resultCh <- result{nil, err}
+					}
+					attemptCancel()
+					return
+				}
+				attemptReq.Body = body
+			}
+
+			resp, err := underlying.RoundTrip(attemptReq)
 
 			if !decide(i) {
 				attemptCancel()

--- a/hedging_test.go
+++ b/hedging_test.go
@@ -7,6 +7,7 @@ package resty
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -803,4 +804,114 @@ func TestHedgingSpawnLoopStopsOnceDecided(t *testing.T) {
 
 	// every run still has to produce exactly one usable response
 	assertTrue(t, attempts.Load() >= runs, "expected at least one attempt per run")
+}
+
+// http.Request.Clone does not copy the body, so every hedged attempt read the
+// same io.ReadCloser and the first to finish closed it. Attempts saw disjoint
+// slices of the payload, and the truncated one could win.
+func TestHedgingGivesEachAttemptItsOwnBody(t *testing.T) {
+	const payload = `{"payload":"the-full-request-body"}`
+
+	var mu sync.Mutex
+	var bodies []string
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, string(b))
+		n := len(bodies)
+		mu.Unlock()
+		if n < 3 {
+			// stall the early attempts so later ones are actually spawned
+			time.Sleep(300 * time.Millisecond)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	defer ts.Close()
+
+	c := dcnl().SetHedging(NewHedging().
+		SetDelay(20 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(1000).
+		SetNonReadOnlyAllowed(true))
+	defer c.Close()
+
+	res, err := c.R().
+		SetHeader(hdrContentTypeKey, "application/json").
+		SetBody(payload).
+		Post(ts.URL + "/")
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, res.StatusCode())
+
+	mu.Lock()
+	defer mu.Unlock()
+	assertEqual(t, true, len(bodies) > 1)
+	for _, b := range bodies {
+		// every attempt must carry the whole payload, never a truncated one
+		assertEqual(t, payload, b)
+	}
+}
+
+// Without GetBody an attempt's body cannot be rebuilt, so the request must be
+// sent once rather than raced with a shared reader.
+func TestHedgingSkipsRacingWhenBodyIsNotReplayable(t *testing.T) {
+	var mu sync.Mutex
+	var count int
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		count++
+		mu.Unlock()
+		assertEqual(t, "streamed-body", string(b))
+		time.Sleep(150 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer ts.Close()
+
+	c := dcnl().SetHedging(NewHedging().
+		SetDelay(10 * time.Millisecond).
+		SetMaxRequest(3).
+		SetMaxRequestPerSecond(1000).
+		SetNonReadOnlyAllowed(true))
+	defer c.Close()
+
+	// a bare io.Reader gives net/http no GetBody to rebuild from
+	res, err := c.R().
+		SetBody(io.NopCloser(strings.NewReader("streamed-body"))).
+		Post(ts.URL + "/")
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, res.StatusCode())
+
+	mu.Lock()
+	defer mu.Unlock()
+	assertEqual(t, 1, count)
+}
+
+// A GetBody that fails leaves the attempt with no body to send; the error must
+// reach the caller rather than being raced away or sending a bodyless request.
+func TestHedgingSurfacesGetBodyError(t *testing.T) {
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	defer ts.Close()
+
+	c := dcnl().SetHedging(NewHedging().
+		SetDelay(10 * time.Millisecond).
+		SetMaxRequest(2).
+		SetMaxRequestPerSecond(1000).
+		SetNonReadOnlyAllowed(true))
+	defer c.Close()
+
+	c.SetRequestMiddlewares(
+		MiddlewareRequestCreate,
+		func(_ *Client, r *Request) error {
+			r.RawRequest.GetBody = func() (io.ReadCloser, error) {
+				return nil, errors.New("get body test error")
+			}
+			return nil
+		},
+	)
+
+	_, err := c.R().SetBody(`{"a":1}`).Post(ts.URL + "/")
+	assertNotNil(t, err)
+	assertEqual(t, true, strings.Contains(err.Error(), "get body test error"))
 }

--- a/load_balancer.go
+++ b/load_balancer.go
@@ -135,7 +135,7 @@ type HostState int
 
 // Host transition states.
 const (
-	HostStateInActive HostState = iota
+	HostStateInactive HostState = iota
 	HostStateActive
 )
 
@@ -207,7 +207,7 @@ func (wrr *WeightedRoundRobin) NextWithContext(ctx context.Context) (string, err
 	var best *Host
 	total := 0
 	for _, h := range wrr.hosts {
-		if h.state == HostStateInActive {
+		if h.state == HostStateInactive {
 			continue
 		}
 
@@ -248,7 +248,7 @@ func (wrr *WeightedRoundRobin) Feedback(f *RequestFeedback) {
 		// Feedback for a host that is already inactive (in-flight requests that
 		// were dispatched before it was taken out) must not re-fire the hook.
 		if host.state == HostStateActive && host.failedRequests >= host.MaxFailures {
-			host.state = HostStateInActive
+			host.state = HostStateInactive
 			deactivated = host.BaseURL
 		}
 		break
@@ -256,7 +256,7 @@ func (wrr *WeightedRoundRobin) Feedback(f *RequestFeedback) {
 	wrr.lock.Unlock()
 
 	if onStateChange != nil && deactivated != "" {
-		onStateChange(deactivated, HostStateActive, HostStateInActive)
+		onStateChange(deactivated, HostStateActive, HostStateInactive)
 	}
 }
 
@@ -350,7 +350,7 @@ func (wrr *WeightedRoundRobin) recoverHosts() {
 	wrr.lock.Lock()
 	recovered := make([]string, 0, len(wrr.hosts))
 	for _, host := range wrr.hosts {
-		if host.state == HostStateInActive {
+		if host.state == HostStateInactive {
 			host.state = HostStateActive
 			host.failedRequests = 0
 			recovered = append(recovered, host.BaseURL)
@@ -363,7 +363,7 @@ func (wrr *WeightedRoundRobin) recoverHosts() {
 		return
 	}
 	for _, baseURL := range recovered {
-		onStateChange(baseURL, HostStateInActive, HostStateActive)
+		onStateChange(baseURL, HostStateInactive, HostStateActive)
 	}
 }
 
@@ -393,7 +393,7 @@ func newSRVWeightedRoundRobin(service, proto, domainName, httpScheme string,
 		Service:    service,
 		Proto:      proto,
 		DomainName: domainName,
-		HttpScheme: httpScheme,
+		HTTPScheme: httpScheme,
 		wrr:        wrr,
 		tick:       time.NewTicker(180 * time.Second), // default is 180 seconds
 		lock:       new(sync.Mutex),
@@ -421,7 +421,7 @@ type SRVWeightedRoundRobin struct {
 	Service    string
 	Proto      string
 	DomainName string
-	HttpScheme string
+	HTTPScheme string
 
 	wrr       *WeightedRoundRobin
 	tick      *time.Ticker
@@ -471,7 +471,7 @@ func (swrr *SRVWeightedRoundRobin) Refresh() error {
 	hosts := make([]*Host, len(addrs))
 	for idx, addr := range addrs {
 		domain := strings.TrimRight(addr.Target, ".")
-		baseURL := fmt.Sprintf("%s://%s:%d", swrr.HttpScheme, domain, addr.Port)
+		baseURL := fmt.Sprintf("%s://%s:%d", swrr.HTTPScheme, domain, addr.Port)
 		hosts[idx] = &Host{BaseURL: baseURL, Weight: int(addr.Weight)}
 	}
 

--- a/load_balancer_test.go
+++ b/load_balancer_test.go
@@ -667,7 +667,7 @@ func TestWeightedRoundRobinStateChangeFiresOnce(t *testing.T) {
 	wrr.SetOnStateChange(func(_ string, from, to HostState) {
 		atomic.AddInt32(&changes, 1)
 		assertEqual(t, HostStateActive, from)
-		assertEqual(t, HostStateInActive, to)
+		assertEqual(t, HostStateInactive, to)
 	})
 
 	for range 5 {
@@ -728,7 +728,7 @@ func TestWeightedRoundRobinHostRecovery(t *testing.T) {
 
 	recovered := make(chan string, 4)
 	wrr.SetOnStateChange(func(baseURL string, from, to HostState) {
-		if from == HostStateInActive && to == HostStateActive {
+		if from == HostStateInactive && to == HostStateActive {
 			// calling back in has to be safe: the hook runs without the lock held
 			_, _ = wrr.NextWithContext(context.Background())
 			recovered <- baseURL

--- a/middleware.go
+++ b/middleware.go
@@ -18,7 +18,6 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
-	"slices"
 	"strings"
 )
 
@@ -61,15 +60,9 @@ func MiddlewareRequestCreate(c *Client, r *Request) (err error) {
 }
 
 func parseRequestURL(c *Client, r *Request) error {
-	if len(c.PathParams())+len(r.PathParams) > 0 {
-		// GitHub #103 Path Params, #663 Raw Path Params
-		for p, v := range c.PathParams() {
-			if _, ok := r.PathParams[p]; ok {
-				continue
-			}
-			r.PathParams[p] = v
-		}
-
+	// GitHub #103 Path Params, #663 Raw Path Params
+	c.mergePathParamsInto(r.PathParams)
+	if len(r.PathParams) > 0 {
 		var prev int
 		buf := acquireBuffer()
 		defer releaseBuffer(buf)
@@ -158,14 +151,8 @@ func parseRequestURL(c *Client, r *Request) error {
 	}
 
 	// Adding Query Param
-	if len(c.QueryParams())+len(r.QueryParams) > 0 {
-		for k, v := range c.QueryParams() {
-			if _, ok := r.QueryParams[k]; ok {
-				continue
-			}
-			r.QueryParams[k] = slices.Clone(v)
-		}
-
+	c.mergeQueryParamsInto(r.QueryParams)
+	if len(r.QueryParams) > 0 {
 		// GitHub #123 Preserve query string order partially.
 		// Since not feasible in `SetQuery*` resty methods, because
 		// standard package `url.Encode(...)` sorts the query params
@@ -192,12 +179,7 @@ func parseRequestURL(c *Client, r *Request) error {
 }
 
 func parseRequestHeader(c *Client, r *Request) {
-	for k, v := range c.Header() {
-		if _, ok := r.Header[k]; ok {
-			continue
-		}
-		r.Header[k] = slices.Clone(v)
-	}
+	c.mergeHeaderInto(r.Header)
 
 	if !r.isHeaderExists(hdrUserAgentKey) {
 		r.Header.Set(hdrUserAgentKey, hdrUserAgentValue)
@@ -350,12 +332,7 @@ func handleMultipartFormData(r *Request) error {
 }
 
 func handleMultipart(c *Client, r *Request) error {
-	for k, v := range c.FormData() {
-		if _, ok := r.FormData[k]; ok {
-			continue
-		}
-		r.FormData[k] = slices.Clone(v)
-	}
+	c.mergeFormDataInto(r.FormData)
 
 	if len(r.multipartFields) == 0 {
 		return handleMultipartFormData(r)
@@ -448,12 +425,7 @@ func handleMultipart(c *Client, r *Request) error {
 }
 
 func handleFormData(c *Client, r *Request) {
-	for k, v := range c.FormData() {
-		if _, ok := r.FormData[k]; ok {
-			continue
-		}
-		r.FormData[k] = slices.Clone(v)
-	}
+	c.mergeFormDataInto(r.FormData)
 
 	r.bodyBuf = acquireBuffer()
 	r.bodyBuf.WriteString(r.FormData.Encode())
@@ -590,6 +562,17 @@ func MiddlewareResponseAutoParse(c *Client, res *Response) (err error) {
 		}
 	}
 
+	// A decoder exists, but no result object was registered for this status code,
+	// so nothing above consumed the body. Read it here: leaving it open holds the
+	// connection out of the keep-alive pool for the life of the process, and it
+	// keeps [Response.String] and [Response.Bytes] working on this path.
+	//
+	// The exception is a save-to-file response, whose body belongs to
+	// [MiddlewareResponseSaveToFile] further down the chain; buffering it here
+	// would hold the whole download in memory.
+	if !res.Request.IsResponseSaveToFile {
+		err = res.readAll()
+	}
 	return
 }
 

--- a/middleware.go
+++ b/middleware.go
@@ -186,7 +186,7 @@ func parseRequestHeader(c *Client, r *Request) {
 	}
 
 	if !r.isHeaderExists(hdrAcceptEncodingKey) {
-		r.Header.Set(hdrAcceptEncodingKey, r.client.ContentDecompresserKeys())
+		r.Header.Set(hdrAcceptEncodingKey, r.client.ContentDecompressorKeys())
 	}
 }
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -474,7 +474,7 @@ func Test_parseRequestHeader(t *testing.T) {
 			tt.init(c, r)
 
 			// add common expected headers from client into expectedHeader
-			tt.expectedHeader.Set(hdrAcceptEncodingKey, c.ContentDecompresserKeys())
+			tt.expectedHeader.Set(hdrAcceptEncodingKey, c.ContentDecompressorKeys())
 
 			parseRequestHeader(c, r)
 

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -12,7 +12,9 @@ import (
 	"io"
 	"mime"
 	"mime/multipart"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/textproto"
 	"net/url"
 	"os"
@@ -20,6 +22,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -1417,11 +1420,11 @@ func TestClientValuesAreNotAliasedIntoRequests(t *testing.T) {
 	// Set then two Adds leaves len 3 in a cap 4 array: one spare slot, which is
 	// where a request's own Add would write.
 	c.SetHeader("X-Multi", "one")
-	c.Header().Add("X-Multi", "two")
-	c.Header().Add("X-Multi", "three")
+	c.AddHeader("X-Multi", "two")
+	c.AddHeader("X-Multi", "three")
 	c.SetQueryParam("tag", "a")
-	c.QueryParams().Add("tag", "b")
-	c.QueryParams().Add("tag", "c")
+	c.AddQueryParam("tag", "b")
+	c.AddQueryParam("tag", "c")
 
 	newRequest := func(path, marker string) *Request {
 		r := c.R()
@@ -1445,4 +1448,89 @@ func TestClientValuesAreNotAliasedIntoRequests(t *testing.T) {
 	// and the client itself must be untouched
 	assertEqual(t, 3, len(c.Header()["X-Multi"]))
 	assertEqual(t, 3, len(c.QueryParams()["tag"]))
+}
+
+// MiddlewareResponseAutoParse used to return without reading or closing the body
+// when a content-type decoder matched but the caller registered no Result (2xx)
+// or ResultError (4xx/5xx). The connection was then never returned to the
+// keep-alive pool, so every such request opened a fresh one.
+func TestAutoParseReleasesBodyWithoutResult(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		contentType string
+		body        string
+		statusCode  int
+		setResult   bool
+		setErr      bool
+	}{
+		{"json 200 without result", "application/json", `{"a":1}`, http.StatusOK, false, false},
+		{"json 200 with result", "application/json", `{"a":1}`, http.StatusOK, true, false},
+		{"json 500 without result error", "application/json", `{"a":1}`, http.StatusInternalServerError, false, false},
+		{"xml 200 without result", "application/xml", `<r><a>1</a></r>`, http.StatusOK, false, false},
+		{"no decoder for content type", "text/plain", `hello`, http.StatusOK, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var conns int32
+			ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set(hdrContentTypeKey, tc.contentType)
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			ts.Config.ConnState = func(_ net.Conn, s http.ConnState) {
+				if s == http.StateNew {
+					atomic.AddInt32(&conns, 1)
+				}
+			}
+			ts.Start()
+			defer ts.Close()
+
+			c := dcnl().SetBaseURL(ts.URL)
+			defer c.Close()
+
+			for i := 0; i < 5; i++ {
+				req := c.R()
+				if tc.setResult {
+					req.SetResult(&map[string]any{})
+				}
+				if tc.setErr {
+					req.SetResultError(&map[string]any{})
+				}
+				res, err := req.Get("/")
+				assertError(t, err)
+				assertEqual(t, tc.statusCode, res.StatusCode())
+				if !tc.setResult && !tc.setErr {
+					// nothing decoded it, so the body must still reach the caller
+					assertEqual(t, tc.body, res.String())
+				}
+			}
+
+			// one connection, reused for all five requests
+			assertEqual(t, int32(1), atomic.LoadInt32(&conns))
+		})
+	}
+}
+
+// A save-to-file response body belongs to MiddlewareResponseSaveToFile, so
+// AutoParse must not buffer it even though a decoder matches its content type.
+func TestAutoParseDoesNotBufferSaveToFileBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(hdrContentTypeKey, "application/json")
+		_, _ = w.Write([]byte(`{"a":1}`))
+	}))
+	defer ts.Close()
+
+	outputFile := filepath.Join(getTestDataPath(), "auto-parse-save.json")
+	defer cleanupFiles(outputFile)
+
+	c := dcnl().SetBaseURL(ts.URL)
+	defer c.Close()
+
+	res, err := c.R().SetResponseSaveFileName(outputFile).Get("/")
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, res.StatusCode())
+	assertEqual(t, false, res.IsRead)
+
+	b, err := os.ReadFile(outputFile)
+	assertError(t, err)
+	assertEqual(t, `{"a":1}`, string(b))
 }

--- a/multipart.go
+++ b/multipart.go
@@ -15,7 +15,11 @@ import (
 	"strings"
 )
 
-var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
+// quoteEscaper matches mime/multipart's own escaper. CR and LF must be
+// percent-encoded: multipart part headers are written verbatim, so a newline in
+// a field name, filename or content type would otherwise inject headers or
+// terminate the part early.
+var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"", "\r", "%0D", "\n", "%0A")
 
 func escapeQuotes(s string) string {
 	return quoteEscaper.Replace(s)
@@ -61,6 +65,11 @@ type MultipartField struct {
 	// tempBuf is used to preserve the byte(s) read from the file to detect the content type.
 	// Or any possible read error early.
 	tempBuf []byte
+
+	// openedByResty records that Resty opened Reader itself from FilePath, so it
+	// owns the handle and may close and reopen it between retry attempts. A
+	// caller-supplied Reader is never reopened, only rewound.
+	openedByResty bool
 }
 
 // Clone returns a copy of m, except [MultipartField.Reader] which is shared.
@@ -71,6 +80,16 @@ func (mf *MultipartField) Clone() *MultipartField {
 }
 
 func (mf *MultipartField) resetReader() error {
+	// tempBuf holds the head sniffed for content-type detection on the previous
+	// attempt. The rewound reader supplies those bytes again, so drop it rather
+	// than writing them a second time.
+	mf.tempBuf = nil
+
+	// A file Resty opened is closed after every attempt, so seeking it would
+	// fail with "file already closed". Reopen it instead.
+	if mf.openedByResty && mf.Reader == nil {
+		return mf.openFile()
+	}
 	if rs, ok := mf.Reader.(io.ReadSeeker); ok {
 		_, err := rs.Seek(0, io.SeekStart)
 		return err
@@ -84,6 +103,11 @@ func (mf *MultipartField) isValues() bool {
 
 func (mf *MultipartField) close() {
 	closeq(mf.Reader)
+	if mf.openedByResty {
+		// Drop the closed handle so a retry reopens FilePath rather than
+		// seeking a file that is already closed.
+		mf.Reader = nil
+	}
 }
 
 func (mf *MultipartField) createHeader() textproto.MIMEHeader {
@@ -121,6 +145,7 @@ func (mf *MultipartField) openFile() error {
 
 	mf.Reader = file
 	mf.FileSize = fileStat.Size()
+	mf.openedByResty = true
 
 	return nil
 }

--- a/multipart_test.go
+++ b/multipart_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"io/fs"
 	"mime/multipart"
 	"net/http"
@@ -754,4 +755,114 @@ func TestRetryNonSeekableReaderWithoutFactoryReturnsError(t *testing.T) {
 
 	assertErrorIs(t, ErrReaderNotSeekable, err)
 	assertEqual(t, 1, attemptCount)
+}
+
+// Resty opens files named by SetFile itself and closes them after every attempt,
+// so a retry used to seek an already-closed handle and abandon the request. The
+// sniffed content-type head must also be sent exactly once per attempt.
+func TestMultipartRetryResendsIdenticalFile(t *testing.T) {
+	var mu sync.Mutex
+	var bodies []string
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, string(body))
+		mu.Unlock()
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	defer ts.Close()
+
+	c := dcnl()
+	defer c.Close()
+
+	_, err := c.R().
+		SetRetryCount(1).
+		SetRetryWaitTime(time.Millisecond).
+		SetRetryMaxWaitTime(2*time.Millisecond).
+		SetRetryAllowNonIdempotent(true).
+		AddRetryConditions(func(res *Response, _ error) bool { return true }).
+		SetFile("file", filepath.Join(getTestDataPath(), "text-file.txt")).
+		Post(ts.URL)
+	assertNil(t, err)
+
+	const payload = "THIS IS TEXT FILE FOR MULTIPART UPLOAD TEST :)"
+
+	mu.Lock()
+	defer mu.Unlock()
+	assertEqual(t, 2, len(bodies))
+	for _, body := range bodies {
+		// exactly once: the sniffed head is neither dropped nor re-sent
+		assertEqual(t, 1, strings.Count(body, payload))
+		assertEqual(t, 1, strings.Count(body, "text-file.txt"))
+	}
+}
+
+// mime/multipart writes part headers verbatim, so CR and LF in a field name,
+// filename or content type must be percent-encoded. Resty's escaper was a fork
+// of the stdlib one with those two replacements dropped, which let an
+// attacker-controlled filename inject headers or forge an entire extra part.
+func TestEscapeQuotesEncodesCRLF(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		in     string
+		expect string
+	}{
+		{"carriage return", "a\rb", "a%0Db"},
+		{"line feed", "a\nb", "a%0Ab"},
+		{"crlf pair", "a\r\nb", "a%0D%0Ab"},
+		{"quote still escaped", `a"b`, `a\"b`},
+		{"backslash still escaped", `a\b`, `a\\b`},
+		{"plain text untouched", "report.pdf", "report.pdf"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assertEqual(t, tc.expect, escapeQuotes(tc.in))
+		})
+	}
+}
+
+func TestMultipartFileNameCannotInjectParts(t *testing.T) {
+	var gotRole string
+	var partCount int
+	var parseErr error
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		mr, err := r.MultipartReader()
+		if err != nil {
+			parseErr = err
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		for {
+			p, err := mr.NextPart()
+			if err != nil {
+				break
+			}
+			partCount++
+			if p.FormName() == "role" {
+				b, _ := io.ReadAll(p)
+				gotRole = string(b)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	defer ts.Close()
+
+	c := dcnl()
+	defer c.Close()
+
+	// A filename carrying a forged part boundary and an extra form field.
+	evil := "x.txt\"\r\n\r\nnot-a-part\r\n--BOUND\r\n" +
+		"Content-Disposition: form-data; name=\"role\"\r\n\r\nadmin\r\n--BOUND--\r\n"
+
+	res, err := c.R().
+		SetMultipartBoundary("BOUND").
+		SetFileReader("file", evil, strings.NewReader("real content")).
+		Post(ts.URL)
+	assertError(t, err)
+	assertEqual(t, http.StatusOK, res.StatusCode())
+
+	// A real multipart parser must see exactly the one part Resty intended,
+	// and no injected "role" field.
+	assertNil(t, parseErr)
+	assertEqual(t, 1, partCount)
+	assertEqual(t, "", gotRole)
 }

--- a/rate_limiter.go
+++ b/rate_limiter.go
@@ -36,18 +36,18 @@ func rateLimitError(ctx context.Context) error {
 
 // RateLimiter is the interface that wraps the rate limiting behavior used by
 // [Client]. Implement this interface to provide custom rate limiting strategies.
-// The [Client] calls [RateLimiter.Allow] before every request; if it returns
+// The [Client] calls [RateLimiter.Wait] before every request; if it returns
 // an error the request is aborted with that error.
 //
-// The context passed to [RateLimiter.Allow] is the request context, so
+// The context passed to [RateLimiter.Wait] is the request context, so
 // cancellation or deadline expiry is respected automatically. Implementations
 // must be safe for concurrent use.
 type RateLimiter interface {
-	// Allow blocks until the rate limiter permits the next request or the
+	// Wait blocks until the rate limiter permits the next request or the
 	// context is done. It returns [ErrRateLimitExceeded] if the context expires
 	// or is cancelled before a token is available, and nil when the request may
 	// proceed. Implementations must be goroutine-safe.
-	Allow(ctx context.Context) error
+	Wait(ctx context.Context) error
 }
 
 // NewRateLimitTokenBucket creates a new token-bucket [RateLimiter] that permits at most
@@ -89,7 +89,7 @@ var _ RateLimiter = (*RateLimitTokenBucket)(nil)
 // RateLimitTokenBucket is a token-bucket based implementation of [RateLimiter].
 // It implements the standard token-bucket algorithm: tokens refill at a
 // constant rate and each request consumes one token. When no tokens are
-// available, [RateLimitTokenBucket.Allow] blocks until either a token becomes
+// available, [RateLimitTokenBucket.Wait] blocks until either a token becomes
 // available or the context expires.
 //
 // This implementation is safe for concurrent use from multiple goroutines.
@@ -119,16 +119,16 @@ func (l *RateLimitTokenBucket) Burst() int {
 	return l.burst
 }
 
-// Allow blocks until the rate limiter grants a token or the context is done.
+// Wait blocks until the rate limiter grants a token or the context is done.
 // It returns [ErrRateLimitExceeded] if the context is cancelled or times out
 // before a token is available.
 //
 // Performance note: Timer allocations occur only when tokens are exhausted and
-// waiting is necessary. When tokens are available (the common case), Allow
+// waiting is necessary. When tokens are available (the common case), Wait
 // returns immediately without allocating timers. Context deadline and
 // cancellation checks are performed on every iteration,
 // respecting cancellation immediately even during token waits.
-func (l *RateLimitTokenBucket) Allow(ctx context.Context) error {
+func (l *RateLimitTokenBucket) Wait(ctx context.Context) error {
 	for {
 		// Check context first to avoid acquiring the lock unnecessarily.
 		select {
@@ -235,16 +235,16 @@ func (l *RateLimitSlidingWindow) WindowSize() time.Duration {
 	return l.windowSize
 }
 
-// Allow blocks until the sliding window permits the next request or the context
+// Wait blocks until the sliding window permits the next request or the context
 // is done. It returns [ErrRateLimitExceeded] if the context is cancelled or
 // times out before a slot becomes available.
 //
-// Performance note: When a slot is available (the common case), Allow returns
+// Performance note: When a slot is available (the common case), Wait returns
 // immediately after evicting out-of-window timestamps. The eviction is O(n)
 // where n is the number of out-of-window timestamps, but typically small due
 // to sliding window semantics. Context cancellation is checked before and during
 // any wait period, respecting cancellation immediately.
-func (l *RateLimitSlidingWindow) Allow(ctx context.Context) error {
+func (l *RateLimitSlidingWindow) Wait(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/rate_limiter_test.go
+++ b/rate_limiter_test.go
@@ -18,7 +18,7 @@ func TestRateLimiterTokenBucket(t *testing.T) {
 	t.Run("allow", func(t *testing.T) {
 		l := NewRateLimitTokenBucket(100, 5)
 		for i := range 5 {
-			err := l.Allow(context.Background())
+			err := l.Wait(context.Background())
 			assertNil(t, err, fmt.Sprintf("unexpected error on iteration %d", i))
 		}
 	})
@@ -28,25 +28,25 @@ func TestRateLimiterTokenBucket(t *testing.T) {
 		l := NewRateLimitTokenBucket(1, 1)
 
 		// First call should succeed immediately (burst token available).
-		err := l.Allow(context.Background())
+		err := l.Wait(context.Background())
 		assertNil(t, err)
 
 		// Second call: no token available, context with very short deadline should time out.
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		defer cancel()
-		err = l.Allow(ctx)
+		err = l.Wait(ctx)
 		assertErrorIs(t, ErrRateLimitExceeded, err)
 	})
 
 	t.Run("context cancellation", func(t *testing.T) {
 		// rate=1/s, burst=1 -> drain burst first, then cancel
 		l := NewRateLimitTokenBucket(1, 1)
-		_ = l.Allow(context.Background()) // drain the single burst token
+		_ = l.Wait(context.Background()) // drain the single burst token
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // already cancelled
 
-		err := l.Allow(ctx)
+		err := l.Wait(ctx)
 		assertErrorIs(t, ErrRateLimitExceeded, err)
 	})
 
@@ -55,7 +55,7 @@ func TestRateLimiterTokenBucket(t *testing.T) {
 		l := NewRateLimitTokenBucket(10, 1)
 
 		// Drain burst.
-		err := l.Allow(context.Background())
+		err := l.Wait(context.Background())
 		assertNil(t, err)
 
 		// Wait for one token to refill, then allow should succeed.
@@ -63,7 +63,7 @@ func TestRateLimiterTokenBucket(t *testing.T) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 		defer cancel()
-		err = l.Allow(ctx)
+		err = l.Wait(ctx)
 		assertNil(t, err, "expected token to be available after refill interval")
 	})
 }
@@ -163,7 +163,7 @@ type customTestLimiter struct {
 	calls *atomic.Int32
 }
 
-func (l *customTestLimiter) Allow(_ context.Context) error {
+func (l *customTestLimiter) Wait(_ context.Context) error {
 	l.calls.Add(1)
 	if !l.allow {
 		return ErrRateLimitExceeded
@@ -175,7 +175,7 @@ func TestRateLimiterSlidingWindow(t *testing.T) {
 	t.Run("allow", func(t *testing.T) {
 		l := NewRateLimitSlidingWindow(5, time.Second)
 		for i := range 5 {
-			err := l.Allow(context.Background())
+			err := l.Wait(context.Background())
 			assertNil(t, err, fmt.Sprintf("unexpected error on iteration %d: %v", i, err))
 		}
 	})
@@ -183,23 +183,23 @@ func TestRateLimiterSlidingWindow(t *testing.T) {
 	t.Run("limit exhausted", func(t *testing.T) {
 		// 2 requests per second window; drain both slots immediately.
 		l := NewRateLimitSlidingWindow(2, time.Second)
-		assertNil(t, l.Allow(context.Background()))
-		assertNil(t, l.Allow(context.Background()))
+		assertNil(t, l.Wait(context.Background()))
+		assertNil(t, l.Wait(context.Background()))
 
 		// Third request: window is full, short deadline must be rejected.
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		defer cancel()
-		err := l.Allow(ctx)
+		err := l.Wait(ctx)
 		assertErrorIs(t, ErrRateLimitExceeded, err)
 	})
 
 	t.Run("context cancellation", func(t *testing.T) {
 		l := NewRateLimitSlidingWindow(1, time.Second)
-		assertNil(t, l.Allow(context.Background())) // drain the single slot
+		assertNil(t, l.Wait(context.Background())) // drain the single slot
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // already cancelled
-		err := l.Allow(ctx)
+		err := l.Wait(ctx)
 		assertErrorIs(t, ErrRateLimitExceeded, err)
 	})
 
@@ -207,13 +207,13 @@ func TestRateLimiterSlidingWindow(t *testing.T) {
 		// Window of 100 ms, limit 1: after the first request, wait >100 ms and
 		// the slot should become available again.
 		l := NewRateLimitSlidingWindow(1, 100*time.Millisecond)
-		assertNil(t, l.Allow(context.Background()))
+		assertNil(t, l.Wait(context.Background()))
 
 		time.Sleep(120 * time.Millisecond)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 		defer cancel()
-		err := l.Allow(ctx)
+		err := l.Wait(ctx)
 		assertNil(t, err, "expected slot to be available after window slides")
 	})
 
@@ -263,12 +263,12 @@ func TestRateLimiterErrorWrapsContextCause(t *testing.T) {
 
 	for name, l := range limiters {
 		t.Run(name, func(t *testing.T) {
-			assertNil(t, l.Allow(context.Background())) // consume the only slot
+			assertNil(t, l.Wait(context.Background())) // consume the only slot
 
 			t.Run("cancelled", func(t *testing.T) {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()
-				err := l.Allow(ctx)
+				err := l.Wait(ctx)
 				assertErrorIs(t, ErrRateLimitExceeded, err)
 				assertErrorIs(t, context.Canceled, err)
 			})
@@ -276,7 +276,7 @@ func TestRateLimiterErrorWrapsContextCause(t *testing.T) {
 			t.Run("deadline exceeded", func(t *testing.T) {
 				ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 				defer cancel()
-				err := l.Allow(ctx)
+				err := l.Wait(ctx)
 				assertErrorIs(t, ErrRateLimitExceeded, err)
 				assertErrorIs(t, context.DeadlineExceeded, err)
 			})

--- a/redirect.go
+++ b/redirect.go
@@ -8,8 +8,9 @@ package resty
 import (
 	"errors"
 	"fmt"
-	"maps"
 	"net/http"
+	"net/url"
+	"slices"
 	"strings"
 )
 
@@ -60,7 +61,7 @@ func RedirectFlexiblePolicy(noOfRedirect int) RedirectPolicy {
 		if len(via) >= noOfRedirect {
 			return fmt.Errorf("resty: stopped after %d redirects", noOfRedirect)
 		}
-		checkHostAndAddHeaders(req, via[0])
+		checkHostAndAddHeaders(req, via)
 		return nil
 	})
 }
@@ -79,7 +80,7 @@ func RedirectDomainCheckPolicy(hostnames ...string) RedirectPolicy {
 		if ok := hosts[strings.ToLower(req.URL.Host)]; !ok {
 			return errors.New("resty: redirect is not allowed as per DomainCheckRedirectPolicy")
 		}
-		checkHostAndAddHeaders(req, via[0])
+		checkHostAndAddHeaders(req, via)
 		return nil
 	})
 }
@@ -123,29 +124,89 @@ func RedirectHeaderStripSensitivePolicy(applyDefault bool, headers ...string) Re
 	})
 }
 
+// redirectBodyHeaders describe the enclosed representation. RFC 9110 section 8.3
+// ties them to a request body, and net/http deliberately withholds them when a
+// 301, 302 or 303 turns a request with a body into a body-less GET, so they must
+// not be restored on a method change either.
+var redirectBodyHeaders = []string{
+	"Content-Type",
+	"Content-Encoding",
+	"Content-Language",
+	"Content-Location",
+}
+
+// sameOrigin reports whether two URLs share a scheme and a host. Host alone is
+// not enough: the default port is elided, so an https to http downgrade of the
+// same hostname compares equal on Host and would look like a same-origin hop.
+func sameOrigin(a, b *url.URL) bool {
+	return strings.EqualFold(a.Scheme, b.Scheme) && strings.EqualFold(a.Host, b.Host)
+}
+
+// leftOrigin reports whether any hop so far targeted an origin other than the
+// one the chain started at.
+func leftOrigin(via []*http.Request) bool {
+	for _, r := range via[1:] {
+		if !sameOrigin(r.URL, via[0].URL) {
+			return true
+		}
+	}
+	return false
+}
+
 // By default, Golang will not redirect request headers.
 // After reading through the various discussion comments from the thread -
 // https://github.com/golang/go/issues/4800
 // Resty will add all the headers during a redirect for the same host and
 // adds library user-agent if the Host is different.
 //
-// For cross-domain redirects, sensitive headers (matching [isSanitizeHeader])
+// For cross-origin redirects, sensitive headers (matching [isSanitizeHeader])
 // are stripped from the redirected request. Go's net/http only strips standard
 // headers such as Authorization and Cookie; custom authentication headers
 // (e.g. those set via [Client.SetHeaderAuthorizationKey]) are forwarded
 // verbatim unless explicitly removed. See https://github.com/go-resty/resty/issues/1128.
-func checkHostAndAddHeaders(cur *http.Request, pre *http.Request) {
-	curHostname := strings.ToLower(cur.URL.Host)
-	preHostname := strings.ToLower(pre.URL.Host)
-	if strings.EqualFold(curHostname, preHostname) {
-		maps.Copy(cur.Header, pre.Header)
-	} else {
-		// Cross-domain redirect: strip sensitive headers that Go's
+//
+// Headers already present on the redirected request are never overwritten, and
+// three kinds are never restored from the original request:
+//
+//   - anything sensitive, once any hop in the chain has left the original
+//     origin. net/http sets its own strip flag once and never clears it, so a
+//     credential dropped at a foreign hop must stay dropped even if the chain
+//     returns to the original host.
+//   - [redirectBodyHeaders], when the redirect changed the method and therefore
+//     dropped the body.
+//   - anything on a hop whose scheme or host differs from the original.
+func checkHostAndAddHeaders(cur *http.Request, via []*http.Request) {
+	orig := via[0]
+
+	if !sameOrigin(cur.URL, orig.URL) {
+		// Cross-origin redirect: strip sensitive headers that Go's
 		// net/http does not know about (custom auth, token, api-key, etc.).
 		for key := range cur.Header {
 			if isSanitizeHeader(key) {
 				cur.Header.Del(key)
 			}
 		}
+		return
+	}
+
+	credentialsSpent := leftOrigin(via)
+	methodChanged := cur.Method != orig.Method
+
+	for key, value := range orig.Header {
+		// Never clobber what net/http or an earlier hop already set; that is how
+		// a Set-Cookie delivered with the redirect supersedes the original
+		// Cookie header (RFC 6265 section 5.3).
+		if _, ok := cur.Header[key]; ok {
+			continue
+		}
+		if credentialsSpent && isSanitizeHeader(key) {
+			continue
+		}
+		if methodChanged && slices.ContainsFunc(redirectBodyHeaders, func(h string) bool {
+			return strings.EqualFold(h, key)
+		}) {
+			continue
+		}
+		cur.Header[key] = slices.Clone(value)
 	}
 }

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2015-present Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
+// resty source code and usage is governed by a MIT style
+// license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package resty
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func mustReq(t *testing.T, method, rawURL string) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(method, rawURL, nil)
+	assertNil(t, err)
+	return req
+}
+
+func TestSameOrigin(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		a, b   string
+		expect bool
+	}{
+		{"identical", "https://a.com/x", "https://a.com/y", true},
+		{"case-insensitive host", "https://A.com/x", "https://a.com/y", true},
+		{"scheme downgrade", "http://a.com/x", "https://a.com/y", false},
+		{"different host", "https://a.com/x", "https://b.com/y", false},
+		{"explicit port differs", "https://a.com:8443/x", "https://a.com/y", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			au, _ := url.Parse(tc.a)
+			bu, _ := url.Parse(tc.b)
+			assertEqual(t, tc.expect, sameOrigin(au, bu))
+		})
+	}
+}
+
+// An https -> http redirect keeps the same URL.Host, because the default port is
+// elided, so a host-only comparison treated the downgrade as same-origin and put
+// the caller's credentials on the wire in cleartext.
+func TestCheckHostAndAddHeadersSchemeDowngrade(t *testing.T) {
+	orig := mustReq(t, http.MethodGet, "https://example.com/api")
+	orig.Header.Set("Authorization", "Bearer secret")
+	orig.Header.Set("Cookie", "sid=secret")
+
+	cur := mustReq(t, http.MethodGet, "http://example.com/api")
+	checkHostAndAddHeaders(cur, []*http.Request{orig})
+
+	assertEqual(t, "", cur.Header.Get("Authorization"))
+	assertEqual(t, "", cur.Header.Get("Cookie"))
+}
+
+// net/http sets its strip flag once and never clears it, so a credential dropped
+// at a foreign hop must stay dropped even when the chain returns to the original
+// host. Resty compared only against via[0] and copied the originals back.
+func TestCheckHostAndAddHeadersDoesNotResurrectCredentials(t *testing.T) {
+	orig := mustReq(t, http.MethodGet, "https://example.com/api")
+	orig.Header.Set("Authorization", "Bearer secret")
+	orig.Header.Set("X-Api-Key", "key")
+	orig.Header.Set("X-Safe", "safe")
+
+	attacker := mustReq(t, http.MethodGet, "https://evil.example.net/x")
+	cur := mustReq(t, http.MethodGet, "https://example.com/back")
+
+	checkHostAndAddHeaders(cur, []*http.Request{orig, attacker})
+
+	assertEqual(t, "", cur.Header.Get("Authorization"))
+	assertEqual(t, "", cur.Header.Get("X-Api-Key"))
+	// non-sensitive headers are still restored
+	assertEqual(t, "safe", cur.Header.Get("X-Safe"))
+}
+
+// A chain that never leaves the origin still gets its headers restored.
+func TestCheckHostAndAddHeadersSameOriginChain(t *testing.T) {
+	orig := mustReq(t, http.MethodGet, "https://example.com/api")
+	orig.Header.Set("Authorization", "Bearer secret")
+
+	hop := mustReq(t, http.MethodGet, "https://example.com/hop")
+	cur := mustReq(t, http.MethodGet, "https://example.com/final")
+
+	checkHostAndAddHeaders(cur, []*http.Request{orig, hop})
+	assertEqual(t, "Bearer secret", cur.Header.Get("Authorization"))
+}
+
+// RFC 9110 section 8.3: Content-Type describes the enclosed representation, and
+// a 301/302/303 that rewrites POST to GET drops the body. net/http withholds the
+// body headers accordingly; Resty copied them back.
+func TestCheckHostAndAddHeadersDropsBodyHeadersOnMethodChange(t *testing.T) {
+	orig := mustReq(t, http.MethodPost, "https://example.com/api")
+	orig.Header.Set("Content-Type", "application/json")
+	orig.Header.Set("Content-Language", "en")
+	orig.Header.Set("X-Trace", "abc")
+
+	cur := mustReq(t, http.MethodGet, "https://example.com/api")
+	checkHostAndAddHeaders(cur, []*http.Request{orig})
+
+	assertEqual(t, "", cur.Header.Get("Content-Type"))
+	assertEqual(t, "", cur.Header.Get("Content-Language"))
+	assertEqual(t, "abc", cur.Header.Get("X-Trace"))
+
+	// same method keeps them
+	cur2 := mustReq(t, http.MethodPost, "https://example.com/api")
+	checkHostAndAddHeaders(cur2, []*http.Request{orig})
+	assertEqual(t, "application/json", cur2.Header.Get("Content-Type"))
+}
+
+// RFC 6265 section 5.3: a cookie received with the redirect supersedes the one
+// the caller sent. maps.Copy overwrote the corrected header with the stale one,
+// so the request carried "sid=old; sid=new" and servers took the first match.
+func TestCheckHostAndAddHeadersDoesNotClobberExistingHeaders(t *testing.T) {
+	orig := mustReq(t, http.MethodGet, "https://example.com/api")
+	orig.Header.Set("Cookie", "sid=old")
+	orig.Header.Set("X-Only-On-Original", "yes")
+
+	cur := mustReq(t, http.MethodGet, "https://example.com/next")
+	cur.Header.Set("Cookie", "sid=new")
+
+	checkHostAndAddHeaders(cur, []*http.Request{orig})
+
+	assertEqual(t, "sid=new", cur.Header.Get("Cookie"))
+	assertEqual(t, 1, len(cur.Header["Cookie"]))
+	assertEqual(t, "yes", cur.Header.Get("X-Only-On-Original"))
+}

--- a/request.go
+++ b/request.go
@@ -173,10 +173,7 @@ func (r *Request) WithContext(ctx context.Context) *Request {
 	if ctx == nil {
 		panic("resty: Request.WithContext nil context")
 	}
-	rr := new(Request)
-	*rr = *r
-	rr.ctx = ctx
-	return rr
+	return r.Clone(ctx)
 }
 
 // SetContentType method is a convenient way to set the header Content-Type in the request
@@ -1573,7 +1570,7 @@ func (r *Request) Execute(method, url string) (res *Response, err error) {
 			// let's drain the response body, before retry wait
 			drainBody(res)
 
-			waitDuration, waitErr := backoff.NextWaitDuration(r.client, res, err, r.Attempt)
+			waitDuration, waitErr := backoff.NextWaitDuration(r.client, r, res, err, r.Attempt)
 			if waitErr != nil {
 				// if any error in retry strategy, stop here
 				err = wrapErrors(waitErr, err)

--- a/request_test.go
+++ b/request_test.go
@@ -778,7 +778,7 @@ func TestFormDataDisableWarn(t *testing.T) {
 
 	c := dcnl()
 	c.SetFormData(map[string]string{"zip_code": "00000", "city": "Los Angeles"}).
-		SetLoggerWarnLevel(true)
+		SetDisableWarn(true)
 	c.outputLogTo(io.Discard)
 
 	resp, err := c.R().
@@ -895,11 +895,11 @@ func TestPutJSONString(t *testing.T) {
 
 	client := dcnl()
 
-	client.AddRequestMiddleware(func(c *Client, r *Request) error {
+	client.AddRequestMiddlewares(func(c *Client, r *Request) error {
 		r.SetHeader("X-Custom-Request-Middleware", "Request middleware")
 		return nil
 	})
-	client.AddRequestMiddleware(func(c *Client, r *Request) error {
+	client.AddRequestMiddlewares(func(c *Client, r *Request) error {
 		r.SetHeader("X-ContentLength", "Request middleware ContentLength set")
 		return nil
 	})
@@ -937,11 +937,11 @@ func TestRequestMiddleware(t *testing.T) {
 
 	c := dcnl()
 
-	c.AddRequestMiddleware(func(c *Client, r *Request) error {
+	c.AddRequestMiddlewares(func(c *Client, r *Request) error {
 		r.SetHeader("X-Custom-Request-Middleware", "Request middleware")
 		return nil
 	})
-	c.AddRequestMiddleware(func(c *Client, r *Request) error {
+	c.AddRequestMiddlewares(func(c *Client, r *Request) error {
 		r.SetHeader("X-ContentLength", "Request middleware ContentLength set")
 		return nil
 	})
@@ -2320,7 +2320,7 @@ func TestResponseBodyUnlimitedReads(t *testing.T) {
 		SetJSONEscapeHTML(false).
 		SetResponseBodyUnlimitedReads(true)
 
-	assertTrue(t, c.ResponseBodyUnlimitedReads())
+	assertTrue(t, c.IsResponseBodyUnlimitedReads())
 
 	resp, err := c.R().
 		SetHeader(hdrContentTypeKey, "application/json; charset=utf-8").

--- a/response.go
+++ b/response.go
@@ -309,13 +309,13 @@ func (r *Response) wrapCopyReadCloser() {
 	}
 }
 
-func (r *Response) wrapContentDecompresser() error {
+func (r *Response) wrapContentDecompressor() error {
 	ce := r.Header().Get(hdrContentEncodingKey)
 	if isStringEmpty(ce) {
 		return nil
 	}
 
-	if decFunc, f := r.Request.client.ContentDecompressers()[strings.ToLower(ce)]; f {
+	if decFunc, f := r.Request.client.ContentDecompressors()[strings.ToLower(ce)]; f {
 		dec, err := decFunc(r.Body)
 		if err != nil {
 			if err == io.EOF {
@@ -331,14 +331,14 @@ func (r *Response) wrapContentDecompresser() error {
 		r.RawResponse.ContentLength = -1
 	} else if r.Request.IsResponseDoNotParse {
 		// GH#1168 Don't return an error if DoNotParse is enabled and the content
-		// decompresser is not found. Possibly the user is handling content decompression
+		// decompressor is not found. Possibly the user is handling content decompression
 		// in their own way, so instead of returning an error and breaking the response
 		// processing, just log it and let the caller handle it when they try to read the body.
-		r.Request.log.Warnf("Response.wrapContentDecompresser: DoNotParse is enabled and the content"+
-			" decompresser is not found for encoding '%s', just log it and let the caller handle it", ce)
+		r.Request.log.Warnf("Response.wrapContentDecompressor: DoNotParse is enabled and the content"+
+			" decompressor is not found for encoding '%s', just log it and let the caller handle it", ce)
 		return nil
 	} else {
-		return ErrContentDecompresserNotFound
+		return ErrContentDecompressorNotFound
 	}
 
 	return nil

--- a/resty.go
+++ b/resty.go
@@ -178,8 +178,8 @@ func createClient(hc *http.Client) *Client {
 		debugBodyLimit:           math.MaxInt32,
 		contentTypeEncoders:      make(map[string]ContentTypeEncoder),
 		contentTypeDecoders:      make(map[string]ContentTypeDecoder),
-		contentDecompresserKeys:  make([]string, 0),
-		contentDecompressers:     make(map[string]ContentDecompresser),
+		contentDecompressorKeys:  make([]string, 0),
+		contentDecompressors:     make(map[string]ContentDecompressor),
 		certWatcherStopChan:      make(chan bool),
 	}
 
@@ -194,8 +194,8 @@ func createClient(hc *http.Client) *Client {
 	c.AddContentTypeDecoder(xmlKey, decodeXML)
 
 	// Order matter, giving priority to gzip
-	c.AddContentDecompresser("deflate", decompressDeflate)
-	c.AddContentDecompresser("gzip", decompressGzip)
+	c.AddContentDecompressor("deflate", decompressDeflate)
+	c.AddContentDecompressor("gzip", decompressGzip)
 
 	// request middlewares
 	c.SetRequestMiddlewares(

--- a/retry.go
+++ b/retry.go
@@ -34,17 +34,22 @@ type (
 	// request state. It receives the same response and error as [RetryConditionFunc].
 	RetryHookFunc func(*Response, error)
 
-	// RetryDelayStrategyFunc defines a custom retry delay strategy.
-	// It receives the response/error from the previous attempt and returns the
-	// wait duration before the next retry.
+	// RetryDelayStrategyFunc defines a custom retry delay strategy. It receives
+	// the request, the response and error from the previous attempt, and the
+	// attempt number, and returns the wait duration before the next retry.
+	//
+	// res is nil when the attempt failed before a response was received, which
+	// is exactly the transport-error case retries exist for; req and attempt are
+	// always supplied so a strategy can back off without one.
+	//
 	// By default, Resty uses capped exponential backoff with jitter.
-	RetryDelayStrategyFunc func(*Response, error) (time.Duration, error)
+	RetryDelayStrategyFunc func(req *Request, res *Response, attempt int, err error) (time.Duration, error)
 )
 
 // RetryConstantDelayStrategy returns a [RetryDelayStrategyFunc] that always
 // returns the specified delay duration.
 func RetryConstantDelayStrategy(delay time.Duration) RetryDelayStrategyFunc {
-	return func(*Response, error) (time.Duration, error) {
+	return func(*Request, *Response, int, error) (time.Duration, error) {
 		return delay, nil
 	}
 }
@@ -150,7 +155,7 @@ type backoffWithJitter struct {
 	max time.Duration
 }
 
-func (b *backoffWithJitter) NextWaitDuration(c *Client, res *Response, err error, attempt int) (time.Duration, error) {
+func (b *backoffWithJitter) NextWaitDuration(c *Client, req *Request, res *Response, err error, attempt int) (time.Duration, error) {
 	if res != nil {
 		if res.StatusCode() == http.StatusTooManyRequests || res.StatusCode() == http.StatusServiceUnavailable {
 			if delay, ok := parseRetryAfterHeader(res.Header().Get(hdrRetryAfterKey)); ok {
@@ -164,12 +169,15 @@ func (b *backoffWithJitter) NextWaitDuration(c *Client, res *Response, err error
 		b.max = maxInt
 	}
 
-	if res == nil || res.Request.RetryDelayStrategy == nil {
+	if req == nil && res != nil {
+		req = res.Request
+	}
+	if req == nil || req.RetryDelayStrategy == nil {
 		return b.balanceMinMax(b.defaultDelayStrategy(attempt)), nil
 	}
 
 	// invoke custom retry delay strategy
-	return res.Request.RetryDelayStrategy(res, err)
+	return req.RetryDelayStrategy(req, res, attempt, err)
 }
 
 // defaultDelayStrategy returns capped exponential backoff with jitter.

--- a/retry_test.go
+++ b/retry_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -218,7 +219,7 @@ func TestClientRetryDelayStrategyFuncError(t *testing.T) {
 	retryWaitTime := 50 * time.Millisecond
 	retryMaxWaitTime := 150 * time.Millisecond
 
-	retryDelayStrategyFunc := func(res *Response, err error) (time.Duration, error) {
+	retryDelayStrategyFunc := func(_ *Request, res *Response, _ int, err error) (time.Duration, error) {
 		return 0, errors.New("quota exceeded")
 	}
 
@@ -1100,7 +1101,7 @@ func TestRetryConstantDelayStrategyReturnsGivenDelay(t *testing.T) {
 	d := 250 * time.Millisecond
 	strat := RetryConstantDelayStrategy(d)
 
-	got, err := strat(nil, nil)
+	got, err := strat(nil, nil, 0, nil)
 	assertNil(t, err)
 	assertEqual(t, d, got)
 }
@@ -1108,14 +1109,14 @@ func TestRetryConstantDelayStrategyReturnsGivenDelay(t *testing.T) {
 func TestRetryConstantDelayStrategyZeroAndNegative(t *testing.T) {
 	// zero duration
 	strategyZero := RetryConstantDelayStrategy(0)
-	d, err := strategyZero(nil, nil)
+	d, err := strategyZero(nil, nil, 0, nil)
 	assertNil(t, err)
 	assertEqual(t, time.Duration(0), d)
 
 	// negative duration (function should faithfully return what was provided)
 	neg := -5 * time.Second
 	strategyNeg := RetryConstantDelayStrategy(neg)
-	d, err = strategyNeg(nil, nil)
+	d, err = strategyNeg(nil, nil, 0, nil)
 	assertNil(t, err)
 	assertEqual(t, neg, d)
 }
@@ -1267,4 +1268,51 @@ func testStaticTime(t *testing.T) {
 	t.Cleanup(func() {
 		timeNow = time.Now
 	})
+}
+
+// RetryDelayStrategyFunc now receives the request and the attempt number
+// directly, so a strategy can back off without reaching through res.Request --
+// which is what it had to do before, and which is unavailable when there is no
+// response at all (the SSE reconnect path passes none).
+func TestRetryDelayStrategyReceivesRequestAndAttempt(t *testing.T) {
+	var mu sync.Mutex
+	var attempts []int
+	var sawTransportError bool
+
+	c := dcnl().SetRetryCount(2).
+		SetRetryWaitTime(time.Millisecond).
+		SetRetryMaxWaitTime(2 * time.Millisecond)
+	defer c.Close()
+
+	_, err := c.R().
+		AddRetryConditions(func(_ *Response, err error) bool { return err != nil }).
+		SetRetryDelayStrategy(func(req *Request, res *Response, attempt int, err error) (time.Duration, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			assertNotNil(t, req)
+			if res == nil || res.RawResponse == nil {
+				sawTransportError = true
+			}
+			attempts = append(attempts, attempt)
+			return time.Millisecond, nil
+		}).
+		Get("http://127.0.0.1:1/never-listening")
+
+	assertNotNil(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assertEqual(t, true, sawTransportError)
+	assertEqual(t, 2, len(attempts))
+	assertEqual(t, 1, attempts[0])
+	assertEqual(t, 2, attempts[1])
+}
+
+// With no response and no request, the strategy cannot be reached, so the
+// default backoff applies. This is the shape the SSE reconnect path uses.
+func TestNextWaitDurationFallsBackWithoutRequest(t *testing.T) {
+	b := newBackoffWithJitter(10*time.Millisecond, 20*time.Millisecond)
+	d, err := b.NextWaitDuration(nil, nil, nil, nil, 0)
+	assertNil(t, err)
+	assertEqual(t, true, d > 0)
 }

--- a/sse.go
+++ b/sse.go
@@ -596,27 +596,36 @@ func (sse *SSESource) isClosed() bool {
 	return sse.closed
 }
 
+// The three trigger methods below snapshot the callback under the read lock and
+// invoke it after releasing. Calling user code while holding the lock deadlocks
+// the moment the callback touches the source -- Close, SetURL and SetHeader all
+// take the write lock, and sync.RWMutex is not reentrant. Stopping the stream
+// from OnOpen and refreshing auth from OnError are both ordinary SSE patterns.
+
 func (sse *SSESource) triggerOnOpen(hdr http.Header) {
 	sse.lock.RLock()
-	defer sse.lock.RUnlock()
-	if sse.onOpen != nil {
-		sse.onOpen(strings.Clone(sse.url), hdr)
+	onOpen, url := sse.onOpen, strings.Clone(sse.url)
+	sse.lock.RUnlock()
+	if onOpen != nil {
+		onOpen(url, hdr)
 	}
 }
 
 func (sse *SSESource) triggerOnError(err error) {
 	sse.lock.RLock()
-	defer sse.lock.RUnlock()
-	if sse.onError != nil {
-		sse.onError(err)
+	onError := sse.onError
+	sse.lock.RUnlock()
+	if onError != nil {
+		onError(err)
 	}
 }
 
 func (sse *SSESource) triggerOnRequestFailure(err error, res *http.Response) {
 	sse.lock.RLock()
-	defer sse.lock.RUnlock()
-	if sse.onRequestFailure != nil {
-		sse.onRequestFailure(err, res)
+	onRequestFailure := sse.onRequestFailure
+	sse.lock.RUnlock()
+	if onRequestFailure != nil {
+		onRequestFailure(err, res)
 	}
 }
 
@@ -753,6 +762,35 @@ func (sse *SSESource) connect() (*http.Response, error) {
 	return nil, fmt.Errorf("resty:sse: unable to connect stream")
 }
 
+// eventTerminators end an event. The WHATWG event stream grammar separates
+// lines with CRLF, LF or CR, so a blank line -- and therefore the end of an
+// event -- is any of those doubled. Recognising only "\n\n" left CRLF streams,
+// which are common in .NET and Java servers, undispatched until EOF.
+var eventTerminators = [][]byte{
+	[]byte("\r\n\r\n"),
+	[]byte("\n\n"),
+	[]byte("\r\r"),
+}
+
+// indexEventTerminator returns the offset and length of the earliest event
+// terminator in data, or -1 when there is none.
+func indexEventTerminator(data []byte) (int, int) {
+	best, width := -1, 0
+	for _, t := range eventTerminators {
+		i := bytes.Index(data, t)
+		if i < 0 {
+			continue
+		}
+		if best < 0 || i < best || (i == best && len(t) > width) {
+			best, width = i, len(t)
+		}
+	}
+	return best, width
+}
+
+// isEventLineBreak reports whether r ends a line in an event stream.
+func isEventLineBreak(r rune) bool { return r == '\n' || r == '\r' }
+
 func (sse *SSESource) listenStream(res *http.Response) error {
 	defer closeq(res.Body)
 
@@ -762,9 +800,9 @@ func (sse *SSESource) listenStream(res *http.Response) error {
 		if atEOF && len(data) == 0 {
 			return 0, nil, nil
 		}
-		if i := bytes.Index(data, []byte{'\n', '\n'}); i >= 0 {
-			// We have a full double newline-terminated line.
-			return i + 1, data[0:i], nil
+		if i, width := indexEventTerminator(data); i >= 0 {
+			// We have a full event, terminated by a blank line.
+			return i + width, data[0:i], nil
 		}
 		// If we're at EOF, we have a final, non-terminated line. Return it.
 		if atEOF {
@@ -786,6 +824,11 @@ func (sse *SSESource) listenStream(res *http.Response) error {
 		}
 
 		if err := sse.processEvent(scanner); err != nil {
+			// Close racing with the server ending the stream must report a clean
+			// shutdown rather than the io.EOF the closed connection produced.
+			if sse.isClosed() {
+				return nil
+			}
 			return err
 		}
 	}
@@ -897,8 +940,9 @@ func parseEventFunc(msg []byte) (*rawSSE, error) {
 
 	e := newRawEvent()
 
-	// Split the line by "\n"
-	for _, line := range bytes.FieldsFunc(msg, func(r rune) bool { return r == '\n' }) {
+	// Split into lines. Per the WHATWG event stream grammar a line ends with
+	// CRLF, LF or CR; FieldsFunc drops the empty field a CRLF pair produces.
+	for _, line := range bytes.FieldsFunc(msg, isEventLineBreak) {
 		switch {
 		case bytes.HasPrefix(line, headerID):
 			e.ID = append([]byte(nil), trimHeader(len(headerID), line)...)
@@ -935,7 +979,7 @@ func trimHeader(size int, data []byte) []byte {
 	if len(data) > 0 && data[0] == ' ' {
 		data = data[1:]
 	}
-	if len(data) > 0 && data[len(data)-1] == '\n' {
+	for len(data) > 0 && isEventLineBreak(rune(data[len(data)-1])) {
 		data = data[:len(data)-1]
 	}
 	return data

--- a/sse.go
+++ b/sse.go
@@ -267,7 +267,7 @@ func (sse *SSESource) tlsConfig() (*tls.Config, error) {
 
 	transport, ok := sse.httpClient.Transport.(*http.Transport)
 	if !ok {
-		return nil, ErrNotHttpTransportType
+		return nil, ErrNotHTTPTransportType
 	}
 
 	if transport.TLSClientConfig == nil {
@@ -359,12 +359,12 @@ func (sse *SSESource) SetRetryMaxWaitTime(maxWaitTime time.Duration) *SSESource 
 	return sse
 }
 
-// SetSizeMaxBuffer method sets the maximum scanner buffer size for the SSE client.
+// SetMaxBufferSize method sets the maximum scanner buffer size for the SSE client.
 //
 // Default is 32kb
 //
-//	sse.SetSizeMaxBuffer(64 * 1024) // 64kb
-func (sse *SSESource) SetSizeMaxBuffer(bufSize int) *SSESource {
+//	sse.SetMaxBufferSize(64 * 1024) // 64kb
+func (sse *SSESource) SetMaxBufferSize(bufSize int) *SSESource {
 	sse.lock.Lock()
 	defer sse.lock.Unlock()
 	sse.maxBufSize = bufSize
@@ -744,7 +744,7 @@ func (sse *SSESource) connect() (*http.Response, error) {
 		// let's drain the response body, before retry wait
 		drainBody(rRes)
 
-		waitDuration, _ := backoff.NextWaitDuration(nil, rRes, doErr, attempt)
+		waitDuration, _ := backoff.NextWaitDuration(nil, nil, rRes, doErr, attempt)
 		timer := time.NewTimer(waitDuration)
 		select {
 		case <-sse.Context().Done():

--- a/sse_test.go
+++ b/sse_test.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -971,4 +972,163 @@ func TestSSESourceConnectContextDoneDuringRetryWait(t *testing.T) {
 	assertTrue(t, time.Since(start) < 2*time.Second,
 		"expected the retry wait to be abandoned when the context is done")
 	assertEqual(t, int32(1), attempts.Load(), "expected no further connect attempts")
+}
+
+// The WHATWG event stream grammar separates lines with CRLF, LF or CR. Resty
+// recognised only LF, so a CRLF stream -- common from .NET and Java servers --
+// was never framed: events arrived glued together at EOF instead of live.
+func TestSSEEventTerminators(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sep  string
+	}{
+		{"LF", "\n"},
+		{"CRLF", "\r\n"},
+		{"CR", "\r"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var got []string
+
+			counter := 0
+			es := NewSSESource().SetRetryCount(0)
+			ts := createSSETestServer(t, 5*time.Millisecond, func(w io.Writer) error {
+				if counter == 3 {
+					es.Close()
+					return fmt.Errorf("stop sending events")
+				}
+				_, err := fmt.Fprintf(w, "event: tick%sdata: value-%d%s%s",
+					tc.sep, counter, tc.sep, tc.sep)
+				counter++
+				return err
+			})
+			defer ts.Close()
+
+			es.SetURL(ts.URL).AddEventListener("tick", func(e any) {
+				mu.Lock()
+				got = append(got, e.(*SSE).Data)
+				mu.Unlock()
+			}, nil)
+
+			assertNil(t, es.Get())
+
+			mu.Lock()
+			defer mu.Unlock()
+			assertEqual(t, 3, len(got))
+			for i, v := range got {
+				assertEqual(t, fmt.Sprintf("value-%d", i), v)
+			}
+		})
+	}
+}
+
+func TestIndexEventTerminator(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		in        string
+		wantIdx   int
+		wantWidth int
+	}{
+		{"lf pair", "a\n\nb", 1, 2},
+		{"crlf pair", "a\r\n\r\nb", 1, 4},
+		{"cr pair", "a\r\rb", 1, 2},
+		{"none", "a\nb", -1, 0},
+		{"earliest wins", "a\n\nb\r\n\r\n", 1, 2},
+		{"empty", "", -1, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			i, w := indexEventTerminator([]byte(tc.in))
+			assertEqual(t, tc.wantIdx, i)
+			assertEqual(t, tc.wantWidth, w)
+		})
+	}
+}
+
+// Callbacks used to run while holding the source's read lock, so any callback
+// touching the source -- Close is the obvious one -- deadlocked on itself.
+func TestSSECallbackMayCloseSource(t *testing.T) {
+	es := NewSSESource().SetRetryCount(0)
+	ts := createSSETestServer(t, 5*time.Millisecond, func(w io.Writer) error {
+		_, err := fmt.Fprint(w, "data: hello\n\n")
+		return err
+	})
+	defer ts.Close()
+
+	es.SetURL(ts.URL).
+		OnMessage(func(_ any) {}, nil).
+		OnOpen(func(_ string, _ http.Header) {
+			// would deadlock: Close takes the write lock the trigger used to hold
+			es.Close()
+		})
+
+	done := make(chan error, 1)
+	go func() { done <- es.Get() }()
+
+	select {
+	case err := <-done:
+		assertNil(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("OnOpen callback calling Close deadlocked")
+	}
+}
+
+// A stream whose final event is not followed by a blank line must still be
+// dispatched when the connection ends.
+func TestSSEFinalEventWithoutTrailingBlankLine(t *testing.T) {
+	var mu sync.Mutex
+	var got []string
+
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// second event has no terminating blank line before the stream ends
+		fmt.Fprint(w, "data: first\n\ndata: last")
+	})
+	defer ts.Close()
+
+	es := NewSSESource().SetRetryCount(0).SetURL(ts.URL).
+		OnMessage(func(e any) {
+			mu.Lock()
+			got = append(got, e.(*SSE).Data)
+			mu.Unlock()
+		}, nil)
+
+	assertErrorIs(t, io.EOF, es.Get())
+
+	mu.Lock()
+	defer mu.Unlock()
+	assertEqual(t, 2, len(got))
+	assertEqual(t, "first", got[0])
+	assertEqual(t, "last", got[1])
+}
+
+// An event that arrives in fragments must be buffered until its terminator
+// shows up, rather than dispatched piecemeal.
+func TestSSEEventDeliveredInFragments(t *testing.T) {
+	var mu sync.Mutex
+	var got []string
+
+	ts := createTestServer(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		rc := http.NewResponseController(w)
+		for _, chunk := range []string{"data: hel", "lo-wor", "ld\n\n"} {
+			fmt.Fprint(w, chunk)
+			_ = rc.Flush()
+			time.Sleep(10 * time.Millisecond)
+		}
+	})
+	defer ts.Close()
+
+	es := NewSSESource().SetRetryCount(0).SetURL(ts.URL).
+		OnMessage(func(e any) {
+			mu.Lock()
+			got = append(got, e.(*SSE).Data)
+			mu.Unlock()
+		}, nil)
+
+	assertErrorIs(t, io.EOF, es.Get())
+
+	mu.Lock()
+	defer mu.Unlock()
+	assertEqual(t, 1, len(got))
+	assertEqual(t, "hello-world", got[0])
 }

--- a/sse_test.go
+++ b/sse_test.go
@@ -715,7 +715,7 @@ func createSSESource(t *testing.T, url string, fn SSEMessageFunc, rt any) *SSESo
 		SetRetryCount(2).
 		SetRetryWaitTime(200 * time.Millisecond).
 		SetRetryMaxWaitTime(1000 * time.Millisecond).
-		SetSizeMaxBuffer(1 << 14). // 16kb
+		SetMaxBufferSize(1 << 14). // 16kb
 		SetLogger(createLogger()).
 		OnOpen(func(url string, respHdr http.Header) {
 			t.Log("I'm connected:", url, respHdr)

--- a/stream.go
+++ b/stream.go
@@ -21,9 +21,9 @@ import (
 )
 
 var (
-	// ErrContentDecompresserNotFound is returned when no decompresser is registered
+	// ErrContentDecompressorNotFound is returned when no decompressor is registered
 	// for the Content-Encoding directive present in the response.
-	ErrContentDecompresserNotFound = errors.New("resty: content decoder not found")
+	ErrContentDecompressorNotFound = errors.New("resty: content decompressor not found")
 
 	// maxDecodeObjects caps the number of JSON or XML objects decoded from a single
 	// response body. If the limit is exceeded before EOF, decoding returns an error.
@@ -47,14 +47,14 @@ type (
 	// See [Client.AddContentTypeDecoder].
 	ContentTypeDecoder func(io.Reader, any) error
 
-	// ContentDecompresser wraps an [io.ReadCloser] response body with
+	// ContentDecompressor wraps an [io.ReadCloser] response body with
 	// decompression based on the Content-Encoding header ([RFC 9110]).
 	// For example, gzip, deflate, etc.
 	//
-	// See [Client.AddContentDecompresser].
+	// See [Client.AddContentDecompressor].
 	//
 	// [RFC 9110]: https://datatracker.ietf.org/doc/html/rfc9110
-	ContentDecompresser func(io.ReadCloser) (io.ReadCloser, error)
+	ContentDecompressor func(io.ReadCloser) (io.ReadCloser, error)
 )
 
 func encodeJSON(w io.Writer, v any) error {

--- a/stream.go
+++ b/stream.go
@@ -6,9 +6,11 @@
 package resty
 
 import (
+	"bufio"
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"context"
 	"encoding/json"
 	"encoding/xml"
@@ -229,11 +231,16 @@ type deflateReaderWrapper struct {
 	mu *sync.Mutex
 	r  io.ReadCloser
 	fr io.ReadCloser
+	// fromPool marks fr as a flate reader that may go back to flateReaderPool.
+	// A zlib reader must never be pooled there: zlib.Resetter and flate.Resetter
+	// have the same method set, so a type assertion cannot tell them apart, and a
+	// pooled zlib reader would fail every later raw-deflate stream.
+	fromPool bool
 }
 
 // acquireDeflateReader gets a flate.Reader from the pool or creates one.
 // It resets the reader for the new stream using the provided io.ReadCloser.
-func acquireDeflateReader(r io.ReadCloser) (*deflateReaderWrapper, error) {
+func acquireDeflateReader(r io.ReadCloser, src io.Reader) (*deflateReaderWrapper, error) {
 	w := &deflateReaderWrapper{
 		mu: new(sync.Mutex),
 		r:  r,
@@ -242,14 +249,16 @@ func acquireDeflateReader(r io.ReadCloser) (*deflateReaderWrapper, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
+	w.fromPool = true
+
 	// Try to get a cached reader from the pool
 	if cached := flateReaderPool.Get(); cached != nil {
 		w.fr = cached.(io.ReadCloser)
 		// Reset the pooled reader for the new stream; flate.Resetter.Reset never errors
-		w.fr.(flate.Resetter).Reset(r, nil)
+		w.fr.(flate.Resetter).Reset(src, nil)
 	} else {
 		// Pool is empty, create a new reader
-		w.fr = flate.NewReader(r)
+		w.fr = flate.NewReader(src)
 	}
 
 	return w, nil
@@ -262,8 +271,12 @@ func releaseDeflateReader(w *deflateReaderWrapper) {
 	defer w.mu.Unlock()
 
 	if w.fr != nil {
-		w.fr.(flate.Resetter).Reset(nopReader{}, nil)
-		flateReaderPool.Put(w.fr)
+		if w.fromPool {
+			w.fr.(flate.Resetter).Reset(nopReader{}, nil)
+			flateReaderPool.Put(w.fr)
+		} else {
+			closeq(w.fr)
+		}
 		w.fr = nil
 	}
 	if w.r != nil {
@@ -272,8 +285,30 @@ func releaseDeflateReader(w *deflateReaderWrapper) {
 	}
 }
 
+// isZlibWrapped reports whether the next two bytes of br are an RFC 1950 zlib
+// header. RFC 9110 section 8.4.1.2 defines the "deflate" content coding as a
+// zlib stream, but plenty of servers send a bare RFC 1951 stream under the same
+// name, so both are accepted.
+func isZlibWrapped(br *bufio.Reader) bool {
+	h, err := br.Peek(2)
+	if err != nil {
+		return false
+	}
+	// The low nibble of CMF is the compression method; 8 is deflate. The two
+	// header bytes read big-endian must also be a multiple of 31.
+	return h[0]&0x0f == 8 && (uint16(h[0])<<8|uint16(h[1]))%31 == 0
+}
+
 func decompressDeflate(r io.ReadCloser) (io.ReadCloser, error) {
-	return acquireDeflateReader(r)
+	br := bufio.NewReader(r)
+	if isZlibWrapped(br) {
+		zr, err := zlib.NewReader(br)
+		if err != nil {
+			return nil, err
+		}
+		return &deflateReaderWrapper{mu: new(sync.Mutex), r: r, fr: zr}, nil
+	}
+	return acquireDeflateReader(r, br)
 }
 
 // Implement io.ReadCloser for deflateReaderWrapper

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,9 +1,11 @@
 package resty
 
 import (
+	"bufio"
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
+	"compress/zlib"
 	"errors"
 	"io"
 	"net/http"
@@ -475,7 +477,7 @@ func TestDeflateReaderPanicOnConcurrentCorruptedBody(t *testing.T) {
 func TestDeflateReaderPoolAcquireAndRead(t *testing.T) {
 	// Test successful creation and read with valid deflate data
 	validData := io.NopCloser(bytes.NewReader(createDeflateValidData()))
-	wrapper, err := acquireDeflateReader(validData)
+	wrapper, err := acquireDeflateReader(validData, validData)
 	assertNil(t, err)
 	assertNotNil(t, wrapper)
 
@@ -507,7 +509,7 @@ func TestDeflateReaderPoolConcurrentAccess(t *testing.T) {
 			for range numOperations {
 				// Create fresh data for each operation
 				validData := io.NopCloser(bytes.NewReader(createDeflateValidData()))
-				wrapper, err := acquireDeflateReader(validData)
+				wrapper, err := acquireDeflateReader(validData, validData)
 				assertNil(t, err)
 				assertNotNil(t, wrapper)
 
@@ -657,4 +659,68 @@ func TestStreamMisc(t *testing.T) {
 		assertEqual(t, 0, n)
 
 	})
+}
+
+// RFC 9110 section 8.4.1.2 defines the "deflate" content coding as a zlib
+// stream (RFC 1950) wrapping deflate-compressed data (RFC 1951). Resty
+// advertises deflate but decoded with compress/flate, so a conforming server's
+// response failed to decode -- and readAll mapped the resulting
+// io.ErrUnexpectedEOF to nil, surfacing a 200 with an empty body.
+func TestDecompressDeflateAcceptsZlibAndRawStreams(t *testing.T) {
+	const payload = `{"hello":"world"}`
+
+	var zlibFramed bytes.Buffer
+	zw := zlib.NewWriter(&zlibFramed)
+	_, _ = zw.Write([]byte(payload))
+	assertNil(t, zw.Close())
+
+	var rawFramed bytes.Buffer
+	fw, err := flate.NewWriter(&rawFramed, flate.DefaultCompression)
+	assertNil(t, err)
+	_, _ = fw.Write([]byte(payload))
+	assertNil(t, fw.Close())
+
+	for _, tc := range []struct {
+		name string
+		body []byte
+	}{
+		{"zlib framed, per RFC 9110", zlibFramed.Bytes()},
+		{"raw deflate, as many servers send", rawFramed.Bytes()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Encoding", "deflate")
+				w.Header().Set(hdrContentTypeKey, "application/json")
+				_, _ = w.Write(tc.body)
+			}))
+			defer ts.Close()
+
+			c := dcnl().SetBaseURL(ts.URL)
+			defer c.Close()
+
+			res, err := c.R().Get("/")
+			assertError(t, err)
+			assertEqual(t, http.StatusOK, res.StatusCode())
+			assertEqual(t, payload, res.String())
+		})
+	}
+}
+
+func TestIsZlibWrapped(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		in     []byte
+		expect bool
+	}{
+		{"zlib default compression", []byte{0x78, 0x9c}, true},
+		{"zlib best compression", []byte{0x78, 0xda}, true},
+		{"raw deflate block", []byte{0x00, 0x01}, false},
+		{"wrong compression method", []byte{0x71, 0x9c}, false},
+		{"too short to tell", []byte{0x78}, false},
+		{"empty", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assertEqual(t, tc.expect, isZlibWrapped(bufio.NewReader(bytes.NewReader(tc.in))))
+		})
+	}
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -724,3 +724,15 @@ func TestIsZlibWrapped(t *testing.T) {
 		})
 	}
 }
+
+// A header that passes the zlib sniff but that zlib.NewReader rejects (FDICT set,
+// so the stream needs a preset dictionary) must surface as an error rather than
+// an empty body.
+func TestDecompressDeflateZlibHeaderError(t *testing.T) {
+	// 0x78 0x20: CM=deflate, FDICT set, and (0x7820 % 31) == 0
+	body := []byte{0x78, 0x20, 0x00, 0x00, 0x00, 0x00}
+	assertEqual(t, true, isZlibWrapped(bufio.NewReader(bytes.NewReader(body))))
+
+	_, err := decompressDeflate(io.NopCloser(bytes.NewReader(body)))
+	assertNotNil(t, err)
+}

--- a/stream_test.go
+++ b/stream_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"compress/zlib"
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -735,4 +736,22 @@ func TestDecompressDeflateZlibHeaderError(t *testing.T) {
 
 	_, err := decompressDeflate(io.NopCloser(bytes.NewReader(body)))
 	assertNotNil(t, err)
+}
+
+// gracefulStopReader turns a cancelled context into io.EOF so io.Copy stops
+// without reporting an error.
+func TestGracefulStopReader(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	gsr := &gracefulStopReader{ctx: ctx, r: strings.NewReader("hello")}
+
+	p := make([]byte, 5)
+	n, err := gsr.Read(p)
+	assertNil(t, err)
+	assertEqual(t, 5, n)
+	assertEqual(t, "hello", string(p))
+
+	cancel()
+	n, err = gsr.Read(p)
+	assertEqual(t, 0, n)
+	assertErrorIs(t, io.EOF, err)
 }


### PR DESCRIPTION
> **Depends on #1208, #1209, #1210 and #1211.** Stacked on them; until they merge this PR shows their commits too.
>
> **Also conflicts with #1200**, which edits `AddRequestMiddleware` — renamed here. That PR's `max()` guard against a negative insert index is carried into `AddRequestMiddlewares`, so the fix is preserved either way; whichever lands second needs a rebase.

Every change here is breaking and becomes permanent at v3.0.0 final, so it belongs in an RC rather than after one. **This is the most opinionated PR of the five — please push back on anything you disagree with, or take it partially.**

## 1. `CircuitBreakerObserver` did not compile in its documented form

`OnTrigger` and `OnStateChange` returned `CircuitBreakerObserver`, which did not embed `CircuitBreaker`, so the obvious idiom was a hard build error:

```go
cb := resty.NewCircuitBreakerCount(3, 1, time.Second).
        OnTrigger(func(r *resty.Request, err error) {})
c.SetCircuitBreaker(cb)
```
```
cannot use cb (variable of interface type resty.CircuitBreakerObserver)
as resty.CircuitBreaker value in argument to c.SetCircuitBreaker:
resty.CircuitBreakerObserver does not implement resty.CircuitBreaker
(missing method Allow)
```

`CircuitBreakerObserver` now embeds `CircuitBreaker`, so a breaker with hooks attached goes straight into `SetCircuitBreaker`. The chaining methods moved from `circuitBreakerBase` — which is not a breaker on its own — onto `CircuitBreakerCount` and `CircuitBreakerRatio`.

`RunOnTriggerHooks` and `RunOnStateChangeHooks` are internal dispatch plumbing that any third-party `CircuitBreaker` had to implement to satisfy the public interface; they are now unexported. Added `State() CircuitBreakerState`, which had no exported accessor at all.

## 2. `RateLimiter.Allow` blocks, which is the opposite of what `Allow` means elsewhere

`golang.org/x/time/rate` — the limiter most people will adapt — defines `Allow() bool` as the **non-blocking** check and `Wait(ctx) error` as the blocking one. Resty's `Allow(ctx) error` blocks. This is the "same name, different semantics" trap: an adapter author reads `Allow`, wires it to `rate.Limiter.Allow()`, and silently gets a hard-reject limiter instead of a blocking one.

Renamed to `Wait` on the interface and both implementations.

## 3. `RetryDelayStrategyFunc` could not see the request or the attempt

The strategy received only `(*Response, error)`, so it had to reach through `res.Request` to learn which attempt it was on — and could not do even that when there is no response, which is the shape the SSE reconnect path passes. New signature:

```go
type RetryDelayStrategyFunc func(req *Request, res *Response, attempt int, err error) (time.Duration, error)
```

A correction worth recording: the audit that prompted this claimed the strategy was skipped entirely on transport errors. **That was wrong** — `Request.Execute` passes a non-nil `Response` wrapper with a nil `RawResponse`, so the old `res == nil` guard never triggered there. The signature change stands on its own merits, not on that rationale.

## 4. Naming

| current | becomes | why |
|---|---|---|
| `ContentDecompresser` (+5 more) | `ContentDecompressor` | not a word |
| `ErrNotHttpTransportType` | `ErrNotHTTPTransportType` | initialism |
| `CertWatcherOptions.PoolInterval` | `PollInterval` | it polls |
| `SRVWeightedRoundRobin.HttpScheme` | `HTTPScheme` | initialism |
| `HostStateInActive` | `HostStateInactive` | one word |
| `SSESource.SetSizeMaxBuffer` | `SetMaxBufferSize` | word order |
| `ResponseBodyUnlimitedReads` | `IsResponseBodyUnlimitedReads` | only bool getter without `Is`; nine siblings have it |
| `SetLoggerWarnLevel` | `SetDisableWarn` | `SetLoggerWarnLevel(true)` *suppressed* warnings while the getter is `IsDisableWarn` |
| `AddRequestMiddleware` | `AddRequestMiddlewares` (variadic) | only non-variadic `Add*`; arity cannot change later |
| `AddResponseMiddleware` | `AddResponseMiddlewares` (variadic) | same |
| `Client.ResultError` | unexported `resultErrorType` | returned `reflect.Type`, freezing the storage choice into the API, and collided by name with `Response.ResultError() any`; only `newErrorInterface` used it |

## 5. `Request.WithContext` shared mutable state with its source

```go
rr := new(Request)
*rr = *r
rr.ctx = ctx
```

`Header`, `QueryParams`, `FormData`, `PathParams`, `multipartFields` and `bodyBuf` were all shared, so `req.WithContext(ctx).SetHeader("X", "1")` mutated `req`. It now delegates to `Clone`, which already did this correctly.

## Verification

`go test ./... -race -count=1 -shuffle=on` green. `gofmt`, `go vet` clean. Coverage 99.9260%, up from 99.9233% on `v3`; the three remaining uncovered blocks are the same ones present before this work.

Last of five stacked PRs from an audit of the v3 branch.
